### PR TITLE
Various fixes and optimizations on dedi title and server info

### DIFF
--- a/NorthstarDedicatedTest/dedicated.cpp
+++ b/NorthstarDedicatedTest/dedicated.cpp
@@ -3,7 +3,7 @@
 #include "hookutils.h"
 #include "gameutils.h"
 #include "serverauthentication.h"
-
+#include "masterserver.h"
 bool IsDedicated()
 {
 	//return CommandLine()->CheckParm("-dedicated");
@@ -70,7 +70,7 @@ void RunServer(CDedicatedExports* dedicated)
 		if (!maxPlayers)
 			maxPlayers = "6";
 
-		SetConsoleTitleA(fmt::format("Titanfall 2 dedicated server - {} {}/{} players ({})", g_pHostState->m_levelName, g_ServerAuthenticationManager->m_additionalPlayerData.size(), maxPlayers, GetCurrentPlaylistName()).c_str());		
+		SetConsoleTitleA(fmt::format("{} - {} {}/{} players ({})", g_MasterServerManager->ns_auth_srvName, g_pHostState->m_levelName, g_ServerAuthenticationManager->m_additionalPlayerData.size(), maxPlayers, GetCurrentPlaylistName()).c_str());
 		std::this_thread::sleep_for(std::chrono::duration<double, std::ratio<1>>(Cvar_base_tickinterval_mp->m_fValue - fmin(Plat_FloatTime() - frameStart, 0.25)));
 	}
 }

--- a/NorthstarDedicatedTest/masterserver.h
+++ b/NorthstarDedicatedTest/masterserver.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "convar.h"
 #include <WinSock2.h>
-
+#include <string>
+#include <cstring>
 struct RemoteModInfo
 {
 public:
@@ -73,6 +74,8 @@ public:
 	char m_ownClientAuthToken[33];
 
 	std::string m_ownModInfoJson;
+	std::string ns_auth_srvName; // Unicode unescaped version of Cvar_ns_auth_servername for support in cjk characters
+	std::string ns_auth_srvDesc; // Unicode unescaped version of Cvar_ns_auth_serverdesc for support in cjk characters
 
 	bool m_bOriginAuthWithMasterServerDone = false;
 	bool m_bOriginAuthWithMasterServerInProgress = false;
@@ -112,7 +115,8 @@ public:
 	void WritePlayerPersistentData(char* playerId, char* pdata, size_t pdataSize);
 	void RemoveSelfFromServerList();
 };
-
+void unescape_unicode(std::string& str);
+void UpdateServerInfoFromUnicodeToUTF8();
 void InitialiseSharedMasterServer(HMODULE baseAddress);
 
 extern MasterServerManager* g_MasterServerManager;

--- a/NorthstarDedicatedTest/masterserver.h
+++ b/NorthstarDedicatedTest/masterserver.h
@@ -115,7 +115,7 @@ public:
 	void WritePlayerPersistentData(char* playerId, char* pdata, size_t pdataSize);
 	void RemoveSelfFromServerList();
 };
-void unescape_unicode(std::string& str);
+std::string unescape_unicode(const std::string &str);
 void UpdateServerInfoFromUnicodeToUTF8();
 void InitialiseSharedMasterServer(HMODULE baseAddress);
 


### PR DESCRIPTION
Server name and desc now support UTF-8 chars in Unicode codepoints.
![image](https://user-images.githubusercontent.com/84360921/149629203-7ddd7a0f-0806-419a-b370-b0db44bdb4e4.png)
![image](https://user-images.githubusercontent.com/84360921/149629209-96691359-5183-4468-9cc2-273d48f3f5e3.png)

note: you might need to chcp 65001 in bat before using utf-8 charset names to avoid garbage characters


Dedicated servers now display the server name on the CMD title for better identification.
![image](https://user-images.githubusercontent.com/84360921/149629221-83e13d6b-1db9-4bb2-bd73-c7d58f1611f0.png)
