### PR TITLE
LatencyFleX Implementation

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -517,6 +517,7 @@
     <ClInclude Include="include\spdlog\version.h" />
     <ClInclude Include="keyvalues.h" />
     <ClInclude Include="languagehooks.h" />
+    <ClInclude Include="latencyflex.h" />
     <ClInclude Include="logging.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="masterserver.h" />
@@ -559,6 +560,7 @@
     <ClCompile Include="hooks.cpp" />
     <ClCompile Include="hookutils.cpp" />
     <ClCompile Include="keyvalues.cpp" />
+    <ClCompile Include="latencyflex.cpp" />
     <ClCompile Include="maxplayers.cpp" />
     <ClCompile Include="languagehooks.cpp" />
     <ClCompile Include="memalloc.cpp" />
@@ -620,7 +622,7 @@
     <None Include="include\spdlog\fmt\bundled\LICENSE.rst" />
   </ItemGroup>
   <ItemGroup>
-	  <None Include="..\Northstar-Legal.txt" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Northstar-Legal.txt" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1434,6 +1434,9 @@
     <ClInclude Include="languagehooks.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
+    <ClInclude Include="latencyflex.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1556,6 +1559,9 @@
     <ClCompile Include="languagehooks.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>
+    <ClCompile Include="latencyflex.cpp">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="include\spdlog\fmt\bundled\LICENSE.rst">
@@ -1642,5 +1648,6 @@
     <None Include="include\crypto\dso_conf.h.in">
       <Filter>Header Files\include\openssl\crypto</Filter>
     </None>
+    <None Include="..\Northstar-Legal.txt" />
   </ItemGroup>
 </Project>

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -21,6 +21,7 @@
 #include "securitypatches.h"
 #include "miscserverscript.h"
 #include "clientauthhooks.h"
+#include "latencyflex.h"
 #include "scriptbrowserhooks.h"
 #include "scriptmainmenupromos.h"
 #include "miscclientfixes.h"
@@ -109,6 +110,7 @@ bool InitialiseNorthstar()
         AddDllLoadCallback("client.dll", InitialiseScriptServerBrowser);
         AddDllLoadCallback("localize.dll", InitialiseModLocalisation);
         AddDllLoadCallback("engine.dll", InitialiseClientAuthHooks);
+        AddDllLoadCallback("client.dll", InitialiseLatencyFleX);
         AddDllLoadCallback("engine.dll", InitialiseScriptExternalBrowserHooks);
         AddDllLoadCallback("client.dll", InitialiseScriptMainMenuPromos);
         AddDllLoadCallback("client.dll", InitialiseMiscClientFixes);

--- a/NorthstarDedicatedTest/latencyflex.cpp
+++ b/NorthstarDedicatedTest/latencyflex.cpp
@@ -1,0 +1,41 @@
+#include "pch.h"
+#include "latencyflex.h"
+#include "hookutils.h"
+#include "dedicated.h"
+
+typedef void(*OnRenderStartType)();
+OnRenderStartType OnRenderStart;
+
+HMODULE m_lfxModule{};
+typedef void (*PFN_winelfx_WaitAndBeginFrame)();
+PFN_winelfx_WaitAndBeginFrame m_winelfx_WaitAndBeginFrame{};
+
+void OnRenderStartHook()
+{
+	m_winelfx_WaitAndBeginFrame();
+
+	OnRenderStart();
+}
+
+void InitialiseLatencyFleX(HMODULE baseAddress)
+{
+	if (IsDedicated())
+		return;
+
+	// Connect to the LatencyFleX service
+	// LatencyFleX is an open source vendor agnostic replacement for Nvidia Reflex input latency reduction technology.
+	// https://ishitatsuyuki.github.io/post/latencyflex/
+	m_lfxModule = LoadLibraryA("latencyflex_wine.dll");
+
+	if (m_lfxModule == nullptr)
+	{
+		spdlog::info("Unable to load LatencyFleX library, LatencyFleX disabled.");
+		return;
+	}
+
+	m_winelfx_WaitAndBeginFrame = reinterpret_cast<PFN_winelfx_WaitAndBeginFrame>(reinterpret_cast<void*>(GetProcAddress(m_lfxModule,"winelfx_WaitAndBeginFrame")));
+	spdlog::info("LatencyFleX initialized.");
+
+	HookEnabler hook;
+	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1952C0, &OnRenderStartHook, reinterpret_cast<LPVOID*>(&OnRenderStart));
+}

--- a/NorthstarDedicatedTest/latencyflex.h
+++ b/NorthstarDedicatedTest/latencyflex.h
@@ -1,0 +1,2 @@
+#pragma once
+void InitialiseLatencyFleX(HMODULE baseAddress);


### PR DESCRIPTION
Adds LatencyFleX, an open source and vendor agnostic input latency reduction technology similar to Nvidia's Reflex. Currently only works on Linux via Wine/Proton, but future versions may support Windows as well. Falls back to doing nothing if LatencyFleX isn't available.

See here for more information:
https://ishitatsuyuki.github.io/post/latencyflex/