### PR TITLE
Don't hook language functions on dedicated server

### DIFF
--- a/NorthstarDedicatedTest/languagehooks.cpp
+++ b/NorthstarDedicatedTest/languagehooks.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "languagehooks.h"
 #include "gameutils.h"
+#include "dedicated.h"
 #include <filesystem>
 #include <regex>
 
@@ -104,6 +105,9 @@ char* GetGameLanguageHook()
 
 void InitialiseTier0LanguageHooks(HMODULE baseAddress)
 {
+	if (IsDedicated())
+		return;
+
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xF560, &GetGameLanguageHook, reinterpret_cast<LPVOID*>(&GetGameLanguageOriginal));
 }


### PR DESCRIPTION
It's common to remove various Titanfall client-only files on dedicated servers to reduce the install files, including the `r2/sounds` folder. However since v1.4.0 removing the sounds folder results in the dedicated server shutting down while loading with these log lines:

```
[02:30:26] [info] Origin detected language "russian", but we do not have audio f
or it installed, falling back to the next option
[02:30:26] [info] Detected system language: english
[02:30:26] [warning] Caution, audio for this language does NOT exist. You might
want to override your game language with -language command line option.

abnormal program termination
```

This PR avoids hooking `GetGameLanguage` on dedicated servers which seems to fix the issue, I'm guessing this was probably unintentionally left out since `InitialiseTier0LanguageHooks` is included in the list of client-exclusive patches anyway?