### PR TITLE
NOP out call to VGUI_Shutdown during server DLL shutdown

### DIFF
--- a/NorthstarDedicatedTest/miscserverfixes.cpp
+++ b/NorthstarDedicatedTest/miscserverfixes.cpp
@@ -6,8 +6,19 @@ void InitialiseMiscServerFixes(HMODULE baseAddress)
 {
 	// ret at the start of the concommand GenerateObjFile as it can crash servers
 	{
-		void* ptr = (char*)baseAddress + 0x38D920;
+		char* ptr = reinterpret_cast<char*>(baseAddress) + 0x38D920;
 		TempReadWrite rw(ptr);
-		*((char*)ptr) = (char)0xC3;
+		*ptr = 0xC3;
+	}
+
+	// nop out call to VGUI shutdown since it crashes the game when quitting from the console
+	{
+		char* ptr = reinterpret_cast<char*>(baseAddress) + 0x154A96;
+		TempReadWrite rw(ptr);
+		*(ptr++) = 0x90; // nop
+		*(ptr++) = 0x90; // nop
+		*(ptr++) = 0x90; // nop
+		*(ptr++) = 0x90; // nop
+		*ptr     = 0x90; // nop
 	}
 }


### PR DESCRIPTION
Avoids a crash that occurs when quitting the game from the console.
Kind of a hacky workaround, but it seems to work fine.