### PR TITLE
Misc improvements

### DIFF
--- a/NorthstarDedicatedTest/hooks.cpp
+++ b/NorthstarDedicatedTest/hooks.cpp
@@ -73,6 +73,10 @@ LPSTR GetCommandLineAHook()
 			argBuffer << cmdlineArgFile.rdbuf();
 			cmdlineArgFile.close();
 
+			// if some other command line option includes "-northstar" in the future then you have to refactor this check to check with both either space after or ending with
+			if (!isDedi && argBuffer.str().find("-northstar") != std::string::npos)
+				MessageBoxA(NULL, "The \"-northstar\" command line option is NOT supposed to go into ns_startup_args.txt file!\n\nThis option is supposed to go into Origin/Steam game launch options, and then you are supposed to launch the original Titanfall2.exe rather than NorthstarLauncher.exe to make use of it.", "Northstar Warning", MB_ICONWARNING);
+
 			args.append(argBuffer.str());
 		}
 

--- a/NorthstarDedicatedTest/languagehooks.cpp
+++ b/NorthstarDedicatedTest/languagehooks.cpp
@@ -26,6 +26,9 @@ std::vector<std::string> file_list(fs::path dir, std::regex ext_pattern)
 {
 	std::vector<std::string> result;
 
+	if (!fs::exists(dir) || !fs::is_directory(dir))
+		return result;
+
 	using iterator = fs::directory_iterator;
 
 	const iterator end;
@@ -77,7 +80,8 @@ char* GetGameLanguageHook()
 		auto lang = GetGameLanguageOriginal();
 		if (!CheckLangAudioExists(lang))
 		{
-			spdlog::info("Origin detected language \"{}\", but we do not have audio for it installed, falling back to the next option", lang);
+			if (strcmp(lang, "russian") != 0) // don't log for "russian" since it's the default and that means Origin detection just didn't change it most likely
+				spdlog::info("Origin detected language \"{}\", but we do not have audio for it installed, falling back to the next option", lang);
 
 		}
 		else
@@ -95,7 +99,7 @@ char* GetGameLanguageHook()
 	{
 		spdlog::warn("Caution, audio for this language does NOT exist. You might want to override your game language with -language command line option.");
 		auto lang = GetAnyInstalledAudioLanguage();
-		spdlog::warn("Falling back to first installed audio language: {}", lang.c_str());
+		spdlog::warn("Falling back to the first installed audio language: {}", lang.c_str());
 		strncpy(ingameLang1, lang.c_str(), 256);
 		return ingameLang1;
 	}

--- a/loader_launcher_proxy/dllmain.cpp
+++ b/loader_launcher_proxy/dllmain.cpp
@@ -5,6 +5,7 @@
 #include <Shlwapi.h>
 #include <sstream>
 #include <fstream>
+#include <filesystem>
 
 HMODULE hLauncherModule;
 HMODULE hHookModule;
@@ -44,9 +45,13 @@ FARPROC GetLauncherMain()
 
 void LibraryLoadError(DWORD dwMessageId, const wchar_t* libName, const wchar_t* location)
 {
-    char text[2048];
-    std::string message = std::system_category().message(dwMessageId); 
+    char text[4096];
+    std::string message = std::system_category().message(dwMessageId);
     sprintf_s(text, "Failed to load the %ls at \"%ls\" (%lu):\n\n%hs", libName, location, dwMessageId, message.c_str());
+    if (dwMessageId == 126 && std::filesystem::exists(location))
+    {
+        sprintf_s(text, "%s\n\nThe file at the specified location DOES exist, so this error indicates that one of its *dependencies* failed to be found.", text);
+    }
     MessageBoxA(GetForegroundWindow(), text, "Northstar Launcher Proxy Error", 0);
 }
 

--- a/loader_wsock32_proxy/loader.h
+++ b/loader_wsock32_proxy/loader.h
@@ -1,8 +1,9 @@
 #pragma once
 
 extern wchar_t exePath[4096];
-extern wchar_t dllPath[8192];
-extern wchar_t dllPath2[4096];
+extern wchar_t buffer1[8192];
+extern wchar_t buffer2[12288];
 
+void LibraryLoadError(DWORD dwMessageId, const wchar_t* libName, const wchar_t* location);
 bool ShouldLoadNorthstar();
 bool ProvisionNorthstar();


### PR DESCRIPTION
* dedicated server will no longer crash if the whole r2/sound dir is removed rather than just its contents
* EA Desktop-installed game will not throw permission error or require running as administrator anymore, instead it will copy original wsock to a temp dir and continue working
* improved error messaging around wsock32, for example failure to load the copied wsock32 will show an error about it rather than just "initialization routine failed" and a bug around buffer manipulations that broke one of the error messages
* added a detection of DLL load failure in case the failed to load thing is a dependency and not a DLL itself (it really was not obvious from the error message itself if you aren't having a PTSD with WinAPI already)
* improved main function for error messages to detect a few more fuckup cases and give a few helpful tips in addition to just saying RTFM

Hopefully the volume of #help channel will decrease with those. I've ran my tests and I think I covered most cases and it works fine, but you're free to run a few of your ones to ensure, however I put my approval stamp on it already.