### PR TITLE
Advanced chat: custom messages and client hooks

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -112,6 +112,8 @@
     <ClInclude Include="bitbuf.h" />
     <ClInclude Include="buildainfile.h" />
     <ClInclude Include="chatcommand.h" />
+    <ClInclude Include="clientchathooks.h" />
+    <ClInclude Include="serverchathooks.h" />
     <ClInclude Include="clientauthhooks.h" />
     <ClInclude Include="concommand.h" />
     <ClInclude Include="configurables.h" />
@@ -556,6 +558,7 @@
     <ClCompile Include="buildainfile.cpp" />
     <ClCompile Include="chatcommand.cpp" />
     <ClCompile Include="clientauthhooks.cpp" />
+    <ClCompile Include="clientchathooks.cpp" />
     <ClCompile Include="concommand.cpp" />
     <ClCompile Include="configurables.cpp" />
     <ClCompile Include="context.cpp" />
@@ -594,6 +597,7 @@
     <ClCompile Include="scriptsrson.cpp" />
     <ClCompile Include="serverauthentication.cpp" />
     <ClCompile Include="miscserverscript.cpp" />
+    <ClCompile Include="serverchathooks.cpp" />
     <ClCompile Include="sigscanning.cpp" />
     <ClCompile Include="sourceconsole.cpp" />
     <ClCompile Include="sourceinterface.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -113,6 +113,7 @@
     <ClInclude Include="buildainfile.h" />
     <ClInclude Include="chatcommand.h" />
     <ClInclude Include="clientchathooks.h" />
+    <ClInclude Include="localchatwriter.h" />
     <ClInclude Include="serverchathooks.h" />
     <ClInclude Include="clientauthhooks.h" />
     <ClInclude Include="concommand.h" />
@@ -572,6 +573,7 @@
     <ClCompile Include="hookutils.cpp" />
     <ClCompile Include="keyvalues.cpp" />
     <ClCompile Include="latencyflex.cpp" />
+    <ClCompile Include="localchatwriter.cpp" />
     <ClCompile Include="maxplayers.cpp" />
     <ClCompile Include="languagehooks.cpp" />
     <ClCompile Include="memalloc.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1455,6 +1455,9 @@
     <ClInclude Include="clientchathooks.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
+    <ClInclude Include="localchatwriter.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1593,6 +1596,9 @@
       <Filter>Source Files\Server</Filter>
     </ClCompile>
     <ClCompile Include="clientchathooks.cpp">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="localchatwriter.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>
   </ItemGroup>

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1449,6 +1449,12 @@
     <ClInclude Include="configurables.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
+    <ClInclude Include="serverchathooks.h">
+      <Filter>Header Files\Server</Filter>
+    </ClInclude>
+    <ClInclude Include="clientchathooks.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1581,6 +1587,12 @@
       <Filter>Source Files\Server</Filter>
     </ClCompile>
     <ClCompile Include="configurables.cpp">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="serverchathooks.cpp">
+      <Filter>Source Files\Server</Filter>
+    </ClCompile>
+    <ClCompile Include="clientchathooks.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>
   </ItemGroup>

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -21,8 +21,10 @@ void ConCommand_say_team(const CCommand& args)
 		ClientSayText(nullptr, args.ArgS(), true, true);
 }
 
-void ConCommand_log(const CCommand& args) {
-	if (args.ArgC() >= 2) {
+void ConCommand_log(const CCommand& args)
+{
+	if (args.ArgC() >= 2)
+	{
 		LocalChatStartLine(LocalChatContext::Game);
 		LocalChatInsertColor(LocalChatContext::Game, 255, 255, 255, 255);
 		LocalChatInsertText(LocalChatContext::Game, args.ArgS());

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -2,6 +2,7 @@
 #include "chatcommand.h"
 #include "concommand.h"
 #include "dedicated.h"
+#include "clientchathooks.h"
 
 // note: isIngameChat is an int64 because the whole register the arg is stored in needs to be 0'd out to work
 // if isIngameChat is false, we use network chat instead
@@ -20,6 +21,15 @@ void ConCommand_say_team(const CCommand& args)
 		ClientSayText(nullptr, args.ArgS(), true, true);
 }
 
+void ConCommand_log(const CCommand& args) {
+	if (args.ArgC() >= 2) {
+		LocalChatStartLine(LocalChatContext::Game);
+		LocalChatInsertColor(LocalChatContext::Game, 255, 255, 255, 255);
+		LocalChatInsertText(LocalChatContext::Game, args.ArgS());
+		LocalChatInsertFade(LocalChatContext::Game, DEFAULT_FADE_SUSTAIN, DEFAULT_FADE_LENGTH);
+	}
+}
+
 void InitialiseChatCommands(HMODULE baseAddress)
 {
 	if (IsDedicated())
@@ -28,4 +38,5 @@ void InitialiseChatCommands(HMODULE baseAddress)
 	ClientSayText = (ClientSayTextType)((char*)baseAddress + 0x54780);
 	RegisterConCommand("say", ConCommand_say, "Enters a message in public chat", FCVAR_CLIENTDLL);
 	RegisterConCommand("say_team", ConCommand_say_team, "Enters a message in team chat", FCVAR_CLIENTDLL);
+	RegisterConCommand("log", ConCommand_log, "Log a message to the local chat window", FCVAR_CLIENTDLL);
 }

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -9,9 +9,6 @@
 typedef void(__fastcall* ClientSayTextType)(void* a1, const char* message, __int64 isIngameChat, bool isTeamChat);
 ClientSayTextType ClientSayText;
 
-const char* whisperReceiver;
-const char* whisperMessage;
-
 void ConCommand_say(const CCommand& args)
 {
 	if (args.ArgC() >= 2)

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -2,8 +2,7 @@
 #include "chatcommand.h"
 #include "concommand.h"
 #include "dedicated.h"
-#include "clientchathooks.h"
-#include "squirrel.h"
+#include "localchatwriter.h"
 
 // note: isIngameChat is an int64 because the whole register the arg is stored in needs to be 0'd out to work
 // if isIngameChat is false, we use network chat instead
@@ -29,7 +28,7 @@ void ConCommand_log(const CCommand& args)
 {
 	if (args.ArgC() >= 2)
 	{
-		LocalChatWriteLine(LocalChatContext::Game, args.ArgS(), 128, AnonymousMessageType::Whisper);
+		LocalChatWriter(LocalChatWriter::GameContext).WriteLine(args.ArgS());
 	}
 }
 

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -25,10 +25,7 @@ void ConCommand_log(const CCommand& args)
 {
 	if (args.ArgC() >= 2)
 	{
-		LocalChatStartLine(LocalChatContext::Game);
-		LocalChatInsertColor(LocalChatContext::Game, 255, 255, 255, 255);
-		LocalChatInsertText(LocalChatContext::Game, args.ArgS());
-		LocalChatInsertFade(LocalChatContext::Game, DEFAULT_FADE_SUSTAIN, DEFAULT_FADE_LENGTH);
+		LocalChatWriteLine(LocalChatContext::Game, args.ArgS());
 	}
 }
 

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -3,11 +3,15 @@
 #include "concommand.h"
 #include "dedicated.h"
 #include "clientchathooks.h"
+#include "squirrel.h"
 
 // note: isIngameChat is an int64 because the whole register the arg is stored in needs to be 0'd out to work
 // if isIngameChat is false, we use network chat instead
 typedef void(__fastcall* ClientSayTextType)(void* a1, const char* message, __int64 isIngameChat, bool isTeamChat);
 ClientSayTextType ClientSayText;
+
+const char* whisperReceiver;
+const char* whisperMessage;
 
 void ConCommand_say(const CCommand& args)
 {
@@ -25,7 +29,7 @@ void ConCommand_log(const CCommand& args)
 {
 	if (args.ArgC() >= 2)
 	{
-		LocalChatWriteLine(LocalChatContext::Game, args.ArgS());
+		LocalChatWriteLine(LocalChatContext::Game, args.ArgS(), 128, AnonymousMessageType::Whisper);
 	}
 }
 

--- a/NorthstarDedicatedTest/chatcommand.h
+++ b/NorthstarDedicatedTest/chatcommand.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void InitialiseChatCommands(HMODULE baseAddress);
+void InitialiseUICommands(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/chatcommand.h
+++ b/NorthstarDedicatedTest/chatcommand.h
@@ -1,4 +1,3 @@
 #pragma once
 
 void InitialiseChatCommands(HMODULE baseAddress);
-void InitialiseUICommands(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -1,0 +1,354 @@
+#include "pch.h"
+#include "clientchathooks.h"
+#include <rapidjson/document.h>
+#include "squirrel.h"
+
+struct vgui_Color {
+	unsigned char r;
+	unsigned char g;
+	unsigned char b;
+	unsigned char a;
+};
+
+class vgui_BaseRichText_vtable;
+
+class vgui_BaseRichText {
+public:
+	vgui_BaseRichText_vtable* vtable;
+};
+
+class vgui_BaseRichText_vtable {
+public:
+	char unknown1[1880];
+
+	void(__fastcall* InsertChar)(vgui_BaseRichText* self, wchar_t ch);
+
+	// yes these are swapped from the Source 2013 code, who knows why
+	void(__fastcall* InsertStringWide)(vgui_BaseRichText* self, const wchar_t* wszText);
+	void(__fastcall* InsertStringAnsi)(vgui_BaseRichText* self, const char* text);
+
+	void(__fastcall* SelectNone)(vgui_BaseRichText* self);
+	void(__fastcall* SelectAllText)(vgui_BaseRichText* self);
+	void(__fastcall* SelectNoText)(vgui_BaseRichText* self);
+	void(__fastcall* CutSelected)(vgui_BaseRichText* self);
+	void(__fastcall* CopySelected)(vgui_BaseRichText* self);
+	void(__fastcall* SetPanelInteractive)(vgui_BaseRichText* self, bool bInteractive);
+	void(__fastcall* SetUnusedScrollbarInvisible)(vgui_BaseRichText* self, bool bInvis);
+
+	void* unknown2;
+
+	void(__fastcall* GotoTextStart)(vgui_BaseRichText* self);
+	void(__fastcall* GotoTextEnd)(vgui_BaseRichText* self);
+
+	void* unknown3[3];
+
+	void(__fastcall* SetVerticalScrollbar)(vgui_BaseRichText* self, bool state);
+	void(__fastcall* SetMaximumCharCount)(vgui_BaseRichText* self, int maxChars);
+	void(__fastcall* InsertColorChange)(vgui_BaseRichText* self, vgui_Color col);
+	void(__fastcall* InsertIndentChange)(vgui_BaseRichText* self, int pixelsIndent);
+	void(__fastcall* InsertClickableTextStart)(vgui_BaseRichText* self, const char* pchClickAction);
+	void(__fastcall* InsertClickableTextEnd)(vgui_BaseRichText* self);
+	void(__fastcall* InsertPossibleURLString)(vgui_BaseRichText* self, const char* text, vgui_Color URLTextColor, vgui_Color normalTextColor);
+	void(__fastcall* InsertFade)(vgui_BaseRichText* self, float flSustain, float flLength);
+	void(__fastcall* ResetAllFades)(vgui_BaseRichText* self, bool bHold, bool bOnlyExpired, float flNewSustain);
+	void(__fastcall* SetToFullHeight)(vgui_BaseRichText* self);
+	int(__fastcall* GetNumLines)(vgui_BaseRichText* self);
+};
+
+class CHudChat {
+public:
+	char unknown1[720];
+
+	vgui_Color m_sameTeamColor;
+	vgui_Color m_enemyTeamColor;
+	vgui_Color m_mainTextColor;
+	vgui_Color m_lobbyNameColor;
+
+	char unknown2[12];
+
+	int m_unknownContext;
+
+	char unknown3[8];
+
+	vgui_BaseRichText* m_richText;
+
+	CHudChat* next;
+	CHudChat* previous;
+};
+
+// Linked list of CHudChats
+CHudChat** gHudChatList;
+
+typedef void(__fastcall* ConvertANSIToUnicodeType)(LPCSTR ansi, int ansiCharLength, LPWSTR unicode, int unicodeCharLength);
+ConvertANSIToUnicodeType ConvertANSIToUnicode;
+
+typedef void(__fastcall* OnNetworkChatType)(const char* message, const char* playerName, int unknown);
+OnNetworkChatType OnNetworkChat;
+
+typedef void(__fastcall* CHudChat__AddGameLineType)(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead);
+CHudChat__AddGameLineType CHudChat__AddGameLine;
+
+void LocalChatStartLine(LocalChatContext context) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int) context) continue;
+
+		hud->m_richText->vtable->InsertChar(hud->m_richText, L'\n');
+	}
+}
+
+void LocalChatInsertLocalized(LocalChatContext context, const char* str) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int) context) continue;
+
+		hud->m_richText->vtable->InsertStringAnsi(hud->m_richText, str);
+	}
+}
+
+void LocalChatInsertText(LocalChatContext context, const char* str) {
+	WCHAR messageUnicode[288];
+	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
+
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int) context) continue;
+
+		hud->m_richText->vtable->InsertStringWide(hud->m_richText, messageUnicode);
+	}
+}
+
+void LocalChatInsertColor(LocalChatContext context, unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int) context) continue;
+
+		hud->m_richText->vtable->InsertColorChange(hud->m_richText, vgui_Color{
+			red,
+			green,
+			blue,
+			alpha
+		});
+	}
+}
+
+void LocalChatInsertFade(LocalChatContext context, float sustainSecs, float lengthSecs) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int) context) continue;
+
+		hud->m_richText->vtable->InsertFade(hud->m_richText, sustainSecs, lengthSecs);
+	}
+}
+
+static void OnNetworkChatHook(const char* message, const char* playerName, int unknown) {
+	// todo: support squirrel hook
+	OnNetworkChat(message, playerName, unknown);
+}
+
+static void OnChatAnnounce(const char* data) {
+	rapidjson::Document document;
+	document.Parse(data);
+
+	float fadeSustainSecs = document.HasMember("fs")
+		? document["fs"].GetFloat()
+		: DEFAULT_FADE_SUSTAIN;
+	float fadeLengthSecs = document.HasMember("fl")
+		? document["fl"].GetFloat()
+		: DEFAULT_FADE_LENGTH;
+
+	LocalChatStartLine(LocalChatContext::Game);
+
+	rapidjson::Value::Array textItems = document["t"].GetArray();
+	for (const rapidjson::Value& textItem : textItems) {
+		const char* itemType = textItem["i"].GetString();
+
+		if (!strcmp(itemType, "l")) {
+			LocalChatInsertLocalized(LocalChatContext::Game, textItem["s"].GetString());
+			LocalChatInsertFade(LocalChatContext::Game, fadeSustainSecs, fadeLengthSecs);
+		}
+		else if (!strcmp(itemType, "t")) {
+			LocalChatInsertText(LocalChatContext::Game, textItem["s"].GetString());
+			LocalChatInsertFade(LocalChatContext::Game, fadeSustainSecs, fadeLengthSecs);
+		}
+		else if (!strcmp(itemType, "c")) {
+			unsigned int color = textItem["c"].GetUint();
+
+			LocalChatInsertColor(
+				LocalChatContext::Game,
+				(color >> 24) & 0xFF,
+				(color >> 16) & 0xFF,
+				(color >> 8) & 0xFF,
+				color & 0xFF
+			);
+		}
+	}
+}
+
+constexpr char CHAT_PACKET_CONTINUE = 1;
+constexpr char CHAT_PACKET_ANNOUNCE = 2;
+std::string gIncomingBuffer;
+
+static void CHudChat__AddGameLineHook(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead) {
+	// Custom messages are from player=0, other messages are handled as normal
+	if (fromPlayerIndex != 0) {
+		// todo: support squirrel hook
+		CHudChat__AddGameLine(self, message, fromPlayerIndex, isteam, isdead);
+		return;
+	}
+
+	// This hook is called for every CHudChat instance, but we want to parse the announcement message and _then_ dispatch it to
+	// each HUD. So ignore this call if this isn't the first HUD.
+	if (self != *gHudChatList) {
+		return;
+	}
+
+	if (message == NULL || message[0] == 0) {
+		return;
+	}
+
+	char packetType = message[0];
+	gIncomingBuffer.append(message + 1);
+
+	if (packetType == CHAT_PACKET_CONTINUE) {
+		return;
+	}
+
+	// Clear incoming data and keep the current packet string
+	std::string packetData = std::move(gIncomingBuffer);
+
+	if (packetType == CHAT_PACKET_ANNOUNCE) {
+		OnChatAnnounce(packetData.c_str());
+	}
+}
+
+// void NSGameChatWriteLine( string text )
+SQRESULT SQ_GameChatWriteLine(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatStartLine(LocalChatContext::Game);
+	LocalChatInsertColor(LocalChatContext::Game, 255, 255, 255, 255);
+	LocalChatInsertText(LocalChatContext::Game, text);
+	LocalChatInsertFade(LocalChatContext::Game, DEFAULT_FADE_SUSTAIN, DEFAULT_FADE_LENGTH);
+
+	return SQRESULT_NULL;
+}
+
+// void NSGameChatStartLine()
+SQRESULT SQ_GameChatStartLine(void* sqvm) {
+	LocalChatStartLine(LocalChatContext::Game);
+
+	return SQRESULT_NULL;
+}
+
+// void NSGameChatInsertLocalized( string text )
+SQRESULT SQ_GameChatInsertLocalized(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatInsertLocalized(LocalChatContext::Game, text);
+	LocalChatInsertFade(LocalChatContext::Game, DEFAULT_FADE_SUSTAIN, DEFAULT_FADE_LENGTH);
+
+	return SQRESULT_NULL;
+}
+
+// void NSGameChatInsertText( string text )
+SQRESULT SQ_GameChatInsertText(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatInsertText(LocalChatContext::Game, text);
+	LocalChatInsertFade(LocalChatContext::Game, DEFAULT_FADE_SUSTAIN, DEFAULT_FADE_LENGTH);
+
+	return SQRESULT_NULL;
+}
+
+// void NSGameChatInsertColor( float red, float green, float blue, float alpha )
+SQRESULT SQ_GameChatInsertColor(void* sqvm) {
+	float red = ClientSq_getfloat(sqvm, 1);
+	float green = ClientSq_getfloat(sqvm, 2);
+	float blue = ClientSq_getfloat(sqvm, 3);
+	float alpha = ClientSq_getfloat(sqvm, 4);
+
+	LocalChatInsertColor(
+		LocalChatContext::Game,
+		(unsigned char)(red * 255.f),
+		(unsigned char)(green * 255.f),
+		(unsigned char)(blue * 255.f),
+		(unsigned char)(alpha * 255.f)
+	);
+
+	return SQRESULT_NULL;
+}
+
+// void NSNetworkChatWriteLine( string text )
+SQRESULT SQ_NetworkChatWriteLine(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatStartLine(LocalChatContext::Network);
+	LocalChatInsertColor(LocalChatContext::Network, 255, 255, 255, 255);
+	LocalChatInsertText(LocalChatContext::Network, text);
+
+	return SQRESULT_NULL;
+}
+
+// void NSNetworkChatStartLine()
+SQRESULT SQ_NetworkChatStartLine(void* sqvm) {
+	LocalChatStartLine(LocalChatContext::Network);
+
+	return SQRESULT_NULL;
+}
+
+// void NSNetworkChatInsertLocalized( string text )
+SQRESULT SQ_NetworkChatInsertLocalized(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatInsertLocalized(LocalChatContext::Network, text);
+
+	return SQRESULT_NULL;
+}
+
+// void NSNetworkChatInsertText( string text )
+SQRESULT SQ_NetworkChatInsertText(void* sqvm) {
+	const char* text = ClientSq_getstring(sqvm, 1);
+
+	LocalChatInsertText(LocalChatContext::Network, text);
+
+	return SQRESULT_NULL;
+}
+
+// void NSNetworkChatInsertColor( float red, float green, float blue, float alpha )
+SQRESULT SQ_NetworkChatInsertColor(void* sqvm) {
+	float red = ClientSq_getfloat(sqvm, 1);
+	float green = ClientSq_getfloat(sqvm, 2);
+	float blue = ClientSq_getfloat(sqvm, 3);
+	float alpha = ClientSq_getfloat(sqvm, 4);
+
+	LocalChatInsertColor(
+		LocalChatContext::Network,
+		(unsigned char)(red * 255.f),
+		(unsigned char)(green * 255.f),
+		(unsigned char)(blue * 255.f),
+		(unsigned char)(alpha * 255.f)
+	);
+
+	return SQRESULT_NULL;
+}
+
+void InitialiseClientChatHooks(HMODULE baseAddress) {
+	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11bA9E8);
+
+	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
+
+	HookEnabler hook;
+	ENABLER_CREATEHOOK(
+		hook, (char*)baseAddress + 0x22F160, &OnNetworkChatHook,
+		reinterpret_cast<LPVOID*>(&OnNetworkChat));
+	ENABLER_CREATEHOOK(
+		hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook,
+		reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
+
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatWriteLine", "string text", "", SQ_GameChatWriteLine);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatStartLine", "", "", SQ_GameChatStartLine);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertLocalized", "string text", "", SQ_GameChatInsertLocalized);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertText", "string text", "", SQ_GameChatInsertText);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_GameChatInsertColor);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatWriteLine", "string text", "", SQ_NetworkChatWriteLine);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatStartLine", "", "", SQ_NetworkChatStartLine);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertLocalized", "string text", "", SQ_NetworkChatInsertLocalized);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertText", "string text", "", SQ_NetworkChatInsertText);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_NetworkChatInsertColor);
+}

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -48,13 +48,15 @@ static unsigned char r;
 static unsigned char g;
 static unsigned char b;*/
 
-struct ChatTags {
+struct ChatTags
+{
 	bool whisper;
 	bool team;
 	bool dead;
 };
 
-struct Chat {
+struct Chat
+{
 	std::string message;
 	int senderId;
 	bool isTeam;
@@ -135,7 +137,8 @@ static void OnReceivedChat(const char* message, int senderIndex, ChatTags tags, 
 	}
 }*/
 
-static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxIndex, bool isTeam, bool isDead) {
+static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxIndex, bool isTeam, bool isDead)
+{
 	int senderIndex = inboxIndex & CUSTOM_MESSAGE_INDEX_BIT;
 	bool isAnonymous = senderIndex == 0;
 	bool isCustom = isAnonymous || (inboxIndex & CUSTOM_MESSAGE_INDEX_MASK);
@@ -143,7 +146,8 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 	// Type is set to 0 for non-custom messages, custom messages have a type encoded as the first byte
 	int type = 0;
 	const char* payload = message;
-	if (isCustom) {
+	if (isCustom)
+	{
 		type = message[0];
 		payload = message + 1;
 	}
@@ -158,7 +162,8 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 }
 
 // void NSChatWrite( int context, string str )
-static SQRESULT SQ_ChatWrite(void* sqvm) {
+static SQRESULT SQ_ChatWrite(void* sqvm)
+{
 	int context = ClientSq_getinteger(sqvm, 1);
 	const char* str = ClientSq_getstring(sqvm, 2);
 
@@ -167,7 +172,8 @@ static SQRESULT SQ_ChatWrite(void* sqvm) {
 }
 
 // void NSChatWriteRaw( int context, string str )
-static SQRESULT SQ_ChatWriteRaw(void* sqvm) {
+static SQRESULT SQ_ChatWriteRaw(void* sqvm)
+{
 	int context = ClientSq_getinteger(sqvm, 1);
 	const char* str = ClientSq_getstring(sqvm, 2);
 
@@ -176,7 +182,8 @@ static SQRESULT SQ_ChatWriteRaw(void* sqvm) {
 }
 
 // void NSChatWriteLine( int context, string str )
-static SQRESULT SQ_ChatWriteLine(void* sqvm) {
+static SQRESULT SQ_ChatWriteLine(void* sqvm)
+{
 	int context = ClientSq_getinteger(sqvm, 1);
 	const char* str = ClientSq_getstring(sqvm, 2);
 
@@ -185,8 +192,10 @@ static SQRESULT SQ_ChatWriteLine(void* sqvm) {
 }
 
 // string NSChatGetCurrentMessage()
-static SQRESULT SQ_ChatGetCurrentMessage(void* sqvm) {
-	if (currentChat == NULL) {
+static SQRESULT SQ_ChatGetCurrentMessage(void* sqvm)
+{
+	if (currentChat == NULL)
+	{
 		ClientSq_pusherror(sqvm, "No chat is available");
 		return SQRESULT_ERROR;
 	}
@@ -196,8 +205,10 @@ static SQRESULT SQ_ChatGetCurrentMessage(void* sqvm) {
 }
 
 // int NSChatGetCurrentPlayer()
-static SQRESULT SQ_ChatGetCurrentPlayer(void* sqvm) {
-	if (currentChat == NULL) {
+static SQRESULT SQ_ChatGetCurrentPlayer(void* sqvm)
+{
+	if (currentChat == NULL)
+	{
 		ClientSq_pusherror(sqvm, "No chat is available");
 		return SQRESULT_ERROR;
 	}
@@ -207,8 +218,10 @@ static SQRESULT SQ_ChatGetCurrentPlayer(void* sqvm) {
 }
 
 // bool NSChatGetIsTeam()
-static SQRESULT SQ_ChatGetIsTeam(void* sqvm) {
-	if (currentChat == NULL) {
+static SQRESULT SQ_ChatGetIsTeam(void* sqvm)
+{
+	if (currentChat == NULL)
+	{
 		ClientSq_pusherror(sqvm, "No chat is available");
 		return SQRESULT_ERROR;
 	}
@@ -218,8 +231,10 @@ static SQRESULT SQ_ChatGetIsTeam(void* sqvm) {
 }
 
 // bool NSChatGetIsDead()
-static SQRESULT SQ_ChatGetIsDead(void* sqvm) {
-	if (currentChat == NULL) {
+static SQRESULT SQ_ChatGetIsDead(void* sqvm)
+{
+	if (currentChat == NULL)
+	{
 		ClientSq_pusherror(sqvm, "No chat is available");
 		return SQRESULT_ERROR;
 	}
@@ -229,8 +244,10 @@ static SQRESULT SQ_ChatGetIsDead(void* sqvm) {
 }
 
 // int NSChatGetCurrentType()
-static SQRESULT SQ_ChatGetCurrentType(void* sqvm) {
-	if (currentChat == NULL) {
+static SQRESULT SQ_ChatGetCurrentType(void* sqvm)
+{
+	if (currentChat == NULL)
+	{
 		ClientSq_pusherror(sqvm, "No chat is available");
 		return SQRESULT_ERROR;
 	}

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -5,48 +5,8 @@
 #include "serverchathooks.h"
 #include "localchatwriter.h"
 
-/*class CBasePlayer_vtable;
-
-class CBasePlayer {
-public:
-	CBasePlayer_vtable* vtable;
-};
-
-class CBasePlayer_vtable {
-public:
-	char unknown[712];
-
-	int(__fastcall* GetTeam)(CBasePlayer* self);
-};
-
-// First parameter to GetPlayerName
-void* gEngine;
-
-typedef bool(__fastcall* GetPlayerNameType)(void* self, int playerIndex, char* outPlayerName);
-GetPlayerNameType GetPlayerName;
-
-typedef CBasePlayer* (__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
-UTIL_PlayerByIndexType UTIL_PlayerByIndex;
-
-typedef CBasePlayer* (__fastcall* GetLocalPlayerType)();
-GetLocalPlayerType GetLocalPlayer;
-
-typedef void(__fastcall* OnNetworkChatType)(const char* message, const char* playerName, int unknown);
-OnNetworkChatType OnNetworkChat;*/
-
-typedef void(__fastcall* CHudChat__AddGameLineType)(void* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead);
+typedef void(__fastcall* CHudChat__AddGameLineType)(void* self, const char* message, int fromPlayerId, bool isteam, bool isdead);
 CHudChat__AddGameLineType CHudChat__AddGameLine;
-
-/*static std::string currentMessage;
-static int currentPlayerId;
-static bool currentIsTeam;
-static bool currentIsDead;
-static bool currentIsEnemy;
-
-static bool useCustomCode;
-static unsigned char r;
-static unsigned char g;
-static unsigned char b;*/
 
 struct ChatTags
 {
@@ -58,90 +18,24 @@ struct ChatTags
 struct Chat
 {
 	std::string message;
-	int senderId;
+	int senderIndex;
 	bool isTeam;
 	bool isDead;
 	int type;
 };
-std::unique_ptr<Chat> currentChat;
+Chat currentChat;
 
-/*static void WriteChatPrefixes(LocalChatWriter& writer, int fromPlayerId, ChatTags tags) {
-	char senderName[256];
-	CBasePlayer* localPlayer = GetLocalPlayer();
-	CBasePlayer* senderPlayer = NULL;
-
-	if (localPlayer == NULL) {
+static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxId, bool isTeam, bool isDead)
+{
+	// This hook is called for each HUD, but we only want our logic to run once.
+	if (!IsFirstHud(self))
+	{
 		return;
 	}
 
-	// Get the sender's name and player object if this isn't anonymous, aborting if either fail
-	if (fromPlayerId >= 0) {
-		int fromPlayerIndex = fromPlayerId + 1;
-		if (!GetPlayerName(gEngine, fromPlayerIndex, senderName)) return;
-
-		senderPlayer = UTIL_PlayerByIndex(fromPlayerIndex);
-		if (senderPlayer == NULL) return;
-	}
-
-	// Force a new line
-	writer.InsertChar(L'\n');
-
-	// Add a [SERVER] tag to anonymous messages
-	if (fromPlayerId < 0) {
-		writer.InsertColorChange(vgui_Color{ 241, 76, 76, 255 });
-		writer.InsertText(L"[SERVER]"); // todo: localize
-	}
-
-	// Add a [WHISPER] tag to whispers
-	if (tags.whisper) {
-		writer.InsertColorChange(vgui_Color{ 214, 112, 214, 255 });
-		writer.InsertText(L"[WHISPER]"); // todo: localize
-	}
-
-	if (fromPlayerId >= 0) {
-		int localTeam = localPlayer->vtable->GetTeam(localPlayer);
-		int senderTeam = senderPlayer->vtable->GetTeam(senderPlayer);
-		writer.InsertSwatchColorChange(localTeam == senderTeam
-			? LocalChatWriter::SameTeamNameColor
-			: LocalChatWriter::EnemyTeamNameColor);
-
-		if (tags.dead) {
-			writer.InsertText(L"[DEAD]"); // todo: localize
-		}
-		if (tags.team) {
-			writer.InsertText(L"[TEAM]");
-		}
-
-		writer.InsertText(senderName);
-		writer.InsertText(L": ");
-		writer.InsertSwatchColorChange(LocalChatWriter::MainTextColor);
-	}
-}
-
-static void OnReceivedChat(const char* message, int senderIndex, ChatTags tags, bool enableAdvancedParsing) {
-	bool isAnonymous = senderIndex == 0;
-	int senderId = senderIndex - 1;
-
-	if (!isAnonymous) {
-		// todo: process with squirrel chat hook
-	}
-
-	LocalChatWriter writer(LocalChatWriter::GameContext);
-	WriteChatPrefixes(writer, senderId, tags);
-
-	if (enableAdvancedParsing) {
-		writer.Write(message);
-	}
-	else {
-		writer.InsertText(message);
-	}
-}*/
-
-static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxIndex, bool isTeam, bool isDead)
-{
-	int senderIndex = inboxIndex & CUSTOM_MESSAGE_INDEX_BIT;
-	bool isAnonymous = senderIndex == 0;
-	bool isCustom = isAnonymous || (inboxIndex & CUSTOM_MESSAGE_INDEX_MASK);
+	int senderId = inboxId & CUSTOM_MESSAGE_INDEX_MASK;
+	bool isAnonymous = senderId == 0;
+	bool isCustom = isAnonymous || (inboxId & CUSTOM_MESSAGE_INDEX_BIT);
 
 	// Type is set to 0 for non-custom messages, custom messages have a type encoded as the first byte
 	int type = 0;
@@ -152,12 +46,11 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 		payload = message + 1;
 	}
 
-	currentChat.reset();
-	currentChat->message = payload;
-	currentChat->senderId = senderIndex - 1;
-	currentChat->isTeam = isTeam;
-	currentChat->isDead = isDead;
-	currentChat->type = type;
+	currentChat.message = payload;
+	currentChat.senderIndex = senderId - 1;
+	currentChat.isTeam = isTeam;
+	currentChat.isDead = isDead;
+	currentChat.type = type;
 	g_ClientSquirrelManager->ExecuteCode("CHudChat_ProcessMessageStartThread()");
 }
 
@@ -194,65 +87,35 @@ static SQRESULT SQ_ChatWriteLine(void* sqvm)
 // string NSChatGetCurrentMessage()
 static SQRESULT SQ_ChatGetCurrentMessage(void* sqvm)
 {
-	if (currentChat == NULL)
-	{
-		ClientSq_pusherror(sqvm, "No chat is available");
-		return SQRESULT_ERROR;
-	}
-
-	ClientSq_pushstring(sqvm, currentChat->message.c_str(), -1);
+	ClientSq_pushstring(sqvm, currentChat.message.c_str(), -1);
 	return SQRESULT_NOTNULL;
 }
 
 // int NSChatGetCurrentPlayer()
 static SQRESULT SQ_ChatGetCurrentPlayer(void* sqvm)
 {
-	if (currentChat == NULL)
-	{
-		ClientSq_pusherror(sqvm, "No chat is available");
-		return SQRESULT_ERROR;
-	}
-
-	ClientSq_pushinteger(sqvm, currentChat->senderId);
+	ClientSq_pushinteger(sqvm, currentChat.senderIndex);
 	return SQRESULT_NOTNULL;
 }
 
 // bool NSChatGetIsTeam()
 static SQRESULT SQ_ChatGetIsTeam(void* sqvm)
 {
-	if (currentChat == NULL)
-	{
-		ClientSq_pusherror(sqvm, "No chat is available");
-		return SQRESULT_ERROR;
-	}
-
-	ClientSq_pushbool(sqvm, currentChat->isTeam);
+	ClientSq_pushbool(sqvm, currentChat.isTeam);
 	return SQRESULT_NOTNULL;
 }
 
 // bool NSChatGetIsDead()
 static SQRESULT SQ_ChatGetIsDead(void* sqvm)
 {
-	if (currentChat == NULL)
-	{
-		ClientSq_pusherror(sqvm, "No chat is available");
-		return SQRESULT_ERROR;
-	}
-
-	ClientSq_pushbool(sqvm, currentChat->isDead);
+	ClientSq_pushbool(sqvm, currentChat.isDead);
 	return SQRESULT_NOTNULL;
 }
 
 // int NSChatGetCurrentType()
 static SQRESULT SQ_ChatGetCurrentType(void* sqvm)
 {
-	if (currentChat == NULL)
-	{
-		ClientSq_pusherror(sqvm, "No chat is available");
-		return SQRESULT_ERROR;
-	}
-
-	ClientSq_pushinteger(sqvm, currentChat->type);
+	ClientSq_pushinteger(sqvm, currentChat.type);
 	return SQRESULT_NOTNULL;
 }
 

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -3,124 +3,41 @@
 #include <rapidjson/document.h>
 #include "squirrel.h"
 #include "serverchathooks.h"
+#include "localchatwriter.h"
 
-struct vgui_Color
-{
-	unsigned char r;
-	unsigned char g;
-	unsigned char b;
-	unsigned char a;
+/*class CBasePlayer_vtable;
+
+class CBasePlayer {
+public:
+	CBasePlayer_vtable* vtable;
 };
 
-class vgui_BaseRichText_vtable;
+class CBasePlayer_vtable {
+public:
+	char unknown[712];
 
-class vgui_BaseRichText
-{
-  public:
-	vgui_BaseRichText_vtable* vtable;
+	int(__fastcall* GetTeam)(CBasePlayer* self);
 };
 
-class vgui_BaseRichText_vtable
-{
-  public:
-	char unknown1[1880];
+// First parameter to GetPlayerName
+void* gEngine;
 
-	void(__fastcall* InsertChar)(vgui_BaseRichText* self, wchar_t ch);
+typedef bool(__fastcall* GetPlayerNameType)(void* self, int playerIndex, char* outPlayerName);
+GetPlayerNameType GetPlayerName;
 
-	// yes these are swapped from the Source 2013 code, who knows why
-	void(__fastcall* InsertStringWide)(vgui_BaseRichText* self, const wchar_t* wszText);
-	void(__fastcall* InsertStringAnsi)(vgui_BaseRichText* self, const char* text);
+typedef CBasePlayer* (__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
+UTIL_PlayerByIndexType UTIL_PlayerByIndex;
 
-	void(__fastcall* SelectNone)(vgui_BaseRichText* self);
-	void(__fastcall* SelectAllText)(vgui_BaseRichText* self);
-	void(__fastcall* SelectNoText)(vgui_BaseRichText* self);
-	void(__fastcall* CutSelected)(vgui_BaseRichText* self);
-	void(__fastcall* CopySelected)(vgui_BaseRichText* self);
-	void(__fastcall* SetPanelInteractive)(vgui_BaseRichText* self, bool bInteractive);
-	void(__fastcall* SetUnusedScrollbarInvisible)(vgui_BaseRichText* self, bool bInvis);
-
-	void* unknown2;
-
-	void(__fastcall* GotoTextStart)(vgui_BaseRichText* self);
-	void(__fastcall* GotoTextEnd)(vgui_BaseRichText* self);
-
-	void* unknown3[3];
-
-	void(__fastcall* SetVerticalScrollbar)(vgui_BaseRichText* self, bool state);
-	void(__fastcall* SetMaximumCharCount)(vgui_BaseRichText* self, int maxChars);
-	void(__fastcall* InsertColorChange)(vgui_BaseRichText* self, vgui_Color col);
-	void(__fastcall* InsertIndentChange)(vgui_BaseRichText* self, int pixelsIndent);
-	void(__fastcall* InsertClickableTextStart)(vgui_BaseRichText* self, const char* pchClickAction);
-	void(__fastcall* InsertClickableTextEnd)(vgui_BaseRichText* self);
-	void(__fastcall* InsertPossibleURLString)(
-		vgui_BaseRichText* self, const char* text, vgui_Color URLTextColor, vgui_Color normalTextColor);
-	void(__fastcall* InsertFade)(vgui_BaseRichText* self, float flSustain, float flLength);
-	void(__fastcall* ResetAllFades)(vgui_BaseRichText* self, bool bHold, bool bOnlyExpired, float flNewSustain);
-	void(__fastcall* SetToFullHeight)(vgui_BaseRichText* self);
-	int(__fastcall* GetNumLines)(vgui_BaseRichText* self);
-};
-
-class CHudChat
-{
-  public:
-	char unknown1[720];
-
-	vgui_Color m_sameTeamColor;
-	vgui_Color m_enemyTeamColor;
-	vgui_Color m_mainTextColor;
-	vgui_Color m_networkNameColor;
-
-	char unknown2[12];
-
-	int m_unknownContext;
-
-	char unknown3[8];
-
-	vgui_BaseRichText* m_richText;
-
-	CHudChat* next;
-	CHudChat* previous;
-};
-
-// Linked list of CHudChats
-CHudChat** gHudChatList;
-
-typedef void(__fastcall* ConvertANSIToUnicodeType)(LPCSTR ansi, int ansiCharLength, LPWSTR unicode, int unicodeCharLength);
-ConvertANSIToUnicodeType ConvertANSIToUnicode;
+typedef CBasePlayer* (__fastcall* GetLocalPlayerType)();
+GetLocalPlayerType GetLocalPlayer;
 
 typedef void(__fastcall* OnNetworkChatType)(const char* message, const char* playerName, int unknown);
-OnNetworkChatType OnNetworkChat;
+OnNetworkChatType OnNetworkChat;*/
 
-typedef void(__fastcall* CHudChat__AddGameLineType)(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead);
+typedef void(__fastcall* CHudChat__AddGameLineType)(void* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead);
 CHudChat__AddGameLineType CHudChat__AddGameLine;
 
-enum class SwatchColor
-{
-	MainText,
-	SameTeamName,
-	EnemyTeamName,
-	NetworkName,
-};
-
-SwatchColor swatchColors[4] = {
-	SwatchColor::MainText,
-	SwatchColor::SameTeamName,
-	SwatchColor::EnemyTeamName,
-	SwatchColor::NetworkName,
-};
-
-vgui_Color darkColors[8] = {vgui_Color{0, 0, 0, 255},	   vgui_Color{205, 49, 49, 255},  vgui_Color{13, 188, 121, 255},
-							vgui_Color{229, 229, 16, 255}, vgui_Color{36, 114, 200, 255}, vgui_Color{188, 63, 188, 255},
-							vgui_Color{17, 168, 205, 255}, vgui_Color{229, 229, 229, 255}};
-
-vgui_Color lightColors[8] = {vgui_Color{102, 102, 102, 255}, vgui_Color{241, 76, 76, 255},	vgui_Color{35, 209, 139, 255},
-							 vgui_Color{245, 245, 67, 255},	 vgui_Color{59, 142, 234, 255}, vgui_Color{214, 112, 214, 255},
-							 vgui_Color{41, 184, 219, 255},	 vgui_Color{255, 255, 255, 255}};
-
-int playerIdForLookup;
-std::string foundPlayerName;
-
-static std::string currentMessage;
+/*static std::string currentMessage;
 static int currentPlayerId;
 static bool currentIsTeam;
 static bool currentIsDead;
@@ -129,518 +46,211 @@ static bool currentIsEnemy;
 static bool useCustomCode;
 static unsigned char r;
 static unsigned char g;
-static unsigned char b;
+static unsigned char b;*/
 
-static void LocalChatInsertChar(LocalChatContext context, wchar_t ch)
-{
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
-	{
-		if (hud->m_unknownContext != (int)context)
-			continue;
-
-		hud->m_richText->vtable->InsertChar(hud->m_richText, ch);
-	}
-}
-
-static void LocalChatInsertText(LocalChatContext context, const char* str)
-{
-	WCHAR messageUnicode[288];
-	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
-
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
-	{
-		if (hud->m_unknownContext != (int)context)
-			continue;
-
-		hud->m_richText->vtable->InsertStringWide(hud->m_richText, messageUnicode);
-		hud->m_richText->vtable->InsertFade(hud->m_richText, 12.f, 1.f);
-	}
-}
-
-static void LocalChatInsertColorChange(LocalChatContext context, vgui_Color color)
-{
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
-	{
-		if (hud->m_unknownContext != (int)context)
-			continue;
-
-		hud->m_richText->vtable->InsertColorChange(hud->m_richText, color);
-	}
-}
-
-static vgui_Color GetHudSwatchColor(CHudChat* hud, SwatchColor swatchColor)
-{
-	switch (swatchColor)
-	{
-	case SwatchColor::MainText:
-		return hud->m_mainTextColor;
-	case SwatchColor::SameTeamName:
-		return hud->m_sameTeamColor;
-	case SwatchColor::EnemyTeamName:
-		return hud->m_enemyTeamColor;
-	case SwatchColor::NetworkName:
-		return hud->m_networkNameColor;
-	}
-	return vgui_Color{0, 0, 0, 0};
-}
-
-static void LocalChatInsertSwatchColorChange(LocalChatContext context, SwatchColor swatchColor)
-{
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
-	{
-		if (hud->m_unknownContext != (int)context)
-			continue;
-		hud->m_richText->vtable->InsertColorChange(hud->m_richText, GetHudSwatchColor(hud, swatchColor));
-	}
-}
-
-class AnsiEscapeDecoder
-{
-  public:
-	explicit AnsiEscapeDecoder(LocalChatContext context) : m_context(context) {}
-
-	void HandleVal(unsigned long val)
-	{
-		switch (m_next)
-		{
-		case Next::ControlType:
-			m_next = HandleControlType(val);
-			break;
-		case Next::ForegroundType:
-			m_next = HandleForegroundType(val);
-			break;
-		case Next::Foreground8Bit:
-			m_next = HandleForeground8Bit(val);
-			break;
-		case Next::ForegroundR:
-			m_next = HandleForegroundR(val);
-			break;
-		case Next::ForegroundG:
-			m_next = HandleForegroundG(val);
-			break;
-		case Next::ForegroundB:
-			m_next = HandleForegroundB(val);
-			break;
-		}
-	}
-
-  private:
-	enum class Next
-	{
-		ControlType,
-		ForegroundType,
-		Foreground8Bit,
-		ForegroundR,
-		ForegroundG,
-		ForegroundB
-	};
-
-	LocalChatContext m_context;
-	Next m_next = Next::ControlType;
-	vgui_Color m_expandedColor{0, 0, 0, 0};
-
-	Next HandleControlType(unsigned long val)
-	{
-		// Reset
-		if (val == 0 || val == 39)
-		{
-			LocalChatInsertSwatchColorChange(m_context, SwatchColor::MainText);
-			return Next::ControlType;
-		}
-
-		// Dark foreground color
-		if (val >= 30 && val < 38)
-		{
-			LocalChatInsertColorChange(m_context, darkColors[val - 30]);
-			return Next::ControlType;
-		}
-
-		// Light foreground color
-		if (val >= 90 && val < 98)
-		{
-			LocalChatInsertColorChange(m_context, lightColors[val - 90]);
-			return Next::ControlType;
-		}
-
-		// Game swatch color
-		if (val >= 110 && val < 114)
-		{
-			LocalChatInsertSwatchColorChange(m_context, swatchColors[val - 110]);
-			return Next::ControlType;
-		}
-
-		// Expanded foreground color
-		if (val == 38)
-		{
-			return Next::ForegroundType;
-		}
-
-		return Next::ControlType;
-	}
-
-	Next HandleForegroundType(unsigned long val)
-	{
-		// Next values are r,g,b
-		if (val == 2)
-		{
-			m_expandedColor = {0, 0, 0, 255};
-			return Next::ForegroundR;
-		}
-		// Next value is 8-bit swatch color
-		if (val == 5)
-		{
-			return Next::Foreground8Bit;
-		}
-
-		// Invalid
-		return Next::ControlType;
-	}
-
-	Next HandleForeground8Bit(unsigned long val)
-	{
-		if (val < 8)
-		{
-			LocalChatInsertColorChange(m_context, darkColors[val]);
-		}
-		else if (val < 16)
-		{
-			LocalChatInsertColorChange(m_context, lightColors[val - 8]);
-		}
-		else if (val < 232)
-		{
-			unsigned char code = val - 16;
-			unsigned char blue = code % 6;
-			unsigned char green = ((code - blue) / 6) % 6;
-			unsigned char red = (code - blue - (green * 6)) / 36;
-			LocalChatInsertColorChange(
-				m_context, vgui_Color{(unsigned char)(red * 51), (unsigned char)(green * 51), (unsigned char)(blue * 51), 255});
-		}
-		else if (val < UCHAR_MAX)
-		{
-			unsigned char brightness = (val - 232) * 10 + 8;
-			LocalChatInsertColorChange(m_context, vgui_Color{brightness, brightness, brightness, 255});
-		}
-
-		return Next::ControlType;
-	}
-
-	Next HandleForegroundR(unsigned long val)
-	{
-		if (val >= UCHAR_MAX)
-			return Next::ControlType;
-
-		m_expandedColor.r = (unsigned char)val;
-		return Next::ForegroundG;
-	}
-
-	Next HandleForegroundG(unsigned long val)
-	{
-		if (val >= UCHAR_MAX)
-			return Next::ControlType;
-
-		m_expandedColor.g = (unsigned char)val;
-		return Next::ForegroundB;
-	}
-
-	Next HandleForegroundB(unsigned long val)
-	{
-		if (val >= UCHAR_MAX)
-			return Next::ControlType;
-
-		m_expandedColor.b = (unsigned char)val;
-		LocalChatInsertColorChange(m_context, m_expandedColor);
-		return Next::ControlType;
-	}
+struct ChatTags {
+	bool whisper;
+	bool team;
+	bool dead;
 };
 
-const char* ApplyAnsiEscape(LocalChatContext context, const char* escape)
-{
-	AnsiEscapeDecoder decoder(context);
-	while (true)
-	{
-		char* afterControlType = NULL;
-		unsigned long controlType = strtoul(escape, &afterControlType, 10);
+struct Chat {
+	std::string message;
+	int senderId;
+	bool isTeam;
+	bool isDead;
+	int type;
+};
+std::unique_ptr<Chat> currentChat;
 
-		// Malformed cases:
-		// afterControlType = NULL: strtoul errored
-		// controlType = 0 and escape doesn't actually start with 0: wasn't a number
-		if (afterControlType == NULL || (controlType == 0 && escape[0] != '0'))
-		{
-			return escape;
-		}
+/*static void WriteChatPrefixes(LocalChatWriter& writer, int fromPlayerId, ChatTags tags) {
+	char senderName[256];
+	CBasePlayer* localPlayer = GetLocalPlayer();
+	CBasePlayer* senderPlayer = NULL;
 
-		decoder.HandleVal(controlType);
-
-		// m indicates the end of the sequence
-		if (afterControlType[0] == 'm')
-		{
-			return afterControlType + 1;
-		}
-
-		// : or ; indicates more values remain, anything else is malformed
-		if (afterControlType[0] != ':' && afterControlType[0] != ';')
-		{
-			return afterControlType;
-		}
-
-		escape = afterControlType + 1;
-	}
-}
-
-void LocalChatWriteLine(LocalChatContext context, const char* str, int fromPlayerId, AnonymousMessageType messageType)
-{
-	char writeBuffer[256];
-
-	// Force a new line and color reset at the start of all chat lines
-	LocalChatInsertChar(context, L'\n');
-	LocalChatInsertSwatchColorChange(context, SwatchColor::MainText);
-
-	if (fromPlayerId == 0)
-	{
-		LocalChatInsertColorChange(context, vgui_Color{255, 100, 100, 255});
-		LocalChatInsertText(context, "[SERVER] ");
-	}
-
-	if (messageType == AnonymousMessageType::Whisper)
-	{
-		LocalChatInsertColorChange(context, vgui_Color{190, 50, 200, 255});
-		LocalChatInsertText(context, "[WHISPER] ");
-		fromPlayerId -= 128;
-		playerIdForLookup = fromPlayerId;
-		g_ClientSquirrelManager->ExecuteCode("GetPlayerNameById()");
-		const char* test = foundPlayerName.c_str();
-		LocalChatInsertText(context, foundPlayerName.c_str());
-		LocalChatInsertText(context, ": ");
-	}
-
-	while (true)
-	{
-		const char* startOfEscape = strstr(str, "\033[");
-
-		if (startOfEscape == NULL)
-		{
-			// No more escape sequences, write the remaining text and exit
-			LocalChatInsertText(context, str);
-			break;
-		}
-
-		if (startOfEscape != str)
-		{
-			// There is some text before the escape sequence, just print that
-
-			size_t copyChars = startOfEscape - str;
-			if (copyChars > 255)
-				copyChars = 255;
-			strncpy(writeBuffer, str, copyChars);
-			writeBuffer[copyChars] = 0;
-
-			LocalChatInsertText(context, writeBuffer);
-		}
-
-		const char* escape = startOfEscape + 2;
-		str = ApplyAnsiEscape(context, escape);
-	}
-}
-
-void LocalChatWriteMessage(LocalChatContext context, const char* str, const char* playerName, bool isTeam, bool isDead, bool isEnemy)
-{
-	char writeBuffer[256];
-
-	// Force a new line and color reset at the start of all chat lines
-	LocalChatInsertChar(context, L'\n');
-	LocalChatInsertSwatchColorChange(context, SwatchColor::MainText);
-	// TODO: the following colors are probably not entire accurate
-	// Should get them from the game dll
-	if (isEnemy)
-	{
-		LocalChatInsertColorChange(context, vgui_Color{220, 70, 0, 255});
-	}
-	else
-	{
-		LocalChatInsertColorChange(context, vgui_Color{52, 225, 255, 255});
-	}
-	if (isTeam)
-	{
-		LocalChatInsertText(context, "[TEAM] ");
-	}
-	LocalChatInsertText(context, playerName);
-	LocalChatInsertText(context, ": ");
-	LocalChatInsertColorChange(context, vgui_Color{255, 255, 255, 255});
-
-	while (true)
-	{
-		const char* startOfEscape = strstr(str, "\033[");
-
-		if (startOfEscape == NULL)
-		{
-			// No more escape sequences, write the remaining text and exit
-			LocalChatInsertText(context, str);
-			break;
-		}
-
-		if (startOfEscape != str)
-		{
-			// There is some text before the escape sequence, just print that
-
-			size_t copyChars = startOfEscape - str;
-			if (copyChars > 255)
-				copyChars = 255;
-			strncpy(writeBuffer, str, copyChars);
-			writeBuffer[copyChars] = 0;
-
-			LocalChatInsertText(context, writeBuffer);
-		}
-
-		const char* escape = startOfEscape + 2;
-		str = ApplyAnsiEscape(context, escape);
-	}
-}
-
-
-static void OnNetworkChatHook(const char* message, const char* playerName, int unknown)
-{
-	OnNetworkChat(message, playerName, unknown);
-}
-
-static void CHudChat__AddGameLineHook(CHudChat* self, const char* message, int fromPlayerIndex, bool isTeam, bool isDead)
-{
-	// Anonymous messages are from playerIndex=0, other messages are handled as normal
-	if (fromPlayerIndex != 0 && fromPlayerIndex < 128)
-	{
-		// todo: support squirrel hook
-		currentMessage = message;
-		currentPlayerId = fromPlayerIndex - 1;
-		currentIsTeam = isTeam;
-		currentIsDead = isDead;
-		currentIsEnemy = false;
-		if (self == *gHudChatList)
-		{
-			g_ClientSquirrelManager->ExecuteCode("CClientGameDLL_ProcessMessageStartThread()");
-		}
-		
+	if (localPlayer == NULL) {
 		return;
 	}
 
-	// This hook is called for every CHudChat instance, but we want to parse the announcement message and _then_ dispatch it to
-	// each HUD. So ignore this call if this isn't the first HUD.
-	if (self != *gHudChatList)
-	{
-		return;
+	// Get the sender's name and player object if this isn't anonymous, aborting if either fail
+	if (fromPlayerId >= 0) {
+		int fromPlayerIndex = fromPlayerId + 1;
+		if (!GetPlayerName(gEngine, fromPlayerIndex, senderName)) return;
+
+		senderPlayer = UTIL_PlayerByIndex(fromPlayerIndex);
+		if (senderPlayer == NULL) return;
 	}
 
-	if (message == NULL || message[0] == 0)
-	{
-		return;
+	// Force a new line
+	writer.InsertChar(L'\n');
+
+	// Add a [SERVER] tag to anonymous messages
+	if (fromPlayerId < 0) {
+		writer.InsertColorChange(vgui_Color{ 241, 76, 76, 255 });
+		writer.InsertText(L"[SERVER]"); // todo: localize
 	}
 
-	char messageType = message[0];
-	const char* messageContent = message + 1;
-	LocalChatWriteLine(LocalChatContext::Game, messageContent, fromPlayerIndex, AnonymousMessageType(messageType));
+	// Add a [WHISPER] tag to whispers
+	if (tags.whisper) {
+		writer.InsertColorChange(vgui_Color{ 214, 112, 214, 255 });
+		writer.InsertText(L"[WHISPER]"); // todo: localize
+	}
+
+	if (fromPlayerId >= 0) {
+		int localTeam = localPlayer->vtable->GetTeam(localPlayer);
+		int senderTeam = senderPlayer->vtable->GetTeam(senderPlayer);
+		writer.InsertSwatchColorChange(localTeam == senderTeam
+			? LocalChatWriter::SameTeamNameColor
+			: LocalChatWriter::EnemyTeamNameColor);
+
+		if (tags.dead) {
+			writer.InsertText(L"[DEAD]"); // todo: localize
+		}
+		if (tags.team) {
+			writer.InsertText(L"[TEAM]");
+		}
+
+		writer.InsertText(senderName);
+		writer.InsertText(L": ");
+		writer.InsertSwatchColorChange(LocalChatWriter::MainTextColor);
+	}
 }
 
-SQRESULT SQ_GameChatWriteMessage(void* sqvm)
-{
-	const char* text = ClientSq_getstring(sqvm, 1);
-	const char* playerName = ClientSq_getstring(sqvm, 2);
-	bool isTeam = ClientSq_getbool(sqvm, 3);
-	bool isDead = ClientSq_getbool(sqvm, 4);
-	bool isEnemy = ClientSq_getbool(sqvm, 5);
-	LocalChatWriteMessage(LocalChatContext::Game, text, playerName, isTeam, isDead, isEnemy);
+static void OnReceivedChat(const char* message, int senderIndex, ChatTags tags, bool enableAdvancedParsing) {
+	bool isAnonymous = senderIndex == 0;
+	int senderId = senderIndex - 1;
+
+	if (!isAnonymous) {
+		// todo: process with squirrel chat hook
+	}
+
+	LocalChatWriter writer(LocalChatWriter::GameContext);
+	WriteChatPrefixes(writer, senderId, tags);
+
+	if (enableAdvancedParsing) {
+		writer.Write(message);
+	}
+	else {
+		writer.InsertText(message);
+	}
+}*/
+
+static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxIndex, bool isTeam, bool isDead) {
+	int senderIndex = inboxIndex & CUSTOM_MESSAGE_INDEX_BIT;
+	bool isAnonymous = senderIndex == 0;
+	bool isCustom = isAnonymous || (inboxIndex & CUSTOM_MESSAGE_INDEX_MASK);
+
+	// Type is set to 0 for non-custom messages, custom messages have a type encoded as the first byte
+	int type = 0;
+	const char* payload = message;
+	if (isCustom) {
+		type = message[0];
+		payload = message + 1;
+	}
+
+	currentChat.reset();
+	currentChat->message = payload;
+	currentChat->senderId = senderIndex - 1;
+	currentChat->isTeam = isTeam;
+	currentChat->isDead = isDead;
+	currentChat->type = type;
+	g_ClientSquirrelManager->ExecuteCode("CHudChat_ProcessMessageStartThread()");
+}
+
+// void NSChatWrite( int context, string str )
+static SQRESULT SQ_ChatWrite(void* sqvm) {
+	int context = ClientSq_getinteger(sqvm, 1);
+	const char* str = ClientSq_getstring(sqvm, 2);
+
+	LocalChatWriter((LocalChatWriter::Context)context).Write(str);
 	return SQRESULT_NOTNULL;
 }
 
+// void NSChatWriteRaw( int context, string str )
+static SQRESULT SQ_ChatWriteRaw(void* sqvm) {
+	int context = ClientSq_getinteger(sqvm, 1);
+	const char* str = ClientSq_getstring(sqvm, 2);
 
-// void NSGameChatWriteLine( string text )
-SQRESULT SQ_GameChatWriteLine(void* sqvm)
-{
-	const char* text = ClientSq_getstring(sqvm, 1);
-	LocalChatWriteLine(LocalChatContext::Game, text, 128, AnonymousMessageType::Announce);
+	LocalChatWriter((LocalChatWriter::Context)context).InsertText(str);
 	return SQRESULT_NOTNULL;
 }
 
-// void NSNetworkChatWriteLine( string text )
-SQRESULT SQ_NetworkChatWriteLine(void* sqvm)
-{
-	const char* text = ClientSq_getstring(sqvm, 1);
-	LocalChatWriteLine(LocalChatContext::Network, text, 128, AnonymousMessageType::Announce);
+// void NSChatWriteLine( int context, string str )
+static SQRESULT SQ_ChatWriteLine(void* sqvm) {
+	int context = ClientSq_getinteger(sqvm, 1);
+	const char* str = ClientSq_getstring(sqvm, 2);
+
+	LocalChatWriter((LocalChatWriter::Context)context).WriteLine(str);
 	return SQRESULT_NOTNULL;
 }
 
-// void NSNetworkChatWriteLine( string text )
-SQRESULT SQ_GetPlayerIdForLookup(void* sqvm)
-{
-	ClientSq_pushinteger(sqvm, playerIdForLookup);
+// string NSChatGetCurrentMessage()
+static SQRESULT SQ_ChatGetCurrentMessage(void* sqvm) {
+	if (currentChat == NULL) {
+		ClientSq_pusherror(sqvm, "No chat is available");
+		return SQRESULT_ERROR;
+	}
+
+	ClientSq_pushstring(sqvm, currentChat->message.c_str(), -1);
 	return SQRESULT_NOTNULL;
 }
 
-// void NSNetworkChatWriteLine( string text )
-SQRESULT SQ_SetFoundPlayerName(void* sqvm)
-{
-	foundPlayerName = ClientSq_getstring(sqvm, 1);
+// int NSChatGetCurrentPlayer()
+static SQRESULT SQ_ChatGetCurrentPlayer(void* sqvm) {
+	if (currentChat == NULL) {
+		ClientSq_pusherror(sqvm, "No chat is available");
+		return SQRESULT_ERROR;
+	}
+
+	ClientSq_pushinteger(sqvm, currentChat->senderId);
 	return SQRESULT_NOTNULL;
 }
 
-static SQRESULT getMessageClient(void* sqvm)
-{
-	ClientSq_pushstring(sqvm, currentMessage.c_str(), -1);
-	return SQRESULT_NOTNULL;
-}
-static SQRESULT getPlayerClient(void* sqvm)
-{
-	ClientSq_pushinteger(sqvm, currentPlayerId);
-	return SQRESULT_NOTNULL;
-}
+// bool NSChatGetIsTeam()
+static SQRESULT SQ_ChatGetIsTeam(void* sqvm) {
+	if (currentChat == NULL) {
+		ClientSq_pusherror(sqvm, "No chat is available");
+		return SQRESULT_ERROR;
+	}
 
-static SQRESULT getTeamClient(void* sqvm)
-{
-	ClientSq_pushinteger(sqvm, currentIsTeam);
+	ClientSq_pushbool(sqvm, currentChat->isTeam);
 	return SQRESULT_NOTNULL;
 }
 
+// bool NSChatGetIsDead()
+static SQRESULT SQ_ChatGetIsDead(void* sqvm) {
+	if (currentChat == NULL) {
+		ClientSq_pusherror(sqvm, "No chat is available");
+		return SQRESULT_ERROR;
+	}
 
-static SQRESULT getDeadClient(void* sqvm)
-{
-	ClientSq_pushinteger(sqvm, currentIsDead);
+	ClientSq_pushbool(sqvm, currentChat->isDead);
 	return SQRESULT_NOTNULL;
 }
 
-static SQRESULT setChat(void* sqvm)
-{
-	useCustomCode = ClientSq_getbool(sqvm, 1);
+// int NSChatGetCurrentType()
+static SQRESULT SQ_ChatGetCurrentType(void* sqvm) {
+	if (currentChat == NULL) {
+		ClientSq_pusherror(sqvm, "No chat is available");
+		return SQRESULT_ERROR;
+	}
+
+	ClientSq_pushinteger(sqvm, currentChat->type);
 	return SQRESULT_NOTNULL;
 }
-
-static SQRESULT setColor(void* sqvm)
-{
-	r = ClientSq_getinteger(sqvm, 1);
-	g = ClientSq_getinteger(sqvm, 2);
-	b = ClientSq_getinteger(sqvm, 3);
-	return SQRESULT_NOTNULL;
-}
-
 
 void InitialiseClientChatHooks(HMODULE baseAddress)
 {
-	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11bA9E8);
-
-	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
-
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22F160, &OnNetworkChatHook, reinterpret_cast<LPVOID*>(&OnNetworkChat));
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook, reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
 
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatWriteLine", "string text", "", SQ_GameChatWriteLine);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatWriteLine", "string text", "", SQ_NetworkChatWriteLine);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatWriteMessage", "string text, string playerName, bool isTeam, bool isDead, bool isEnemy", "", SQ_GameChatWriteMessage);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWrite", "int context, string text", "", SQ_ChatWrite);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWriteRaw", "int context, string text", "", SQ_ChatWriteRaw);
+	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWriteLine", "int context, string text", "", SQ_ChatWriteLine);
 
-	g_ClientSquirrelManager->AddFuncRegistration("int", "NSGetPlayerIdForLookup", "", "", SQ_GetPlayerIdForLookup);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSSetFoundPlayerName", "string text", "", SQ_SetFoundPlayerName);
-
-	g_ClientSquirrelManager->AddFuncRegistration("string", "NSChatGetCurrentMessage", "", "", getMessageClient);
-	g_ClientSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentPlayer", "", "", getPlayerClient);
-	g_ClientSquirrelManager->AddFuncRegistration("bool", "NSChatGetIsTeam", "", "", getTeamClient);
-	g_ClientSquirrelManager->AddFuncRegistration("bool", "NSChatGetIsDead", "", "", getDeadClient);
-
-	g_ClientSquirrelManager->AddFuncRegistration("void", "setchat", "bool value", "", setChat);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "setcolor", "int r, int g, int b", "", setColor);
+	g_ClientSquirrelManager->AddFuncRegistration("string", "NSChatGetCurrentMessage", "", "", SQ_ChatGetCurrentMessage);
+	g_ClientSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentPlayer", "", "", SQ_ChatGetCurrentPlayer);
+	g_ClientSquirrelManager->AddFuncRegistration("bool", "NSChatGetIsTeam", "", "", SQ_ChatGetIsTeam);
+	g_ClientSquirrelManager->AddFuncRegistration("bool", "NSChatGetIsDead", "", "", SQ_ChatGetIsDead);
+	g_ClientSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentType", "", "", SQ_ChatGetCurrentType);
 }

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -311,7 +311,8 @@ class AnsiEscapeDecoder
 
 	Next HandleForegroundR(unsigned long val)
 	{
-		if (val >= UCHAR_MAX) return Next::ControlType;
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
 
 		m_expandedColor.r = (unsigned char)val;
 		return Next::ForegroundG;
@@ -319,7 +320,8 @@ class AnsiEscapeDecoder
 
 	Next HandleForegroundG(unsigned long val)
 	{
-		if (val >= UCHAR_MAX) return Next::ControlType;
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
 
 		m_expandedColor.g = (unsigned char)val;
 		return Next::ForegroundB;
@@ -327,7 +329,8 @@ class AnsiEscapeDecoder
 
 	Next HandleForegroundB(unsigned long val)
 	{
-		if (val >= UCHAR_MAX) return Next::ControlType;
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
 
 		m_expandedColor.b = (unsigned char)val;
 		LocalChatInsertColorChange(m_context, m_expandedColor);

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -3,7 +3,8 @@
 #include <rapidjson/document.h>
 #include "squirrel.h"
 
-struct vgui_Color {
+struct vgui_Color
+{
 	unsigned char r;
 	unsigned char g;
 	unsigned char b;
@@ -12,13 +13,15 @@ struct vgui_Color {
 
 class vgui_BaseRichText_vtable;
 
-class vgui_BaseRichText {
-public:
+class vgui_BaseRichText
+{
+  public:
 	vgui_BaseRichText_vtable* vtable;
 };
 
-class vgui_BaseRichText_vtable {
-public:
+class vgui_BaseRichText_vtable
+{
+  public:
 	char unknown1[1880];
 
 	void(__fastcall* InsertChar)(vgui_BaseRichText* self, wchar_t ch);
@@ -48,15 +51,17 @@ public:
 	void(__fastcall* InsertIndentChange)(vgui_BaseRichText* self, int pixelsIndent);
 	void(__fastcall* InsertClickableTextStart)(vgui_BaseRichText* self, const char* pchClickAction);
 	void(__fastcall* InsertClickableTextEnd)(vgui_BaseRichText* self);
-	void(__fastcall* InsertPossibleURLString)(vgui_BaseRichText* self, const char* text, vgui_Color URLTextColor, vgui_Color normalTextColor);
+	void(__fastcall* InsertPossibleURLString)(
+		vgui_BaseRichText* self, const char* text, vgui_Color URLTextColor, vgui_Color normalTextColor);
 	void(__fastcall* InsertFade)(vgui_BaseRichText* self, float flSustain, float flLength);
 	void(__fastcall* ResetAllFades)(vgui_BaseRichText* self, bool bHold, bool bOnlyExpired, float flNewSustain);
 	void(__fastcall* SetToFullHeight)(vgui_BaseRichText* self);
 	int(__fastcall* GetNumLines)(vgui_BaseRichText* self);
 };
 
-class CHudChat {
-public:
+class CHudChat
+{
+  public:
 	char unknown1[720];
 
 	vgui_Color m_sameTeamColor;
@@ -88,94 +93,100 @@ OnNetworkChatType OnNetworkChat;
 typedef void(__fastcall* CHudChat__AddGameLineType)(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead);
 CHudChat__AddGameLineType CHudChat__AddGameLine;
 
-void LocalChatStartLine(LocalChatContext context) {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int) context) continue;
+void LocalChatStartLine(LocalChatContext context)
+{
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)context)
+			continue;
 
 		hud->m_richText->vtable->InsertChar(hud->m_richText, L'\n');
 	}
 }
 
-void LocalChatInsertLocalized(LocalChatContext context, const char* str) {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int) context) continue;
+void LocalChatInsertLocalized(LocalChatContext context, const char* str)
+{
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)context)
+			continue;
 
 		hud->m_richText->vtable->InsertStringAnsi(hud->m_richText, str);
 	}
 }
 
-void LocalChatInsertText(LocalChatContext context, const char* str) {
+void LocalChatInsertText(LocalChatContext context, const char* str)
+{
 	WCHAR messageUnicode[288];
 	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
 
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int) context) continue;
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)context)
+			continue;
 
 		hud->m_richText->vtable->InsertStringWide(hud->m_richText, messageUnicode);
 	}
 }
 
-void LocalChatInsertColor(LocalChatContext context, unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha) {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int) context) continue;
+void LocalChatInsertColor(LocalChatContext context, unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha)
+{
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)context)
+			continue;
 
-		hud->m_richText->vtable->InsertColorChange(hud->m_richText, vgui_Color{
-			red,
-			green,
-			blue,
-			alpha
-		});
+		hud->m_richText->vtable->InsertColorChange(hud->m_richText, vgui_Color{red, green, blue, alpha});
 	}
 }
 
-void LocalChatInsertFade(LocalChatContext context, float sustainSecs, float lengthSecs) {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int) context) continue;
+void LocalChatInsertFade(LocalChatContext context, float sustainSecs, float lengthSecs)
+{
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)context)
+			continue;
 
 		hud->m_richText->vtable->InsertFade(hud->m_richText, sustainSecs, lengthSecs);
 	}
 }
 
-static void OnNetworkChatHook(const char* message, const char* playerName, int unknown) {
+static void OnNetworkChatHook(const char* message, const char* playerName, int unknown)
+{
 	// todo: support squirrel hook
 	OnNetworkChat(message, playerName, unknown);
 }
 
-static void OnChatAnnounce(const char* data) {
+static void OnChatAnnounce(const char* data)
+{
 	rapidjson::Document document;
 	document.Parse(data);
 
-	float fadeSustainSecs = document.HasMember("fs")
-		? document["fs"].GetFloat()
-		: DEFAULT_FADE_SUSTAIN;
-	float fadeLengthSecs = document.HasMember("fl")
-		? document["fl"].GetFloat()
-		: DEFAULT_FADE_LENGTH;
+	float fadeSustainSecs = document.HasMember("fs") ? document["fs"].GetFloat() : DEFAULT_FADE_SUSTAIN;
+	float fadeLengthSecs = document.HasMember("fl") ? document["fl"].GetFloat() : DEFAULT_FADE_LENGTH;
 
 	LocalChatStartLine(LocalChatContext::Game);
 
 	rapidjson::Value::Array textItems = document["t"].GetArray();
-	for (const rapidjson::Value& textItem : textItems) {
+	for (const rapidjson::Value& textItem : textItems)
+	{
 		const char* itemType = textItem["i"].GetString();
 
-		if (!strcmp(itemType, "l")) {
+		if (!strcmp(itemType, "l"))
+		{
 			LocalChatInsertLocalized(LocalChatContext::Game, textItem["s"].GetString());
 			LocalChatInsertFade(LocalChatContext::Game, fadeSustainSecs, fadeLengthSecs);
 		}
-		else if (!strcmp(itemType, "t")) {
+		else if (!strcmp(itemType, "t"))
+		{
 			LocalChatInsertText(LocalChatContext::Game, textItem["s"].GetString());
 			LocalChatInsertFade(LocalChatContext::Game, fadeSustainSecs, fadeLengthSecs);
 		}
-		else if (!strcmp(itemType, "c")) {
+		else if (!strcmp(itemType, "c"))
+		{
 			unsigned int color = textItem["c"].GetUint();
 
-			LocalChatInsertColor(
-				LocalChatContext::Game,
-				(color >> 24) & 0xFF,
-				(color >> 16) & 0xFF,
-				(color >> 8) & 0xFF,
-				color & 0xFF
-			);
+			LocalChatInsertColor(LocalChatContext::Game, (color >> 24) & 0xFF, (color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
 		}
 	}
 }
@@ -186,9 +197,11 @@ constexpr char CHAT_PACKET_ANNOUNCE = 2;
 std::string g_IncomingBuffer;
 bool g_IsIgnoringPacket = false;
 
-static void CHudChat__AddGameLineHook(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead) {
+static void CHudChat__AddGameLineHook(CHudChat* self, const char* message, int fromPlayerIndex, bool isteam, bool isdead)
+{
 	// Custom messages are from player=0, other messages are handled as normal
-	if (fromPlayerIndex != 0) {
+	if (fromPlayerIndex != 0)
+	{
 		// todo: support squirrel hook
 		CHudChat__AddGameLine(self, message, fromPlayerIndex, isteam, isdead);
 		return;
@@ -196,47 +209,55 @@ static void CHudChat__AddGameLineHook(CHudChat* self, const char* message, int f
 
 	// This hook is called for every CHudChat instance, but we want to parse the announcement message and _then_ dispatch it to
 	// each HUD. So ignore this call if this isn't the first HUD.
-	if (self != *gHudChatList) {
+	if (self != *gHudChatList)
+	{
 		return;
 	}
 
-	if (message == NULL || message[0] == 0) {
+	if (message == NULL || message[0] == 0)
+	{
 		return;
 	}
 
 	char packetType = message[0];
-	if (packetType != CHAT_PACKET_CONTINUE && g_IsIgnoringPacket) {
+	if (packetType != CHAT_PACKET_CONTINUE && g_IsIgnoringPacket)
+	{
 		// The packet that we were ignoring has ended, stop ignoring.
 		g_IsIgnoringPacket = false;
 		return;
 	}
-	else if (g_IsIgnoringPacket) {
+	else if (g_IsIgnoringPacket)
+	{
 		return;
 	}
 
 	g_IncomingBuffer.append(message + 1);
 
 	// Limit the buffer at 64KiB, ignore the rest of it if we've reached that limit
-	if (g_IncomingBuffer.size() > 65536) {
+	if (g_IncomingBuffer.size() > 65536)
+	{
 		g_IncomingBuffer.clear();
 		g_IsIgnoringPacket = true;
 		return;
 	}
 
-	if (packetType == CHAT_PACKET_CONTINUE) {
+	if (packetType == CHAT_PACKET_CONTINUE)
+	{
 		return;
 	}
 
 	// Clear incoming data and keep the current packet string
 	std::string packetData = std::move(g_IncomingBuffer);
 
-	if (packetType == CHAT_PACKET_ANNOUNCE) {
+	if (packetType == CHAT_PACKET_ANNOUNCE)
+	{
 		OnChatAnnounce(packetData.c_str());
 	}
 }
 
 // void NSGameChatWriteLine( string text )
-SQRESULT SQ_GameChatWriteLine(void* sqvm) {
+SQRESULT SQ_GameChatWriteLine(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatStartLine(LocalChatContext::Game);
@@ -248,14 +269,16 @@ SQRESULT SQ_GameChatWriteLine(void* sqvm) {
 }
 
 // void NSGameChatStartLine()
-SQRESULT SQ_GameChatStartLine(void* sqvm) {
+SQRESULT SQ_GameChatStartLine(void* sqvm)
+{
 	LocalChatStartLine(LocalChatContext::Game);
 
 	return SQRESULT_NULL;
 }
 
 // void NSGameChatInsertLocalized( string text )
-SQRESULT SQ_GameChatInsertLocalized(void* sqvm) {
+SQRESULT SQ_GameChatInsertLocalized(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatInsertLocalized(LocalChatContext::Game, text);
@@ -265,7 +288,8 @@ SQRESULT SQ_GameChatInsertLocalized(void* sqvm) {
 }
 
 // void NSGameChatInsertText( string text )
-SQRESULT SQ_GameChatInsertText(void* sqvm) {
+SQRESULT SQ_GameChatInsertText(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatInsertText(LocalChatContext::Game, text);
@@ -275,25 +299,23 @@ SQRESULT SQ_GameChatInsertText(void* sqvm) {
 }
 
 // void NSGameChatInsertColor( float red, float green, float blue, float alpha )
-SQRESULT SQ_GameChatInsertColor(void* sqvm) {
+SQRESULT SQ_GameChatInsertColor(void* sqvm)
+{
 	float red = ClientSq_getfloat(sqvm, 1);
 	float green = ClientSq_getfloat(sqvm, 2);
 	float blue = ClientSq_getfloat(sqvm, 3);
 	float alpha = ClientSq_getfloat(sqvm, 4);
 
 	LocalChatInsertColor(
-		LocalChatContext::Game,
-		(unsigned char)(red * 255.f),
-		(unsigned char)(green * 255.f),
-		(unsigned char)(blue * 255.f),
-		(unsigned char)(alpha * 255.f)
-	);
+		LocalChatContext::Game, (unsigned char)(red * 255.f), (unsigned char)(green * 255.f), (unsigned char)(blue * 255.f),
+		(unsigned char)(alpha * 255.f));
 
 	return SQRESULT_NULL;
 }
 
 // void NSNetworkChatWriteLine( string text )
-SQRESULT SQ_NetworkChatWriteLine(void* sqvm) {
+SQRESULT SQ_NetworkChatWriteLine(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatStartLine(LocalChatContext::Network);
@@ -304,14 +326,16 @@ SQRESULT SQ_NetworkChatWriteLine(void* sqvm) {
 }
 
 // void NSNetworkChatStartLine()
-SQRESULT SQ_NetworkChatStartLine(void* sqvm) {
+SQRESULT SQ_NetworkChatStartLine(void* sqvm)
+{
 	LocalChatStartLine(LocalChatContext::Network);
 
 	return SQRESULT_NULL;
 }
 
 // void NSNetworkChatInsertLocalized( string text )
-SQRESULT SQ_NetworkChatInsertLocalized(void* sqvm) {
+SQRESULT SQ_NetworkChatInsertLocalized(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatInsertLocalized(LocalChatContext::Network, text);
@@ -320,7 +344,8 @@ SQRESULT SQ_NetworkChatInsertLocalized(void* sqvm) {
 }
 
 // void NSNetworkChatInsertText( string text )
-SQRESULT SQ_NetworkChatInsertText(void* sqvm) {
+SQRESULT SQ_NetworkChatInsertText(void* sqvm)
+{
 	const char* text = ClientSq_getstring(sqvm, 1);
 
 	LocalChatInsertText(LocalChatContext::Network, text);
@@ -329,44 +354,40 @@ SQRESULT SQ_NetworkChatInsertText(void* sqvm) {
 }
 
 // void NSNetworkChatInsertColor( float red, float green, float blue, float alpha )
-SQRESULT SQ_NetworkChatInsertColor(void* sqvm) {
+SQRESULT SQ_NetworkChatInsertColor(void* sqvm)
+{
 	float red = ClientSq_getfloat(sqvm, 1);
 	float green = ClientSq_getfloat(sqvm, 2);
 	float blue = ClientSq_getfloat(sqvm, 3);
 	float alpha = ClientSq_getfloat(sqvm, 4);
 
 	LocalChatInsertColor(
-		LocalChatContext::Network,
-		(unsigned char)(red * 255.f),
-		(unsigned char)(green * 255.f),
-		(unsigned char)(blue * 255.f),
-		(unsigned char)(alpha * 255.f)
-	);
+		LocalChatContext::Network, (unsigned char)(red * 255.f), (unsigned char)(green * 255.f), (unsigned char)(blue * 255.f),
+		(unsigned char)(alpha * 255.f));
 
 	return SQRESULT_NULL;
 }
 
-void InitialiseClientChatHooks(HMODULE baseAddress) {
+void InitialiseClientChatHooks(HMODULE baseAddress)
+{
 	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11bA9E8);
 
 	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x22F160, &OnNetworkChatHook,
-		reinterpret_cast<LPVOID*>(&OnNetworkChat));
-	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook,
-		reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
+	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22F160, &OnNetworkChatHook, reinterpret_cast<LPVOID*>(&OnNetworkChat));
+	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook, reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
 
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatWriteLine", "string text", "", SQ_GameChatWriteLine);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatStartLine", "", "", SQ_GameChatStartLine);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertLocalized", "string text", "", SQ_GameChatInsertLocalized);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertText", "string text", "", SQ_GameChatInsertText);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSGameChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_GameChatInsertColor);
+	g_ClientSquirrelManager->AddFuncRegistration(
+		"void", "NSGameChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_GameChatInsertColor);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatWriteLine", "string text", "", SQ_NetworkChatWriteLine);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatStartLine", "", "", SQ_NetworkChatStartLine);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertLocalized", "string text", "", SQ_NetworkChatInsertLocalized);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertText", "string text", "", SQ_NetworkChatInsertText);
-	g_ClientSquirrelManager->AddFuncRegistration("void", "NSNetworkChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_NetworkChatInsertColor);
+	g_ClientSquirrelManager->AddFuncRegistration(
+		"void", "NSNetworkChatInsertColor", "float red, float green, float blue, float alpha", "", SQ_NetworkChatInsertColor);
 }

--- a/NorthstarDedicatedTest/clientchathooks.h
+++ b/NorthstarDedicatedTest/clientchathooks.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "pch.h"
+#include "serverchathooks.h"
 
 enum class LocalChatContext
 {
@@ -7,6 +8,6 @@ enum class LocalChatContext
 	Game = 1
 };
 
-void LocalChatWriteLine(LocalChatContext context, const char* str);
+void LocalChatWriteLine(LocalChatContext context, const char* str, int fromPlayerId, AnonymousMessageType messageType);
 
 void InitialiseClientChatHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/clientchathooks.h
+++ b/NorthstarDedicatedTest/clientchathooks.h
@@ -4,7 +4,8 @@
 constexpr float DEFAULT_FADE_SUSTAIN = 12.f;
 constexpr float DEFAULT_FADE_LENGTH = 1.f;
 
-enum class LocalChatContext {
+enum class LocalChatContext
+{
 	Network = 0,
 	Game = 1
 };

--- a/NorthstarDedicatedTest/clientchathooks.h
+++ b/NorthstarDedicatedTest/clientchathooks.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "pch.h"
+
+constexpr float DEFAULT_FADE_SUSTAIN = 12.f;
+constexpr float DEFAULT_FADE_LENGTH = 1.f;
+
+enum class LocalChatContext {
+	Network = 0,
+	Game = 1
+};
+
+void LocalChatStartLine(LocalChatContext context);
+
+void LocalChatInsertLocalized(LocalChatContext context, const char* str);
+
+void LocalChatInsertText(LocalChatContext context, const char* str);
+
+void LocalChatInsertColor(LocalChatContext context, unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha);
+
+void LocalChatInsertFade(LocalChatContext context, float sustainSecs, float lengthSecs);
+
+void InitialiseClientChatHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/clientchathooks.h
+++ b/NorthstarDedicatedTest/clientchathooks.h
@@ -2,12 +2,4 @@
 #include "pch.h"
 #include "serverchathooks.h"
 
-enum class LocalChatContext
-{
-	Network = 0,
-	Game = 1
-};
-
-void LocalChatWriteLine(LocalChatContext context, const char* str, int fromPlayerId, AnonymousMessageType messageType);
-
 void InitialiseClientChatHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/clientchathooks.h
+++ b/NorthstarDedicatedTest/clientchathooks.h
@@ -1,23 +1,12 @@
 #pragma once
 #include "pch.h"
 
-constexpr float DEFAULT_FADE_SUSTAIN = 12.f;
-constexpr float DEFAULT_FADE_LENGTH = 1.f;
-
 enum class LocalChatContext
 {
 	Network = 0,
 	Game = 1
 };
 
-void LocalChatStartLine(LocalChatContext context);
-
-void LocalChatInsertLocalized(LocalChatContext context, const char* str);
-
-void LocalChatInsertText(LocalChatContext context, const char* str);
-
-void LocalChatInsertColor(LocalChatContext context, unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha);
-
-void LocalChatInsertFade(LocalChatContext context, float sustainSecs, float lengthSecs);
+void LocalChatWriteLine(LocalChatContext context, const char* str);
 
 void InitialiseClientChatHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -36,6 +36,7 @@
 #include "configurables.h"
 #include "serverchathooks.h"
 #include "clientchathooks.h"
+#include "localchatwriter.h"
 #include <string.h>
 #include "pch.h"
 
@@ -123,7 +124,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallback("client.dll", InitialiseMiscClientFixes);
 		AddDllLoadCallback("client.dll", InitialiseClientPrintHooks);
 		AddDllLoadCallback("client.dll", InitialiseClientChatHooks);
-		AddDllLoadCallback("client.dll", InitialiseUICommands);
+		AddDllLoadCallback("client.dll", InitialiseLocalChatWriter);
 	}
 
 	AddDllLoadCallback("engine.dll", InitialiseEngineSpewFuncHooks);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -129,7 +129,6 @@ bool InitialiseNorthstar()
 	AddDllLoadCallback("server.dll", InitialiseServerSquirrel);
 	AddDllLoadCallback("engine.dll", InitialiseBanSystem);
 	AddDllLoadCallback("engine.dll", InitialiseServerAuthentication);
-	AddDllLoadCallback("server.dll", InitialiseServerAuthenticationServerDLL);
 	AddDllLoadCallback("engine.dll", InitialiseSharedMasterServer);
 	AddDllLoadCallback("server.dll", InitialiseMiscServerScriptCommand);
 	AddDllLoadCallback("server.dll", InitialiseMiscServerFixes);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -123,6 +123,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallback("client.dll", InitialiseMiscClientFixes);
 		AddDllLoadCallback("client.dll", InitialiseClientPrintHooks);
 		AddDllLoadCallback("client.dll", InitialiseClientChatHooks);
+		AddDllLoadCallback("client.dll", InitialiseUICommands);
 	}
 
 	AddDllLoadCallback("engine.dll", InitialiseEngineSpewFuncHooks);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -34,6 +34,8 @@
 #include "audio.h"
 #include "buildainfile.h"
 #include "configurables.h"
+#include "serverchathooks.h"
+#include "clientchathooks.h"
 #include <string.h>
 #include "pch.h"
 
@@ -120,6 +122,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallback("client.dll", InitialiseScriptMainMenuPromos);
 		AddDllLoadCallback("client.dll", InitialiseMiscClientFixes);
 		AddDllLoadCallback("client.dll", InitialiseClientPrintHooks);
+		AddDllLoadCallback("client.dll", InitialiseClientChatHooks);
 	}
 
 	AddDllLoadCallback("engine.dll", InitialiseEngineSpewFuncHooks);
@@ -137,6 +140,9 @@ bool InitialiseNorthstar()
 	AddDllLoadCallback("filesystem_stdio.dll", InitialiseFilesystem);
 	AddDllLoadCallback("engine.dll", InitialiseEngineRpakFilesystem);
 	AddDllLoadCallback("engine.dll", InitialiseKeyValues);
+
+	AddDllLoadCallback("engine.dll", InitialiseServerChatHooks_Engine);
+	AddDllLoadCallback("server.dll", InitialiseServerChatHooks_Server);
 
 	// maxplayers increase
 	AddDllLoadCallback("engine.dll", InitialiseMaxPlayersOverride_Engine);

--- a/NorthstarDedicatedTest/localchatwriter.cpp
+++ b/NorthstarDedicatedTest/localchatwriter.cpp
@@ -1,0 +1,439 @@
+#include "pch.h"
+#include "localchatwriter.h"
+
+class vgui_BaseRichText_vtable;
+
+class vgui_BaseRichText
+{
+public:
+	vgui_BaseRichText_vtable* vtable;
+};
+
+class vgui_BaseRichText_vtable
+{
+public:
+	char unknown1[1880];
+
+	void(__fastcall* InsertChar)(vgui_BaseRichText* self, wchar_t ch);
+
+	// yes these are swapped from the Source 2013 code, who knows why
+	void(__fastcall* InsertStringWide)(vgui_BaseRichText* self, const wchar_t* wszText);
+	void(__fastcall* InsertStringAnsi)(vgui_BaseRichText* self, const char* text);
+
+	void(__fastcall* SelectNone)(vgui_BaseRichText* self);
+	void(__fastcall* SelectAllText)(vgui_BaseRichText* self);
+	void(__fastcall* SelectNoText)(vgui_BaseRichText* self);
+	void(__fastcall* CutSelected)(vgui_BaseRichText* self);
+	void(__fastcall* CopySelected)(vgui_BaseRichText* self);
+	void(__fastcall* SetPanelInteractive)(vgui_BaseRichText* self, bool bInteractive);
+	void(__fastcall* SetUnusedScrollbarInvisible)(vgui_BaseRichText* self, bool bInvis);
+
+	void* unknown2;
+
+	void(__fastcall* GotoTextStart)(vgui_BaseRichText* self);
+	void(__fastcall* GotoTextEnd)(vgui_BaseRichText* self);
+
+	void* unknown3[3];
+
+	void(__fastcall* SetVerticalScrollbar)(vgui_BaseRichText* self, bool state);
+	void(__fastcall* SetMaximumCharCount)(vgui_BaseRichText* self, int maxChars);
+	void(__fastcall* InsertColorChange)(vgui_BaseRichText* self, vgui_Color col);
+	void(__fastcall* InsertIndentChange)(vgui_BaseRichText* self, int pixelsIndent);
+	void(__fastcall* InsertClickableTextStart)(vgui_BaseRichText* self, const char* pchClickAction);
+	void(__fastcall* InsertClickableTextEnd)(vgui_BaseRichText* self);
+	void(__fastcall* InsertPossibleURLString)(
+		vgui_BaseRichText* self, const char* text, vgui_Color URLTextColor, vgui_Color normalTextColor);
+	void(__fastcall* InsertFade)(vgui_BaseRichText* self, float flSustain, float flLength);
+	void(__fastcall* ResetAllFades)(vgui_BaseRichText* self, bool bHold, bool bOnlyExpired, float flNewSustain);
+	void(__fastcall* SetToFullHeight)(vgui_BaseRichText* self);
+	int(__fastcall* GetNumLines)(vgui_BaseRichText* self);
+};
+
+class CGameSettings {
+public:
+	char unknown1[92];
+	int isChatEnabled;
+};
+
+// Not sure what this actually refers to but chatFadeLength and chatFadeSustain
+// have their value at the same offset
+class CGameFloatVar {
+public:
+	char unknown1[88];
+	float value;
+};
+
+class CHudChat
+{
+public:
+	char unknown1[720];
+
+	vgui_Color m_sameTeamColor;
+	vgui_Color m_enemyTeamColor;
+	vgui_Color m_mainTextColor;
+	vgui_Color m_networkNameColor;
+
+	char unknown2[12];
+
+	int m_unknownContext;
+
+	char unknown3[8];
+
+	vgui_BaseRichText* m_richText;
+
+	CHudChat* next;
+	CHudChat* previous;
+};
+
+CGameSettings* gGameSettings;
+CGameFloatVar* gChatFadeLength;
+CGameFloatVar* gChatFadeSustain;
+
+// Linked list of CHudChats
+CHudChat** gHudChatList;
+
+typedef void(__fastcall* ConvertANSIToUnicodeType)(LPCSTR ansi, int ansiCharLength, LPWSTR unicode, int unicodeCharLength);
+ConvertANSIToUnicodeType ConvertANSIToUnicode;
+
+LocalChatWriter::SwatchColor swatchColors[4] = {
+	LocalChatWriter::MainTextColor,
+	LocalChatWriter::SameTeamNameColor,
+	LocalChatWriter::EnemyTeamNameColor,
+	LocalChatWriter::NetworkNameColor,
+};
+
+vgui_Color darkColors[8] = { vgui_Color{0, 0, 0, 255},	   vgui_Color{205, 49, 49, 255},  vgui_Color{13, 188, 121, 255},
+							vgui_Color{229, 229, 16, 255}, vgui_Color{36, 114, 200, 255}, vgui_Color{188, 63, 188, 255},
+							vgui_Color{17, 168, 205, 255}, vgui_Color{229, 229, 229, 255} };
+
+vgui_Color lightColors[8] = { vgui_Color{102, 102, 102, 255}, vgui_Color{241, 76, 76, 255},	vgui_Color{35, 209, 139, 255},
+							 vgui_Color{245, 245, 67, 255},	 vgui_Color{59, 142, 234, 255}, vgui_Color{214, 112, 214, 255},
+							 vgui_Color{41, 184, 219, 255},	 vgui_Color{255, 255, 255, 255} };
+
+class AnsiEscapeParser {
+public:
+	explicit AnsiEscapeParser(LocalChatWriter* writer) : m_writer(writer) {}
+
+	void HandleVal(unsigned long val)
+	{
+		switch (m_next)
+		{
+		case Next::ControlType:
+			m_next = HandleControlType(val);
+			break;
+		case Next::ForegroundType:
+			m_next = HandleForegroundType(val);
+			break;
+		case Next::Foreground8Bit:
+			m_next = HandleForeground8Bit(val);
+			break;
+		case Next::ForegroundR:
+			m_next = HandleForegroundR(val);
+			break;
+		case Next::ForegroundG:
+			m_next = HandleForegroundG(val);
+			break;
+		case Next::ForegroundB:
+			m_next = HandleForegroundB(val);
+			break;
+		}
+	}
+
+private:
+	enum class Next
+	{
+		ControlType,
+		ForegroundType,
+		Foreground8Bit,
+		ForegroundR,
+		ForegroundG,
+		ForegroundB
+	};
+
+	LocalChatWriter* m_writer;
+	Next m_next = Next::ControlType;
+	vgui_Color m_expandedColor{ 0, 0, 0, 0 };
+
+	Next HandleControlType(unsigned long val)
+	{
+		// Reset
+		if (val == 0 || val == 39)
+		{
+			m_writer->InsertSwatchColorChange(LocalChatWriter::MainTextColor);
+			return Next::ControlType;
+		}
+
+		// Dark foreground color
+		if (val >= 30 && val < 38)
+		{
+			m_writer->InsertColorChange(darkColors[val - 30]);
+			return Next::ControlType;
+		}
+
+		// Light foreground color
+		if (val >= 90 && val < 98)
+		{
+			m_writer->InsertColorChange(lightColors[val - 90]);
+			return Next::ControlType;
+		}
+
+		// Game swatch color
+		if (val >= 110 && val < 114)
+		{
+			m_writer->InsertSwatchColorChange(swatchColors[val - 110]);
+			return Next::ControlType;
+		}
+
+		// Expanded foreground color
+		if (val == 38)
+		{
+			return Next::ForegroundType;
+		}
+
+		return Next::ControlType;
+	}
+
+	Next HandleForegroundType(unsigned long val)
+	{
+		// Next values are r,g,b
+		if (val == 2)
+		{
+			m_expandedColor = { 0, 0, 0, 255 };
+			return Next::ForegroundR;
+		}
+		// Next value is 8-bit swatch color
+		if (val == 5)
+		{
+			return Next::Foreground8Bit;
+		}
+
+		// Invalid
+		return Next::ControlType;
+	}
+
+	Next HandleForeground8Bit(unsigned long val)
+	{
+		if (val < 8)
+		{
+			m_writer->InsertColorChange(darkColors[val]);
+		}
+		else if (val < 16)
+		{
+			m_writer->InsertColorChange(lightColors[val - 8]);
+		}
+		else if (val < 232)
+		{
+			unsigned char code = val - 16;
+			unsigned char blue = code % 6;
+			unsigned char green = ((code - blue) / 6) % 6;
+			unsigned char red = (code - blue - (green * 6)) / 36;
+			m_writer->InsertColorChange(
+				vgui_Color{ (unsigned char)(red * 51), (unsigned char)(green * 51), (unsigned char)(blue * 51), 255 });
+		}
+		else if (val < UCHAR_MAX)
+		{
+			unsigned char brightness = (val - 232) * 10 + 8;
+			m_writer->InsertColorChange(vgui_Color{ brightness, brightness, brightness, 255 });
+		}
+
+		return Next::ControlType;
+	}
+
+	Next HandleForegroundR(unsigned long val)
+	{
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
+
+		m_expandedColor.r = (unsigned char)val;
+		return Next::ForegroundG;
+	}
+
+	Next HandleForegroundG(unsigned long val)
+	{
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
+
+		m_expandedColor.g = (unsigned char)val;
+		return Next::ForegroundB;
+	}
+
+	Next HandleForegroundB(unsigned long val)
+	{
+		if (val >= UCHAR_MAX)
+			return Next::ControlType;
+
+		m_expandedColor.b = (unsigned char)val;
+		m_writer->InsertColorChange(m_expandedColor);
+		return Next::ControlType;
+	}
+};
+
+LocalChatWriter::LocalChatWriter(Context context) : m_context(context) {}
+
+void LocalChatWriter::Write(const char* str) {
+	char writeBuffer[256];
+
+	while (true) {
+		const char* startOfEscape = strstr(str, "\033[");
+
+		if (startOfEscape == NULL)
+		{
+			// No more escape sequences, write the remaining text and exit
+			InsertText(str);
+			break;
+		}
+
+		if (startOfEscape != str)
+		{
+			// There is some text before the escape sequence, just print that
+
+			size_t copyChars = startOfEscape - str;
+			if (copyChars > 255)
+				copyChars = 255;
+			strncpy(writeBuffer, str, copyChars);
+			writeBuffer[copyChars] = 0;
+
+			InsertText(writeBuffer);
+		}
+
+		const char* escape = startOfEscape + 2;
+		str = ApplyAnsiEscape(escape);
+	}
+}
+
+void LocalChatWriter::WriteLine(const char* str) {
+	InsertChar(L'\n');
+	InsertSwatchColorChange(MainTextColor);
+	Write(str);
+}
+
+void LocalChatWriter::InsertChar(wchar_t ch) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
+
+		hud->m_richText->vtable->InsertChar(hud->m_richText, ch);
+	}
+
+	if (ch != L'\n') {
+		InsertDefaultFade();
+	}
+}
+
+void LocalChatWriter::InsertText(const char* str) {
+	WCHAR messageUnicode[288];
+	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
+
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
+
+		hud->m_richText->vtable->InsertStringWide(hud->m_richText, messageUnicode);
+	}
+
+	InsertDefaultFade();
+}
+
+void LocalChatWriter::InsertText(const wchar_t* str) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
+
+		hud->m_richText->vtable->InsertStringWide(hud->m_richText, str);
+	}
+
+	InsertDefaultFade();
+}
+
+void LocalChatWriter::InsertColorChange(vgui_Color color) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
+
+		hud->m_richText->vtable->InsertColorChange(hud->m_richText, color);
+	}
+}
+
+static vgui_Color GetHudSwatchColor(CHudChat* hud, LocalChatWriter::SwatchColor swatchColor)
+{
+	switch (swatchColor)
+	{
+	case LocalChatWriter::MainTextColor:
+		return hud->m_mainTextColor;
+	case LocalChatWriter::SameTeamNameColor:
+		return hud->m_sameTeamColor;
+	case LocalChatWriter::EnemyTeamNameColor:
+		return hud->m_enemyTeamColor;
+	case LocalChatWriter::NetworkNameColor:
+		return hud->m_networkNameColor;
+	}
+	return vgui_Color{ 0, 0, 0, 0 };
+}
+
+void LocalChatWriter::InsertSwatchColorChange(SwatchColor swatchColor) {
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
+		hud->m_richText->vtable->InsertColorChange(hud->m_richText, GetHudSwatchColor(hud, swatchColor));
+	}
+}
+
+const char* LocalChatWriter::ApplyAnsiEscape(const char* escape) {
+	AnsiEscapeParser decoder(this);
+	while (true)
+	{
+		char* afterControlType = NULL;
+		unsigned long controlType = strtoul(escape, &afterControlType, 10);
+
+		// Malformed cases:
+		// afterControlType = NULL: strtoul errored
+		// controlType = 0 and escape doesn't actually start with 0: wasn't a number
+		if (afterControlType == NULL || (controlType == 0 && escape[0] != '0'))
+		{
+			return escape;
+		}
+
+		decoder.HandleVal(controlType);
+
+		// m indicates the end of the sequence
+		if (afterControlType[0] == 'm')
+		{
+			return afterControlType + 1;
+		}
+
+		// : or ; indicates more values remain, anything else is malformed
+		if (afterControlType[0] != ':' && afterControlType[0] != ';')
+		{
+			return afterControlType;
+		}
+
+		escape = afterControlType + 1;
+	}
+}
+
+void LocalChatWriter::InsertDefaultFade() {
+	float fadeLength = 0.f;
+	float fadeSustain = 0.f;
+	if (gGameSettings->isChatEnabled) {
+		fadeLength = gChatFadeLength->value;
+		fadeSustain = gChatFadeSustain->value;
+	}
+
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+		if (hud->m_unknownContext != (int)m_context) continue;
+		hud->m_richText->vtable->InsertFade(hud->m_richText, fadeSustain, fadeLength);
+	}
+}
+
+void InitialiseLocalChatWriter(HMODULE baseAddress) {
+	gGameSettings = (CGameSettings*)((char*)baseAddress + 0x11BAA48);
+	gChatFadeLength = (CGameFloatVar*)((char*)baseAddress + 0x11BAB78);
+	gChatFadeSustain = (CGameFloatVar*)((char*)baseAddress + 0x11BAC08);
+	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
+
+	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
+}

--- a/NorthstarDedicatedTest/localchatwriter.cpp
+++ b/NorthstarDedicatedTest/localchatwriter.cpp
@@ -87,9 +87,9 @@ class CHudChat
 	CHudChat* previous;
 };
 
-CGameSettings* gGameSettings;
-CGameFloatVar* gChatFadeLength;
-CGameFloatVar* gChatFadeSustain;
+CGameSettings** gGameSettings;
+CGameFloatVar** gChatFadeLength;
+CGameFloatVar** gChatFadeSustain;
 
 // Linked list of CHudChats
 CHudChat** gHudChatList;
@@ -433,10 +433,10 @@ void LocalChatWriter::InsertDefaultFade()
 {
 	float fadeLength = 0.f;
 	float fadeSustain = 0.f;
-	if (gGameSettings->isChatEnabled)
+	if ((*gGameSettings)->isChatEnabled)
 	{
-		fadeLength = gChatFadeLength->value;
-		fadeSustain = gChatFadeSustain->value;
+		fadeLength = (*gChatFadeLength)->value;
+		fadeSustain = (*gChatFadeSustain)->value;
 	}
 
 	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
@@ -447,11 +447,13 @@ void LocalChatWriter::InsertDefaultFade()
 	}
 }
 
+bool IsFirstHud(void* hud) { return hud == *gHudChatList; }
+
 void InitialiseLocalChatWriter(HMODULE baseAddress)
 {
-	gGameSettings = (CGameSettings*)((char*)baseAddress + 0x11BAA48);
-	gChatFadeLength = (CGameFloatVar*)((char*)baseAddress + 0x11BAB78);
-	gChatFadeSustain = (CGameFloatVar*)((char*)baseAddress + 0x11BAC08);
+	gGameSettings = (CGameSettings**)((char*)baseAddress + 0x11BAA48);
+	gChatFadeLength = (CGameFloatVar**)((char*)baseAddress + 0x11BAB78);
+	gChatFadeSustain = (CGameFloatVar**)((char*)baseAddress + 0x11BAC08);
 	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
 
 	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);

--- a/NorthstarDedicatedTest/localchatwriter.cpp
+++ b/NorthstarDedicatedTest/localchatwriter.cpp
@@ -5,13 +5,13 @@ class vgui_BaseRichText_vtable;
 
 class vgui_BaseRichText
 {
-public:
+  public:
 	vgui_BaseRichText_vtable* vtable;
 };
 
 class vgui_BaseRichText_vtable
 {
-public:
+  public:
 	char unknown1[1880];
 
 	void(__fastcall* InsertChar)(vgui_BaseRichText* self, wchar_t ch);
@@ -49,23 +49,25 @@ public:
 	int(__fastcall* GetNumLines)(vgui_BaseRichText* self);
 };
 
-class CGameSettings {
-public:
+class CGameSettings
+{
+  public:
 	char unknown1[92];
 	int isChatEnabled;
 };
 
 // Not sure what this actually refers to but chatFadeLength and chatFadeSustain
 // have their value at the same offset
-class CGameFloatVar {
-public:
+class CGameFloatVar
+{
+  public:
 	char unknown1[88];
 	float value;
 };
 
 class CHudChat
 {
-public:
+  public:
 	char unknown1[720];
 
 	vgui_Color m_sameTeamColor;
@@ -102,16 +104,17 @@ LocalChatWriter::SwatchColor swatchColors[4] = {
 	LocalChatWriter::NetworkNameColor,
 };
 
-vgui_Color darkColors[8] = { vgui_Color{0, 0, 0, 255},	   vgui_Color{205, 49, 49, 255},  vgui_Color{13, 188, 121, 255},
+vgui_Color darkColors[8] = {vgui_Color{0, 0, 0, 255},	   vgui_Color{205, 49, 49, 255},  vgui_Color{13, 188, 121, 255},
 							vgui_Color{229, 229, 16, 255}, vgui_Color{36, 114, 200, 255}, vgui_Color{188, 63, 188, 255},
-							vgui_Color{17, 168, 205, 255}, vgui_Color{229, 229, 229, 255} };
+							vgui_Color{17, 168, 205, 255}, vgui_Color{229, 229, 229, 255}};
 
-vgui_Color lightColors[8] = { vgui_Color{102, 102, 102, 255}, vgui_Color{241, 76, 76, 255},	vgui_Color{35, 209, 139, 255},
+vgui_Color lightColors[8] = {vgui_Color{102, 102, 102, 255}, vgui_Color{241, 76, 76, 255},	vgui_Color{35, 209, 139, 255},
 							 vgui_Color{245, 245, 67, 255},	 vgui_Color{59, 142, 234, 255}, vgui_Color{214, 112, 214, 255},
-							 vgui_Color{41, 184, 219, 255},	 vgui_Color{255, 255, 255, 255} };
+							 vgui_Color{41, 184, 219, 255},	 vgui_Color{255, 255, 255, 255}};
 
-class AnsiEscapeParser {
-public:
+class AnsiEscapeParser
+{
+  public:
 	explicit AnsiEscapeParser(LocalChatWriter* writer) : m_writer(writer) {}
 
 	void HandleVal(unsigned long val)
@@ -139,7 +142,7 @@ public:
 		}
 	}
 
-private:
+  private:
 	enum class Next
 	{
 		ControlType,
@@ -152,7 +155,7 @@ private:
 
 	LocalChatWriter* m_writer;
 	Next m_next = Next::ControlType;
-	vgui_Color m_expandedColor{ 0, 0, 0, 0 };
+	vgui_Color m_expandedColor{0, 0, 0, 0};
 
 	Next HandleControlType(unsigned long val)
 	{
@@ -198,7 +201,7 @@ private:
 		// Next values are r,g,b
 		if (val == 2)
 		{
-			m_expandedColor = { 0, 0, 0, 255 };
+			m_expandedColor = {0, 0, 0, 255};
 			return Next::ForegroundR;
 		}
 		// Next value is 8-bit swatch color
@@ -228,12 +231,12 @@ private:
 			unsigned char green = ((code - blue) / 6) % 6;
 			unsigned char red = (code - blue - (green * 6)) / 36;
 			m_writer->InsertColorChange(
-				vgui_Color{ (unsigned char)(red * 51), (unsigned char)(green * 51), (unsigned char)(blue * 51), 255 });
+				vgui_Color{(unsigned char)(red * 51), (unsigned char)(green * 51), (unsigned char)(blue * 51), 255});
 		}
 		else if (val < UCHAR_MAX)
 		{
 			unsigned char brightness = (val - 232) * 10 + 8;
-			m_writer->InsertColorChange(vgui_Color{ brightness, brightness, brightness, 255 });
+			m_writer->InsertColorChange(vgui_Color{brightness, brightness, brightness, 255});
 		}
 
 		return Next::ControlType;
@@ -270,10 +273,12 @@ private:
 
 LocalChatWriter::LocalChatWriter(Context context) : m_context(context) {}
 
-void LocalChatWriter::Write(const char* str) {
+void LocalChatWriter::Write(const char* str)
+{
 	char writeBuffer[256];
 
-	while (true) {
+	while (true)
+	{
 		const char* startOfEscape = strstr(str, "\033[");
 
 		if (startOfEscape == NULL)
@@ -301,13 +306,15 @@ void LocalChatWriter::Write(const char* str) {
 	}
 }
 
-void LocalChatWriter::WriteLine(const char* str) {
+void LocalChatWriter::WriteLine(const char* str)
+{
 	InsertChar(L'\n');
 	InsertSwatchColorChange(MainTextColor);
 	Write(str);
 }
 
-void LocalChatWriter::InsertChar(wchar_t ch) {
+void LocalChatWriter::InsertChar(wchar_t ch)
+{
 	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
@@ -316,12 +323,14 @@ void LocalChatWriter::InsertChar(wchar_t ch) {
 		hud->m_richText->vtable->InsertChar(hud->m_richText, ch);
 	}
 
-	if (ch != L'\n') {
+	if (ch != L'\n')
+	{
 		InsertDefaultFade();
 	}
 }
 
-void LocalChatWriter::InsertText(const char* str) {
+void LocalChatWriter::InsertText(const char* str)
+{
 	WCHAR messageUnicode[288];
 	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
 
@@ -336,8 +345,10 @@ void LocalChatWriter::InsertText(const char* str) {
 	InsertDefaultFade();
 }
 
-void LocalChatWriter::InsertText(const wchar_t* str) {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
+void LocalChatWriter::InsertText(const wchar_t* str)
+{
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
 
@@ -347,7 +358,8 @@ void LocalChatWriter::InsertText(const wchar_t* str) {
 	InsertDefaultFade();
 }
 
-void LocalChatWriter::InsertColorChange(vgui_Color color) {
+void LocalChatWriter::InsertColorChange(vgui_Color color)
+{
 	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
@@ -370,10 +382,11 @@ static vgui_Color GetHudSwatchColor(CHudChat* hud, LocalChatWriter::SwatchColor 
 	case LocalChatWriter::NetworkNameColor:
 		return hud->m_networkNameColor;
 	}
-	return vgui_Color{ 0, 0, 0, 0 };
+	return vgui_Color{0, 0, 0, 0};
 }
 
-void LocalChatWriter::InsertSwatchColorChange(SwatchColor swatchColor) {
+void LocalChatWriter::InsertSwatchColorChange(SwatchColor swatchColor)
+{
 	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
@@ -382,7 +395,8 @@ void LocalChatWriter::InsertSwatchColorChange(SwatchColor swatchColor) {
 	}
 }
 
-const char* LocalChatWriter::ApplyAnsiEscape(const char* escape) {
+const char* LocalChatWriter::ApplyAnsiEscape(const char* escape)
+{
 	AnsiEscapeParser decoder(this);
 	while (true)
 	{
@@ -415,21 +429,26 @@ const char* LocalChatWriter::ApplyAnsiEscape(const char* escape) {
 	}
 }
 
-void LocalChatWriter::InsertDefaultFade() {
+void LocalChatWriter::InsertDefaultFade()
+{
 	float fadeLength = 0.f;
 	float fadeSustain = 0.f;
-	if (gGameSettings->isChatEnabled) {
+	if (gGameSettings->isChatEnabled)
+	{
 		fadeLength = gChatFadeLength->value;
 		fadeSustain = gChatFadeSustain->value;
 	}
 
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next) {
-		if (hud->m_unknownContext != (int)m_context) continue;
+	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	{
+		if (hud->m_unknownContext != (int)m_context)
+			continue;
 		hud->m_richText->vtable->InsertFade(hud->m_richText, fadeSustain, fadeLength);
 	}
 }
 
-void InitialiseLocalChatWriter(HMODULE baseAddress) {
+void InitialiseLocalChatWriter(HMODULE baseAddress)
+{
 	gGameSettings = (CGameSettings*)((char*)baseAddress + 0x11BAA48);
 	gChatFadeLength = (CGameFloatVar*)((char*)baseAddress + 0x11BAB78);
 	gChatFadeSustain = (CGameFloatVar*)((char*)baseAddress + 0x11BAC08);

--- a/NorthstarDedicatedTest/localchatwriter.h
+++ b/NorthstarDedicatedTest/localchatwriter.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "pch.h"
+
+struct vgui_Color
+{
+	unsigned char r;
+	unsigned char g;
+	unsigned char b;
+	unsigned char a;
+};
+
+class LocalChatWriter {
+public:
+	enum Context {
+		NetworkContext = 0,
+		GameContext = 1
+	};
+	enum SwatchColor {
+		MainTextColor,
+		SameTeamNameColor,
+		EnemyTeamNameColor,
+		NetworkNameColor
+	};
+
+	explicit LocalChatWriter(Context context);
+
+	// Custom chat writing with ANSI escape codes
+	void Write(const char* str);
+	void WriteLine(const char* str);
+
+	// Low-level RichText access
+	void InsertChar(wchar_t ch);
+	void InsertText(const char* str);
+	void InsertText(const wchar_t* str);
+	void InsertColorChange(vgui_Color color);
+	void InsertSwatchColorChange(SwatchColor color);
+
+private:
+	Context m_context;
+
+	const char* ApplyAnsiEscape(const char* escape);
+	void InsertDefaultFade();
+};
+
+void InitialiseLocalChatWriter(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/localchatwriter.h
+++ b/NorthstarDedicatedTest/localchatwriter.h
@@ -9,13 +9,16 @@ struct vgui_Color
 	unsigned char a;
 };
 
-class LocalChatWriter {
-public:
-	enum Context {
+class LocalChatWriter
+{
+  public:
+	enum Context
+	{
 		NetworkContext = 0,
 		GameContext = 1
 	};
-	enum SwatchColor {
+	enum SwatchColor
+	{
 		MainTextColor,
 		SameTeamNameColor,
 		EnemyTeamNameColor,
@@ -35,7 +38,7 @@ public:
 	void InsertColorChange(vgui_Color color);
 	void InsertSwatchColorChange(SwatchColor color);
 
-private:
+  private:
 	Context m_context;
 
 	const char* ApplyAnsiEscape(const char* escape);

--- a/NorthstarDedicatedTest/localchatwriter.h
+++ b/NorthstarDedicatedTest/localchatwriter.h
@@ -45,4 +45,6 @@ class LocalChatWriter
 	void InsertDefaultFade();
 };
 
+bool IsFirstHud(void* hud);
+
 void InitialiseLocalChatWriter(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/miscserverscript.cpp
+++ b/NorthstarDedicatedTest/miscserverscript.cpp
@@ -4,6 +4,7 @@
 #include "masterserver.h"
 #include "serverauthentication.h"
 #include "gameutils.h"
+#include "serverchathooks.h"
 
 // annoying helper function because i can't figure out getting players or entities from sqvm rn
 // wish i didn't have to do it like this, but here we are
@@ -57,10 +58,84 @@ SQRESULT SQ_IsPlayerIndexLocalPlayer(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
+// void function NSChatSendFromPlayer( int playerIndex, string text, bool isteam )
+SQRESULT SQ_ChatSendFromPlayer(void* sqvm) {
+	int playerIndex = ServerSq_getinteger(sqvm, 1);
+	const char* text = ServerSq_getstring(sqvm, 2);
+	bool isteam = ServerSq_getbool(sqvm, 3);
+
+	ChatSendFromPlayer(playerIndex, text, isteam);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatWhisperFromPlayer( int fromPlayerIndex, int toPlayerIndex, string text )
+SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm) {
+	int fromPlayerIndex = ServerSq_getinteger(sqvm, 1);
+	int toPlayerIndex = ServerSq_getinteger(sqvm, 2);
+	const char* text = ServerSq_getstring(sqvm, 3);
+
+	ChatWhisperFromPlayer(fromPlayerIndex, toPlayerIndex, text);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatBroadcastText( string text )
+SQRESULT SQ_ChatBroadcastText(void* sqvm) {
+	const char* text = ServerSq_getstring(sqvm, 1);
+
+	ChatBroadcastText(text);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatBroadcastRainbowText( string text )
+SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm) {
+	const char* text = ServerSq_getstring(sqvm, 1);
+
+	unsigned char colors[18];
+	colors[0] = 0xFF; colors[1] = 0x7F; colors[2] = 0x7F;
+	colors[3] = 0xFF; colors[4] = 0xFF; colors[5] = 0x7F;
+	colors[6] = 0x7F; colors[7] = 0xFF; colors[8] = 0x7F;
+	colors[9] = 0x7F; colors[10] = 0xFF; colors[11] = 0xFF;
+	colors[12] = 0x7F; colors[13] = 0x7F; colors[14] = 0xFF;
+	colors[15] = 0xFF; colors[16] = 0x7F; colors[17] = 0xFF;
+
+	ChatRichText richText;
+	size_t textLen = strlen(text);
+	for (size_t charIndex = 0; charIndex < textLen; charIndex++) {
+		size_t colorIndex = charIndex % 6;
+		richText.InsertColor(colors[colorIndex * 3], colors[colorIndex * 3 + 1], colors[colorIndex * 3 + 2], 255);
+
+		char mini[2];
+		mini[0] = text[charIndex];
+		mini[1] = 0;
+		richText.InsertText(mini);
+	}
+	ChatBroadcastRichText(richText);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatWhisperText( int toPlayerIndex, string text )
+SQRESULT SQ_ChatWhisperText(void* sqvm) {
+	int toPlayerIndex = ServerSq_getinteger(sqvm, 1);
+	const char* text = ServerSq_getstring(sqvm, 2);
+
+	ChatWhisperText(toPlayerIndex, text);
+
+	return SQRESULT_NULL;
+}
+
 void InitialiseMiscServerScriptCommand(HMODULE baseAddress)
 {
 	g_ServerSquirrelManager->AddFuncRegistration(
 		"void", "NSEarlyWritePlayerIndexPersistenceForLeave", "int playerIndex", "", SQ_EarlyWritePlayerIndexPersistenceForLeave);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsWritingPlayerPersistence", "", "", SQ_IsWritingPlayerPersistence);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsPlayerIndexLocalPlayer", "int playerIndex", "", SQ_IsPlayerIndexLocalPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatSendFromPlayer", "int playerIndex, string text, bool isteam", "", SQ_ChatSendFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperFromPlayer", "int fromPlayerIndex, int toPlayerIndex, string text", "", SQ_ChatWhisperFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastText", "string text", "", SQ_ChatBroadcastText);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastRainbowText", "string text", "", SQ_ChatBroadcastRainbowText);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperText", "int toPlayerIndex, string text", "", SQ_ChatWhisperText);
 }

--- a/NorthstarDedicatedTest/miscserverscript.cpp
+++ b/NorthstarDedicatedTest/miscserverscript.cpp
@@ -4,7 +4,6 @@
 #include "masterserver.h"
 #include "serverauthentication.h"
 #include "gameutils.h"
-#include "serverchathooks.h"
 
 // annoying helper function because i can't figure out getting players or entities from sqvm rn
 // wish i didn't have to do it like this, but here we are
@@ -58,84 +57,10 @@ SQRESULT SQ_IsPlayerIndexLocalPlayer(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-// void function NSChatSendFromPlayer( int playerIndex, string text, bool isteam )
-SQRESULT SQ_ChatSendFromPlayer(void* sqvm) {
-	int playerIndex = ServerSq_getinteger(sqvm, 1);
-	const char* text = ServerSq_getstring(sqvm, 2);
-	bool isteam = ServerSq_getbool(sqvm, 3);
-
-	ChatSendFromPlayer(playerIndex, text, isteam);
-
-	return SQRESULT_NULL;
-}
-
-// void function NSChatWhisperFromPlayer( int fromPlayerIndex, int toPlayerIndex, string text )
-SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm) {
-	int fromPlayerIndex = ServerSq_getinteger(sqvm, 1);
-	int toPlayerIndex = ServerSq_getinteger(sqvm, 2);
-	const char* text = ServerSq_getstring(sqvm, 3);
-
-	ChatWhisperFromPlayer(fromPlayerIndex, toPlayerIndex, text);
-
-	return SQRESULT_NULL;
-}
-
-// void function NSChatBroadcastText( string text )
-SQRESULT SQ_ChatBroadcastText(void* sqvm) {
-	const char* text = ServerSq_getstring(sqvm, 1);
-
-	ChatBroadcastText(text);
-
-	return SQRESULT_NULL;
-}
-
-// void function NSChatBroadcastRainbowText( string text )
-SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm) {
-	const char* text = ServerSq_getstring(sqvm, 1);
-
-	unsigned char colors[18];
-	colors[0] = 0xFF; colors[1] = 0x7F; colors[2] = 0x7F;
-	colors[3] = 0xFF; colors[4] = 0xFF; colors[5] = 0x7F;
-	colors[6] = 0x7F; colors[7] = 0xFF; colors[8] = 0x7F;
-	colors[9] = 0x7F; colors[10] = 0xFF; colors[11] = 0xFF;
-	colors[12] = 0x7F; colors[13] = 0x7F; colors[14] = 0xFF;
-	colors[15] = 0xFF; colors[16] = 0x7F; colors[17] = 0xFF;
-
-	ChatRichText richText;
-	size_t textLen = strlen(text);
-	for (size_t charIndex = 0; charIndex < textLen; charIndex++) {
-		size_t colorIndex = charIndex % 6;
-		richText.InsertColor(colors[colorIndex * 3], colors[colorIndex * 3 + 1], colors[colorIndex * 3 + 2], 255);
-
-		char mini[2];
-		mini[0] = text[charIndex];
-		mini[1] = 0;
-		richText.InsertText(mini);
-	}
-	ChatBroadcastRichText(richText);
-
-	return SQRESULT_NULL;
-}
-
-// void function NSChatWhisperText( int toPlayerIndex, string text )
-SQRESULT SQ_ChatWhisperText(void* sqvm) {
-	int toPlayerIndex = ServerSq_getinteger(sqvm, 1);
-	const char* text = ServerSq_getstring(sqvm, 2);
-
-	ChatWhisperText(toPlayerIndex, text);
-
-	return SQRESULT_NULL;
-}
-
 void InitialiseMiscServerScriptCommand(HMODULE baseAddress)
 {
 	g_ServerSquirrelManager->AddFuncRegistration(
 		"void", "NSEarlyWritePlayerIndexPersistenceForLeave", "int playerIndex", "", SQ_EarlyWritePlayerIndexPersistenceForLeave);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsWritingPlayerPersistence", "", "", SQ_IsWritingPlayerPersistence);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsPlayerIndexLocalPlayer", "int playerIndex", "", SQ_IsPlayerIndexLocalPlayer);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatSendFromPlayer", "int playerIndex, string text, bool isteam", "", SQ_ChatSendFromPlayer);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperFromPlayer", "int fromPlayerIndex, int toPlayerIndex, string text", "", SQ_ChatWhisperFromPlayer);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastText", "string text", "", SQ_ChatBroadcastText);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastRainbowText", "string text", "", SQ_ChatBroadcastRainbowText);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperText", "int toPlayerIndex, string text", "", SQ_ChatWhisperText);
 }

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -262,7 +262,8 @@ void ServerAuthenticationManager::WritePersistentData(void* player)
 	}
 }
 
-bool ServerAuthenticationManager::CheckPlayerChatRatelimit(void* player) {
+bool ServerAuthenticationManager::CheckPlayerChatRatelimit(void* player)
+{
 	if (Plat_FloatTime() - m_additionalPlayerData[player].lastSayTextLimitStart >= 1.0)
 	{
 		m_additionalPlayerData[player].lastSayTextLimitStart = Plat_FloatTime();

--- a/NorthstarDedicatedTest/serverauthentication.h
+++ b/NorthstarDedicatedTest/serverauthentication.h
@@ -96,13 +96,13 @@ class ServerAuthenticationManager
 	bool AuthenticatePlayer(void* player, int64_t uid, char* authToken);
 	bool RemovePlayerAuthData(void* player);
 	void WritePersistentData(void* player);
+	bool CheckPlayerChatRatelimit(void* player);
 };
 
 typedef void (*CBaseClient__DisconnectType)(void* self, uint32_t unknownButAlways1, const char* reason, ...);
 extern CBaseClient__DisconnectType CBaseClient__Disconnect;
 
 void InitialiseServerAuthentication(HMODULE baseAddress);
-void InitialiseServerAuthenticationServerDLL(HMODULE baseAddress);
 
 extern ServerAuthenticationManager* g_ServerAuthenticationManager;
 extern ConVar* Cvar_ns_player_auth_port;

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -77,7 +77,7 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 	}
 
 	g_ServerSquirrelManager->setupfunc("CServerGameDLL_ProcessMessageStartThread");
-	g_ServerSquirrelManager->pusharg((int) senderPlayerId - 1);
+	g_ServerSquirrelManager->pusharg((int)senderPlayerId - 1);
 	g_ServerSquirrelManager->pusharg(text);
 	g_ServerSquirrelManager->pusharg(isTeam);
 	g_ServerSquirrelManager->call(3);

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -18,7 +18,7 @@ class CRecipientFilter
 CServerGameDLL* gServer;
 
 typedef void(__fastcall* CServerGameDLL__OnReceivedSayTextMessageType)(
-	CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId);
+	CServerGameDLL* self, unsigned int senderPlayerId, const char* text, int channelId);
 CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessage;
 CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessageHookBase;
 

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -120,6 +120,7 @@ CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int 
 
 void ChatSendMessage(unsigned int playerId, const char* text, bool isteam)
 {
+	isSkippingHook = true;
 	CServerGameDLL__OnReceivedSayTextMessage(
 		gServer,
 		// Ensure the first bit isn't set, since this indicates a custom message
@@ -218,7 +219,7 @@ void InitialiseServerChatHooks_Server(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x1595C0, &CServerGameDLL__OnReceivedSayTextMessageHook,
+		hook, CServerGameDLL__OnReceivedSayTextMessage, &CServerGameDLL__OnReceivedSayTextMessageHook,
 		reinterpret_cast<LPVOID*>(&CServerGameDLL__OnReceivedSayTextMessageHookBase));
 
 	// Chat intercept functions

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -1,0 +1,250 @@
+#include "pch.h"
+#include "serverchathooks.h"
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+class CServerGameDLL;
+class CBasePlayer;
+
+class CRecipientFilter {
+	char unknown[58];
+};
+
+CServerGameDLL* gServer;
+
+typedef void(__fastcall* CServerGameDLL__OnReceivedSayTextMessageType)(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId);
+CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessage;
+CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessageUnhooked;
+
+typedef CBasePlayer* (__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
+UTIL_PlayerByIndexType UTIL_PlayerByIndex;
+
+typedef void(__fastcall* CRecipientFilter__ConstructType)(CRecipientFilter* self);
+CRecipientFilter__ConstructType CRecipientFilter__Construct;
+
+typedef void(__fastcall* CRecipientFilter__DestructType)(CRecipientFilter* self);
+CRecipientFilter__DestructType CRecipientFilter__Destruct;
+
+typedef void(__fastcall* CRecipientFilter__AddAllPlayersType)(CRecipientFilter* self);
+CRecipientFilter__AddAllPlayersType CRecipientFilter__AddAllPlayers;
+
+typedef void(__fastcall* CRecipientFilter__AddRecipientType)(CRecipientFilter* self, const CBasePlayer* player);
+CRecipientFilter__AddRecipientType CRecipientFilter__AddRecipient;
+
+typedef void(__fastcall* CRecipientFilter__MakeReliableType)(CRecipientFilter* self);
+CRecipientFilter__MakeReliableType CRecipientFilter__MakeReliable;
+
+typedef void(__fastcall* UserMessageBeginType)(CRecipientFilter* filter, const char* messagename);
+UserMessageBeginType UserMessageBegin;
+
+typedef void(__fastcall* MessageEndType)();
+MessageEndType MessageEnd;
+
+typedef void(__fastcall* MessageWriteByteType)(int iValue);
+MessageWriteByteType MessageWriteByte;
+
+typedef void(__fastcall* MessageWriteStringType)(const char* sz);
+MessageWriteStringType MessageWriteString;
+
+typedef void(__fastcall* MessageWriteBoolType)(bool bValue);
+MessageWriteBoolType MessageWriteBool;
+
+bool gSkipSayTextHook = false;
+static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId) {
+	if (gSkipSayTextHook) {
+		gSkipSayTextHook = false;
+		CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
+		return;
+	}
+
+	// todo: impl other hook code here
+
+	CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
+}
+
+ChatRichText::ChatRichText() {
+	m_document.SetObject();
+	m_document.AddMember("t", rapidjson::Value(rapidjson::kArrayType), m_document.GetAllocator());
+}
+
+void ChatRichText::ToString(rapidjson::StringBuffer& buffer) const {
+	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+	m_document.Accept(writer);
+}
+
+void ChatRichText::InsertLocalized(const char* str) {
+	rapidjson::Value obj(rapidjson::kObjectType);
+	obj.AddMember("i", "l", m_document.GetAllocator());
+	obj.AddMember("s", std::string(str), m_document.GetAllocator());
+	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
+}
+
+void ChatRichText::InsertText(const char* str) {
+	rapidjson::Value obj(rapidjson::kObjectType);
+	obj.AddMember("i", "t", m_document.GetAllocator());
+	obj.AddMember("s", std::string(str), m_document.GetAllocator());
+	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
+}
+
+void ChatRichText::InsertColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha) {
+	unsigned int color = (red << 24) + (green << 16) + (blue << 8) + alpha;
+
+	rapidjson::Value obj(rapidjson::kObjectType);
+	obj.AddMember("i", "c", m_document.GetAllocator());
+	obj.AddMember("c", color, m_document.GetAllocator());
+	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
+}
+
+void ChatRichText::SetFadeSustainSecs(float fadeSustain) {
+	m_document["fs"] = fadeSustain;
+}
+
+void ChatRichText::SetFadeLengthSecs(float fadeLength) {
+	m_document["fl"] = fadeLength;
+}
+
+void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam) {
+	unsigned int playerIndex = playerId + 1;
+
+	gSkipSayTextHook = true;
+	CServerGameDLL__OnReceivedSayTextMessage(gServer, playerIndex, text, isteam ? 1 : 0);
+}
+
+void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text) {
+	unsigned int fromPlayerIndex = fromPlayerId + 1;
+	unsigned int toPlayerIndex = toPlayerId + 1;
+
+	CBasePlayer* toPlayer = UTIL_PlayerByIndex(toPlayerIndex);
+	if (toPlayer == NULL) {
+		return;
+	}
+
+	CRecipientFilter filter;
+	CRecipientFilter__Construct(&filter);
+	CRecipientFilter__AddRecipient(&filter, toPlayer);
+	CRecipientFilter__MakeReliable(&filter);
+
+	UserMessageBegin(&filter, "SayText");
+	MessageWriteByte(fromPlayerIndex);
+	MessageWriteString(text);
+	MessageWriteBool(false); // isteam=false
+	MessageWriteBool(false); // isdead=false
+	MessageEnd();
+
+	CRecipientFilter__Destruct(&filter);
+}
+
+void ChatBroadcastText(const char* text) {
+	ChatRichText rich;
+	rich.InsertColor(0xff, 0xff, 0xff, 0xff);
+	rich.InsertText(text);
+	ChatBroadcastRichText(rich);
+}
+
+void ChatWhisperText(unsigned int toPlayerId, const char* text) {
+	ChatRichText rich;
+	rich.InsertColor(0xff, 0xff, 0xff, 0xff);
+	rich.InsertText(text);
+	ChatWhisperRichText(toPlayerId, rich);
+}
+
+constexpr char CHAT_PACKET_CONTINUE = 1;
+constexpr char CHAT_PACKET_ANNOUNCE = 2;
+
+void ChatBroadcastRichText(const ChatRichText& text) {
+	rapidjson::StringBuffer buffer;
+
+	text.ToString(buffer);
+
+	size_t remainingLength = buffer.GetSize();
+	const char* textOffset = buffer.GetString();
+
+	CRecipientFilter filter;
+	CRecipientFilter__Construct(&filter);
+	CRecipientFilter__AddAllPlayers(&filter);
+	CRecipientFilter__MakeReliable(&filter);
+
+	// Custom messages are formatted as JSON, so they can be pretty long.
+	// SayText string payloads are limited to 255 characters long, so as a workaround
+	// we send multiple separate chunks and construct them into one string on the other
+	// side.
+	// The first char is the packet ID. As a byte:
+	//  1=not done
+	//  2=announce
+	while (true) {
+		bool isLast = remainingLength <= 254;
+
+		char sendText[256];
+		sendText[0] = isLast ? CHAT_PACKET_ANNOUNCE : CHAT_PACKET_CONTINUE;
+		strncpy(sendText + 1, textOffset, 254);
+		sendText[255] = 0;
+
+		UserMessageBegin(&filter, "SayText");
+		MessageWriteByte(0); // playerIndex=0 for rich text
+		MessageWriteString(sendText);
+		MessageWriteBool(false); // isteam=false
+		MessageWriteBool(false); // isdead=false
+		MessageEnd();
+
+		if (isLast) {
+			break;
+		}
+
+		remainingLength -= 254;
+		textOffset += 254;
+	}
+
+	CRecipientFilter__Destruct(&filter);
+}
+
+void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text) {
+	unsigned int toPlayerIndex = toPlayerId + 1;
+	rapidjson::StringBuffer buffer;
+
+	text.ToString(buffer);
+
+	CBasePlayer* toPlayer = UTIL_PlayerByIndex(toPlayerIndex);
+	if (toPlayer == NULL) {
+		return;
+	}
+
+	CRecipientFilter filter;
+	CRecipientFilter__Construct(&filter);
+	CRecipientFilter__AddRecipient(&filter, toPlayer);
+	CRecipientFilter__MakeReliable(&filter);
+
+	UserMessageBegin(&filter, "SayText");
+	MessageWriteByte(0); // playerIndex=0 for rich text
+	MessageWriteString(buffer.GetString());
+	MessageWriteBool(false); // isteam=false
+	MessageWriteBool(false); // isdead=false
+	MessageEnd();
+
+	CRecipientFilter__Destruct(&filter);
+}
+
+void InitialiseServerChatHooks_Engine(HMODULE baseAddress) {
+	gServer = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98);
+}
+
+void InitialiseServerChatHooks_Server(HMODULE baseAddress) {
+	CServerGameDLL__OnReceivedSayTextMessage = (CServerGameDLL__OnReceivedSayTextMessageType)((char*)baseAddress + 0x1595C0);
+	UTIL_PlayerByIndex = (UTIL_PlayerByIndexType)((char*)baseAddress + 0x26AA10);
+	CRecipientFilter__Construct = (CRecipientFilter__ConstructType)((char*)baseAddress + 0x1E9440);
+	CRecipientFilter__Destruct = (CRecipientFilter__DestructType)((char*)baseAddress + 0x1E9700);
+	CRecipientFilter__AddAllPlayers = (CRecipientFilter__AddAllPlayersType)((char*)baseAddress + 0x1E9940);
+	CRecipientFilter__AddRecipient = (CRecipientFilter__AddRecipientType)((char*)baseAddress + 0x1E9b30);
+	CRecipientFilter__MakeReliable = (CRecipientFilter__MakeReliableType)((char*)baseAddress + 0x1EA4E0);
+
+	UserMessageBegin = (UserMessageBeginType)((char*)baseAddress + 0x15C520);
+	MessageEnd = (MessageEndType)((char*)baseAddress + 0x158880);
+	MessageWriteByte = (MessageWriteByteType)((char*)baseAddress + 0x158A90);
+	MessageWriteString = (MessageWriteStringType)((char*)baseAddress + 0x158D00);
+	MessageWriteBool = (MessageWriteBoolType)((char*)baseAddress + 0x158A00);
+
+	HookEnabler hook;
+	ENABLER_CREATEHOOK(
+		hook, (char*)baseAddress + 0x1595C0, &CServerGameDLL__OnReceivedSayTextMessageHook,
+		reinterpret_cast<LPVOID*>(&CServerGameDLL__OnReceivedSayTextMessage));
+}

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -20,7 +20,6 @@ CServerGameDLL* gServer;
 typedef void(__fastcall* CServerGameDLL__OnReceivedSayTextMessageType)(
 	CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId);
 CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessage;
-CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessageUnhooked;
 
 typedef CBasePlayer*(__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
 UTIL_PlayerByIndexType UTIL_PlayerByIndex;
@@ -108,7 +107,7 @@ CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int 
 	if (g_SkipSayTextHook)
 	{
 		g_SkipSayTextHook = false;
-		CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
+		CServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerIndex, text, channelId);
 		return;
 	}
 

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -10,17 +10,19 @@
 class CServerGameDLL;
 class CBasePlayer;
 
-class CRecipientFilter {
+class CRecipientFilter
+{
 	char unknown[58];
 };
 
 CServerGameDLL* gServer;
 
-typedef void(__fastcall* CServerGameDLL__OnReceivedSayTextMessageType)(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId);
+typedef void(__fastcall* CServerGameDLL__OnReceivedSayTextMessageType)(
+	CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId);
 CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessage;
 CServerGameDLL__OnReceivedSayTextMessageType CServerGameDLL__OnReceivedSayTextMessageUnhooked;
 
-typedef CBasePlayer* (__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
+typedef CBasePlayer*(__fastcall* UTIL_PlayerByIndexType)(int playerIndex);
 UTIL_PlayerByIndexType UTIL_PlayerByIndex;
 
 typedef void(__fastcall* CRecipientFilter__ConstructType)(CRecipientFilter* self);
@@ -99,9 +101,12 @@ static SQRESULT pushMessage(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId) {
+static void
+CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId)
+{
 	// Set by ChatSendFromPlayer so it can bypass any checks
-	if (g_SkipSayTextHook) {
+	if (g_SkipSayTextHook)
+	{
 		g_SkipSayTextHook = false;
 		CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
 		return;
@@ -110,7 +115,8 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 	void* sender = GetPlayerByIndex(senderPlayerIndex - 1);
 
 	// check chat ratelimits
-	if (!g_ServerAuthenticationManager->CheckPlayerChatRatelimit(sender)) {
+	if (!g_ServerAuthenticationManager->CheckPlayerChatRatelimit(sender))
+	{
 		return;
 	}
 
@@ -136,31 +142,36 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 	}
 }
 
-ChatRichText::ChatRichText() {
+ChatRichText::ChatRichText()
+{
 	m_document.SetObject();
 	m_document.AddMember("t", rapidjson::Value(rapidjson::kArrayType), m_document.GetAllocator());
 }
 
-void ChatRichText::ToString(rapidjson::StringBuffer& buffer) const {
+void ChatRichText::ToString(rapidjson::StringBuffer& buffer) const
+{
 	rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 	m_document.Accept(writer);
 }
 
-void ChatRichText::InsertLocalized(const char* str) {
+void ChatRichText::InsertLocalized(const char* str)
+{
 	rapidjson::Value obj(rapidjson::kObjectType);
 	obj.AddMember("i", "l", m_document.GetAllocator());
 	obj.AddMember("s", std::string(str), m_document.GetAllocator());
 	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
 }
 
-void ChatRichText::InsertText(const char* str) {
+void ChatRichText::InsertText(const char* str)
+{
 	rapidjson::Value obj(rapidjson::kObjectType);
 	obj.AddMember("i", "t", m_document.GetAllocator());
 	obj.AddMember("s", std::string(str), m_document.GetAllocator());
 	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
 }
 
-void ChatRichText::InsertColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha) {
+void ChatRichText::InsertColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha)
+{
 	unsigned int color = (red << 24) + (green << 16) + (blue << 8) + alpha;
 
 	rapidjson::Value obj(rapidjson::kObjectType);
@@ -169,27 +180,26 @@ void ChatRichText::InsertColor(unsigned char red, unsigned char green, unsigned 
 	m_document["t"].PushBack(std::move(obj), m_document.GetAllocator());
 }
 
-void ChatRichText::SetFadeSustainSecs(float fadeSustain) {
-	m_document["fs"] = fadeSustain;
-}
+void ChatRichText::SetFadeSustainSecs(float fadeSustain) { m_document["fs"] = fadeSustain; }
 
-void ChatRichText::SetFadeLengthSecs(float fadeLength) {
-	m_document["fl"] = fadeLength;
-}
+void ChatRichText::SetFadeLengthSecs(float fadeLength) { m_document["fl"] = fadeLength; }
 
-void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam) {
+void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam)
+{
 	unsigned int playerIndex = playerId + 1;
 
 	g_SkipSayTextHook = true;
 	CServerGameDLL__OnReceivedSayTextMessage(gServer, playerIndex, text, isteam ? 1 : 0);
 }
 
-void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text) {
+void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text)
+{
 	unsigned int fromPlayerIndex = fromPlayerId + 1;
 	unsigned int toPlayerIndex = toPlayerId + 1;
 
 	CBasePlayer* toPlayer = UTIL_PlayerByIndex(toPlayerIndex);
-	if (toPlayer == NULL) {
+	if (toPlayer == NULL)
+	{
 		return;
 	}
 
@@ -208,14 +218,16 @@ void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, c
 	CRecipientFilter__Destruct(&filter);
 }
 
-void ChatBroadcastText(const char* text) {
+void ChatBroadcastText(const char* text)
+{
 	ChatRichText rich;
 	rich.InsertColor(0xff, 0xff, 0xff, 0xff);
 	rich.InsertText(text);
 	ChatBroadcastRichText(rich);
 }
 
-void ChatWhisperText(unsigned int toPlayerId, const char* text) {
+void ChatWhisperText(unsigned int toPlayerId, const char* text)
+{
 	ChatRichText rich;
 	rich.InsertColor(0xff, 0xff, 0xff, 0xff);
 	rich.InsertText(text);
@@ -225,7 +237,8 @@ void ChatWhisperText(unsigned int toPlayerId, const char* text) {
 constexpr char CHAT_PACKET_CONTINUE = 1;
 constexpr char CHAT_PACKET_ANNOUNCE = 2;
 
-void ChatBroadcastRichText(const ChatRichText& text) {
+void ChatBroadcastRichText(const ChatRichText& text)
+{
 	rapidjson::StringBuffer buffer;
 
 	text.ToString(buffer);
@@ -245,7 +258,8 @@ void ChatBroadcastRichText(const ChatRichText& text) {
 	// The first char is the packet ID. As a byte:
 	//  1=not done
 	//  2=announce
-	while (true) {
+	while (true)
+	{
 		bool isLast = remainingLength <= 254;
 
 		char sendText[256];
@@ -260,7 +274,8 @@ void ChatBroadcastRichText(const ChatRichText& text) {
 		MessageWriteBool(false); // isdead=false
 		MessageEnd();
 
-		if (isLast) {
+		if (isLast)
+		{
 			break;
 		}
 
@@ -271,14 +286,16 @@ void ChatBroadcastRichText(const ChatRichText& text) {
 	CRecipientFilter__Destruct(&filter);
 }
 
-void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text) {
+void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text)
+{
 	unsigned int toPlayerIndex = toPlayerId + 1;
 	rapidjson::StringBuffer buffer;
 
 	text.ToString(buffer);
 
 	CBasePlayer* toPlayer = UTIL_PlayerByIndex(toPlayerIndex);
-	if (toPlayer == NULL) {
+	if (toPlayer == NULL)
+	{
 		return;
 	}
 
@@ -298,7 +315,8 @@ void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text) {
 }
 
 // void function NSChatSendFromPlayer( int playerIndex, string text, bool isteam )
-SQRESULT SQ_ChatSendFromPlayer(void* sqvm) {
+SQRESULT SQ_ChatSendFromPlayer(void* sqvm)
+{
 	int playerIndex = ServerSq_getinteger(sqvm, 1);
 	const char* text = ServerSq_getstring(sqvm, 2);
 	bool isteam = ServerSq_getbool(sqvm, 3);
@@ -309,7 +327,8 @@ SQRESULT SQ_ChatSendFromPlayer(void* sqvm) {
 }
 
 // void function NSChatWhisperFromPlayer( int fromPlayerIndex, int toPlayerIndex, string text )
-SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm) {
+SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm)
+{
 	int fromPlayerIndex = ServerSq_getinteger(sqvm, 1);
 	int toPlayerIndex = ServerSq_getinteger(sqvm, 2);
 	const char* text = ServerSq_getstring(sqvm, 3);
@@ -320,7 +339,8 @@ SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm) {
 }
 
 // void function NSChatBroadcastText( string text )
-SQRESULT SQ_ChatBroadcastText(void* sqvm) {
+SQRESULT SQ_ChatBroadcastText(void* sqvm)
+{
 	const char* text = ServerSq_getstring(sqvm, 1);
 
 	ChatBroadcastText(text);
@@ -329,20 +349,34 @@ SQRESULT SQ_ChatBroadcastText(void* sqvm) {
 }
 
 // void function NSChatBroadcastRainbowText( string text )
-SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm) {
+SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm)
+{
 	const char* text = ServerSq_getstring(sqvm, 1);
 
 	unsigned char colors[18];
-	colors[0] = 0xFF; colors[1] = 0x7F; colors[2] = 0x7F;
-	colors[3] = 0xFF; colors[4] = 0xFF; colors[5] = 0x7F;
-	colors[6] = 0x7F; colors[7] = 0xFF; colors[8] = 0x7F;
-	colors[9] = 0x7F; colors[10] = 0xFF; colors[11] = 0xFF;
-	colors[12] = 0x7F; colors[13] = 0x7F; colors[14] = 0xFF;
-	colors[15] = 0xFF; colors[16] = 0x7F; colors[17] = 0xFF;
+	colors[0] = 0xFF;
+	colors[1] = 0x7F;
+	colors[2] = 0x7F;
+	colors[3] = 0xFF;
+	colors[4] = 0xFF;
+	colors[5] = 0x7F;
+	colors[6] = 0x7F;
+	colors[7] = 0xFF;
+	colors[8] = 0x7F;
+	colors[9] = 0x7F;
+	colors[10] = 0xFF;
+	colors[11] = 0xFF;
+	colors[12] = 0x7F;
+	colors[13] = 0x7F;
+	colors[14] = 0xFF;
+	colors[15] = 0xFF;
+	colors[16] = 0x7F;
+	colors[17] = 0xFF;
 
 	ChatRichText richText;
 	size_t textLen = strlen(text);
-	for (size_t charIndex = 0; charIndex < textLen; charIndex++) {
+	for (size_t charIndex = 0; charIndex < textLen; charIndex++)
+	{
 		size_t colorIndex = charIndex % 6;
 		richText.InsertColor(colors[colorIndex * 3], colors[colorIndex * 3 + 1], colors[colorIndex * 3 + 2], 255);
 
@@ -357,7 +391,8 @@ SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm) {
 }
 
 // void function NSChatWhisperText( int toPlayerIndex, string text )
-SQRESULT SQ_ChatWhisperText(void* sqvm) {
+SQRESULT SQ_ChatWhisperText(void* sqvm)
+{
 	int toPlayerIndex = ServerSq_getinteger(sqvm, 1);
 	const char* text = ServerSq_getstring(sqvm, 2);
 
@@ -366,11 +401,10 @@ SQRESULT SQ_ChatWhisperText(void* sqvm) {
 	return SQRESULT_NULL;
 }
 
-void InitialiseServerChatHooks_Engine(HMODULE baseAddress) {
-	gServer = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98);
-}
+void InitialiseServerChatHooks_Engine(HMODULE baseAddress) { gServer = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98); }
 
-void InitialiseServerChatHooks_Server(HMODULE baseAddress) {
+void InitialiseServerChatHooks_Server(HMODULE baseAddress)
+{
 	CServerGameDLL__OnReceivedSayTextMessage = (CServerGameDLL__OnReceivedSayTextMessageType)((char*)baseAddress + 0x1595C0);
 	UTIL_PlayerByIndex = (UTIL_PlayerByIndexType)((char*)baseAddress + 0x26AA10);
 	CRecipientFilter__Construct = (CRecipientFilter__ConstructType)((char*)baseAddress + 0x1E9440);
@@ -391,16 +425,20 @@ void InitialiseServerChatHooks_Server(HMODULE baseAddress) {
 		reinterpret_cast<LPVOID*>(&CServerGameDLL__OnReceivedSayTextMessage));
 
 	// Chat intercept functions
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSSetMessage", "string message, int playerId, int channelId, bool shouldBlock", "", setMessage);
+	g_ServerSquirrelManager->AddFuncRegistration(
+		"void", "NSSetMessage", "string message, int playerId, int channelId, bool shouldBlock", "", setMessage);
 	g_ServerSquirrelManager->AddFuncRegistration("string", "NSChatGetCurrentMessage", "", "", getMessageServer);
 	g_ServerSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentPlayer", "", "", getPlayerServer);
 	g_ServerSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentChannel", "", "", getChannelServer);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSShouldProcessMessage", "", "", getShouldProcessMessage);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSPushMessage", "string message, int playerId, int channelId, bool shouldBlock", "", pushMessage);
+	g_ServerSquirrelManager->AddFuncRegistration(
+		"void", "NSPushMessage", "string message, int playerId, int channelId, bool shouldBlock", "", pushMessage);
 
 	// Chat sending functions
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatSendFromPlayer", "int playerIndex, string text, bool isteam", "", SQ_ChatSendFromPlayer);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperFromPlayer", "int fromPlayerIndex, int toPlayerIndex, string text", "", SQ_ChatWhisperFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration(
+		"void", "NSChatSendFromPlayer", "int playerIndex, string text, bool isteam", "", SQ_ChatSendFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration(
+		"void", "NSChatWhisperFromPlayer", "int fromPlayerIndex, int toPlayerIndex, string text", "", SQ_ChatWhisperFromPlayer);
 	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastText", "string text", "", SQ_ChatBroadcastText);
 	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastRainbowText", "string text", "", SQ_ChatBroadcastRainbowText);
 	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperText", "int toPlayerIndex, string text", "", SQ_ChatWhisperText);

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -3,6 +3,9 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include "serverauthentication.h"
+#include "squirrel.h"
+#include "miscserverscript.h"
 
 class CServerGameDLL;
 class CBasePlayer;
@@ -50,17 +53,87 @@ MessageWriteStringType MessageWriteString;
 typedef void(__fastcall* MessageWriteBoolType)(bool bValue);
 MessageWriteBoolType MessageWriteBool;
 
-bool gSkipSayTextHook = false;
+static bool g_SkipSayTextHook = false;
+
+static std::string currentMessage;
+static int currentPlayerId;
+static int currentChannelId;
+static bool shouldBlock;
+static bool isProcessed = true;
+
+static SQRESULT setMessage(void* sqvm)
+{
+	currentMessage = ServerSq_getstring(sqvm, 1);
+	currentPlayerId = ServerSq_getinteger(sqvm, 2);
+	currentChannelId = ServerSq_getinteger(sqvm, 3);
+	shouldBlock = ServerSq_getbool(sqvm, 4);
+	return SQRESULT_NOTNULL;
+}
+static SQRESULT getMessageServer(void* sqvm)
+{
+	ServerSq_pushstring(sqvm, currentMessage.c_str(), -1);
+	return SQRESULT_NOTNULL;
+}
+static SQRESULT getPlayerServer(void* sqvm)
+{
+	ServerSq_pushinteger(sqvm, currentPlayerId);
+	return SQRESULT_NOTNULL;
+}
+static SQRESULT getChannelServer(void* sqvm)
+{
+	ServerSq_pushinteger(sqvm, currentChannelId);
+	return SQRESULT_NOTNULL;
+}
+static SQRESULT getShouldProcessMessage(void* sqvm)
+{
+	ServerSq_pushbool(sqvm, !isProcessed);
+	return SQRESULT_NOTNULL;
+}
+static SQRESULT pushMessage(void* sqvm)
+{
+	currentMessage = ServerSq_getstring(sqvm, 1);
+	currentPlayerId = ServerSq_getinteger(sqvm, 2);
+	currentChannelId = ServerSq_getinteger(sqvm, 3);
+	shouldBlock = ServerSq_getbool(sqvm, 4);
+	isProcessed = true;
+	return SQRESULT_NOTNULL;
+}
+
 static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, unsigned int senderPlayerIndex, const char* text, int channelId) {
-	if (gSkipSayTextHook) {
-		gSkipSayTextHook = false;
+	// Set by ChatSendFromPlayer so it can bypass any checks
+	if (g_SkipSayTextHook) {
+		g_SkipSayTextHook = false;
 		CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
 		return;
 	}
 
-	// todo: impl other hook code here
+	void* sender = GetPlayerByIndex(senderPlayerIndex - 1);
 
-	CServerGameDLL__OnReceivedSayTextMessageUnhooked(self, senderPlayerIndex, text, channelId);
+	// check chat ratelimits
+	if (!g_ServerAuthenticationManager->CheckPlayerChatRatelimit(sender)) {
+		return;
+	}
+
+	bool shouldDoChathooks = strstr(GetCommandLineA(), "-enablechathooks");
+	if (shouldDoChathooks)
+	{
+
+		currentMessage = text;
+		currentPlayerId = senderPlayerIndex - 1; // Stupid fix cause of index offsets
+		currentChannelId = channelId;
+		shouldBlock = false;
+		isProcessed = false;
+
+		g_ServerSquirrelManager->ExecuteCode("CServerGameDLL_ProcessMessageStartThread()");
+		if (!shouldBlock && currentPlayerId + 1 == senderPlayerIndex) // stop player id spoofing from server
+		{
+			CServerGameDLL__OnReceivedSayTextMessage(self, currentPlayerId + 1, currentMessage.c_str(), currentChannelId);
+		}
+	}
+	else
+	{
+		CServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerIndex, text, channelId);
+	}
 }
 
 ChatRichText::ChatRichText() {
@@ -107,7 +180,7 @@ void ChatRichText::SetFadeLengthSecs(float fadeLength) {
 void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam) {
 	unsigned int playerIndex = playerId + 1;
 
-	gSkipSayTextHook = true;
+	g_SkipSayTextHook = true;
 	CServerGameDLL__OnReceivedSayTextMessage(gServer, playerIndex, text, isteam ? 1 : 0);
 }
 
@@ -224,6 +297,75 @@ void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text) {
 	CRecipientFilter__Destruct(&filter);
 }
 
+// void function NSChatSendFromPlayer( int playerIndex, string text, bool isteam )
+SQRESULT SQ_ChatSendFromPlayer(void* sqvm) {
+	int playerIndex = ServerSq_getinteger(sqvm, 1);
+	const char* text = ServerSq_getstring(sqvm, 2);
+	bool isteam = ServerSq_getbool(sqvm, 3);
+
+	ChatSendFromPlayer(playerIndex, text, isteam);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatWhisperFromPlayer( int fromPlayerIndex, int toPlayerIndex, string text )
+SQRESULT SQ_ChatWhisperFromPlayer(void* sqvm) {
+	int fromPlayerIndex = ServerSq_getinteger(sqvm, 1);
+	int toPlayerIndex = ServerSq_getinteger(sqvm, 2);
+	const char* text = ServerSq_getstring(sqvm, 3);
+
+	ChatWhisperFromPlayer(fromPlayerIndex, toPlayerIndex, text);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatBroadcastText( string text )
+SQRESULT SQ_ChatBroadcastText(void* sqvm) {
+	const char* text = ServerSq_getstring(sqvm, 1);
+
+	ChatBroadcastText(text);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatBroadcastRainbowText( string text )
+SQRESULT SQ_ChatBroadcastRainbowText(void* sqvm) {
+	const char* text = ServerSq_getstring(sqvm, 1);
+
+	unsigned char colors[18];
+	colors[0] = 0xFF; colors[1] = 0x7F; colors[2] = 0x7F;
+	colors[3] = 0xFF; colors[4] = 0xFF; colors[5] = 0x7F;
+	colors[6] = 0x7F; colors[7] = 0xFF; colors[8] = 0x7F;
+	colors[9] = 0x7F; colors[10] = 0xFF; colors[11] = 0xFF;
+	colors[12] = 0x7F; colors[13] = 0x7F; colors[14] = 0xFF;
+	colors[15] = 0xFF; colors[16] = 0x7F; colors[17] = 0xFF;
+
+	ChatRichText richText;
+	size_t textLen = strlen(text);
+	for (size_t charIndex = 0; charIndex < textLen; charIndex++) {
+		size_t colorIndex = charIndex % 6;
+		richText.InsertColor(colors[colorIndex * 3], colors[colorIndex * 3 + 1], colors[colorIndex * 3 + 2], 255);
+
+		char mini[2];
+		mini[0] = text[charIndex];
+		mini[1] = 0;
+		richText.InsertText(mini);
+	}
+	ChatBroadcastRichText(richText);
+
+	return SQRESULT_NULL;
+}
+
+// void function NSChatWhisperText( int toPlayerIndex, string text )
+SQRESULT SQ_ChatWhisperText(void* sqvm) {
+	int toPlayerIndex = ServerSq_getinteger(sqvm, 1);
+	const char* text = ServerSq_getstring(sqvm, 2);
+
+	ChatWhisperText(toPlayerIndex, text);
+
+	return SQRESULT_NULL;
+}
+
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress) {
 	gServer = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98);
 }
@@ -247,4 +389,19 @@ void InitialiseServerChatHooks_Server(HMODULE baseAddress) {
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x1595C0, &CServerGameDLL__OnReceivedSayTextMessageHook,
 		reinterpret_cast<LPVOID*>(&CServerGameDLL__OnReceivedSayTextMessage));
+
+	// Chat intercept functions
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSSetMessage", "string message, int playerId, int channelId, bool shouldBlock", "", setMessage);
+	g_ServerSquirrelManager->AddFuncRegistration("string", "NSChatGetCurrentMessage", "", "", getMessageServer);
+	g_ServerSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentPlayer", "", "", getPlayerServer);
+	g_ServerSquirrelManager->AddFuncRegistration("int", "NSChatGetCurrentChannel", "", "", getChannelServer);
+	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSShouldProcessMessage", "", "", getShouldProcessMessage);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSPushMessage", "string message, int playerId, int channelId, bool shouldBlock", "", pushMessage);
+
+	// Chat sending functions
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatSendFromPlayer", "int playerIndex, string text, bool isteam", "", SQ_ChatSendFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperFromPlayer", "int fromPlayerIndex, int toPlayerIndex, string text", "", SQ_ChatWhisperFromPlayer);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastText", "string text", "", SQ_ChatBroadcastText);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatBroadcastRainbowText", "string text", "", SQ_ChatBroadcastRainbowText);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSChatWhisperText", "int toPlayerIndex, string text", "", SQ_ChatWhisperText);
 }

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -6,13 +6,11 @@
 enum class CustomMessageType : char
 {
 	Chat = 1,
-	Whisper = 2,
-
-	ENUM_MAX,
+	Whisper = 2
 };
 
-constexpr unsigned int CUSTOM_MESSAGE_INDEX_BIT = 0b10000000;
-constexpr unsigned int CUSTOM_MESSAGE_INDEX_MASK = ~CUSTOM_MESSAGE_INDEX_BIT;
+constexpr unsigned char CUSTOM_MESSAGE_INDEX_BIT = 0b10000000;
+constexpr unsigned char CUSTOM_MESSAGE_INDEX_MASK = ~CUSTOM_MESSAGE_INDEX_BIT;
 
 // Send a vanilla chat message as if it was from the player.
 void ChatSendMessage(unsigned int playerId, const char* text, bool isteam);

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -5,12 +5,17 @@
 
 void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam);
 
-void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text);
-
-void ChatBroadcastText(const char* text);
-
-void ChatWhisperText(unsigned int toPlayerId, const char* text);
+void ChatBroadcastText(int playerIndex, const char* text, bool isTeam);
 
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
 
 void InitialiseServerChatHooks_Server(HMODULE baseAddress);
+
+#ifndef MESSAGETYPE
+#define MESSAGETYPE
+enum class AnonymousMessageType : char
+{
+	Announce = 1,
+	Whisper = 2,
+};
+#endif

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -3,24 +3,6 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 
-class ChatRichText
-{
-  public:
-	ChatRichText();
-
-	void ToString(rapidjson::StringBuffer& buffer) const;
-
-	void InsertLocalized(const char* str);
-	void InsertText(const char* str);
-	void InsertColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha);
-
-	void SetFadeSustainSecs(float fadeSustain);
-	void SetFadeLengthSecs(float fadeLength);
-
-  private:
-	rapidjson::Document m_document;
-};
-
 void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam);
 
 void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text);
@@ -28,10 +10,6 @@ void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, c
 void ChatBroadcastText(const char* text);
 
 void ChatWhisperText(unsigned int toPlayerId, const char* text);
-
-void ChatBroadcastRichText(const ChatRichText& text);
-
-void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text);
 
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
 

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "pch.h"
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+
+class ChatRichText {
+public:
+	ChatRichText();
+
+	void ToString(rapidjson::StringBuffer& buffer) const;
+
+	void InsertLocalized(const char* str);
+	void InsertText(const char* str);
+	void InsertColor(unsigned char red, unsigned char green, unsigned char blue, unsigned char alpha);
+
+	void SetFadeSustainSecs(float fadeSustain);
+	void SetFadeLengthSecs(float fadeLength);
+
+private:
+	rapidjson::Document m_document;
+};
+
+void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam);
+
+void ChatWhisperFromPlayer(unsigned int fromPlayerId, unsigned int toPlayerId, const char* text);
+
+void ChatBroadcastText(const char* text);
+
+void ChatWhisperText(unsigned int toPlayerId, const char* text);
+
+void ChatBroadcastRichText(const ChatRichText& text);
+
+void ChatWhisperRichText(unsigned int toPlayerId, const ChatRichText& text);
+
+void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
+
+void InitialiseServerChatHooks_Server(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -13,15 +13,16 @@ constexpr unsigned char CUSTOM_MESSAGE_INDEX_BIT = 0b10000000;
 constexpr unsigned char CUSTOM_MESSAGE_INDEX_MASK = ~CUSTOM_MESSAGE_INDEX_BIT;
 
 // Send a vanilla chat message as if it was from the player.
-void ChatSendMessage(unsigned int playerId, const char* text, bool isteam);
+void ChatSendMessage(unsigned int playerIndex, const char* text, bool isteam);
 
 // Send a custom message.
-//   fromPlayerId: set to -1 for a [SERVER] message, or another value to send from a specific player
-//   toPlayerId: set to -1 to send to all players, or another value to send to a single player
+//   fromPlayerIndex: set to -1 for a [SERVER] message, or another value to send from a specific player
+//   toPlayerIndex: set to -1 to send to all players, or another value to send to a single player
 //   isTeam: display a [TEAM] badge
 //   isDead: display a [DEAD] badge
 //   messageType: send a specific message type
-void ChatBroadcastMessage(int fromPlayerId, int toPlayerId, const char* text, bool isTeam, bool isDead, CustomMessageType messageType);
+void ChatBroadcastMessage(
+	int fromPlayerIndex, int toPlayerIndex, const char* text, bool isTeam, bool isDead, CustomMessageType messageType);
 
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
 

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -3,19 +3,28 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 
-void ChatSendFromPlayer(unsigned int playerId, const char* text, bool isteam);
+enum class CustomMessageType : char
+{
+	Chat = 1,
+	Whisper = 2,
 
-void ChatBroadcastText(int playerIndex, const char* text, bool isTeam);
+	ENUM_MAX,
+};
+
+constexpr unsigned int CUSTOM_MESSAGE_INDEX_BIT = 0b10000000;
+constexpr unsigned int CUSTOM_MESSAGE_INDEX_MASK = ~CUSTOM_MESSAGE_INDEX_BIT;
+
+// Send a vanilla chat message as if it was from the player.
+void ChatSendMessage(unsigned int playerId, const char* text, bool isteam);
+
+// Send a custom message.
+//   fromPlayerId: set to -1 for a [SERVER] message, or another value to send from a specific player
+//   toPlayerId: set to -1 to send to all players, or another value to send to a single player
+//   isTeam: display a [TEAM] badge
+//   isDead: display a [DEAD] badge
+//   messageType: send a specific message type
+void ChatBroadcastMessage(int fromPlayerId, int toPlayerId, const char* text, bool isTeam, bool isDead, CustomMessageType messageType);
 
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
 
 void InitialiseServerChatHooks_Server(HMODULE baseAddress);
-
-#ifndef MESSAGETYPE
-#define MESSAGETYPE
-enum class AnonymousMessageType : char
-{
-	Announce = 1,
-	Whisper = 2,
-};
-#endif

--- a/NorthstarDedicatedTest/serverchathooks.h
+++ b/NorthstarDedicatedTest/serverchathooks.h
@@ -3,8 +3,9 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 
-class ChatRichText {
-public:
+class ChatRichText
+{
+  public:
 	ChatRichText();
 
 	void ToString(rapidjson::StringBuffer& buffer) const;
@@ -16,7 +17,7 @@ public:
 	void SetFadeSustainSecs(float fadeSustain);
 	void SetFadeLengthSecs(float fadeLength);
 
-private:
+  private:
 	rapidjson::Document m_document;
 };
 

--- a/NorthstarDedicatedTest/squirrel.cpp
+++ b/NorthstarDedicatedTest/squirrel.cpp
@@ -84,6 +84,9 @@ sq_getfloatType ServerSq_getfloat;
 sq_getboolType ClientSq_getbool;
 sq_getboolType ServerSq_getbool;
 
+sq_getType ClientSq_sq_get;
+sq_getType ServerSq_sq_get;
+
 template <ScriptContext context> void ExecuteCodeCommand(const CCommand& args);
 
 // inits
@@ -136,6 +139,8 @@ void InitialiseClientSquirrel(HMODULE baseAddress)
 	ClientSq_getfloat = (sq_getfloatType)((char*)baseAddress + 0x6100);
 	ClientSq_getbool = (sq_getboolType)((char*)baseAddress + 0x6130);
 
+	ClientSq_sq_get = (sq_getType)((char*)baseAddress + 0x7C30);
+
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x26130, &CreateNewVMHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientCreateNewVM)); // client createnewvm function
@@ -174,6 +179,8 @@ void InitialiseServerSquirrel(HMODULE baseAddress)
 	ServerSq_getinteger = (sq_getintegerType)((char*)baseAddress + 0x60C0);
 	ServerSq_getfloat = (sq_getfloatType)((char*)baseAddress + 0x60E0);
 	ServerSq_getbool = (sq_getboolType)((char*)baseAddress + 0x6110);
+
+	ServerSq_sq_get = (sq_getType)((char*)baseAddress + 0x7C00);
 
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x1FE90, &SQPrintHook<ScriptContext::SERVER>,

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -200,13 +200,11 @@ template <ScriptContext context> class SquirrelManager
 	int setupfunc(const char* funcname)
 	{
 		int result = -2;
-		spdlog::info("Context: {}", context);
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)
 		{
 			ClientSq_pushroottable(sqvm2);
 			ClientSq_pushstring(sqvm2, funcname, -1);
 			result = ClientSq_sq_get(sqvm2, -2);
-			spdlog::info("sq_get returned {}", result);
 			ClientSq_pushroottable(sqvm2);
 		}
 		else if (context == ScriptContext::SERVER)
@@ -214,7 +212,6 @@ template <ScriptContext context> class SquirrelManager
 			ServerSq_pushroottable(sqvm2);
 			ServerSq_pushstring(sqvm2, funcname, -1);
 			result = ServerSq_sq_get(sqvm2, -2);
-			spdlog::info("sq_get returned {}", result);
 			ServerSq_pushroottable(sqvm2);
 		}
 		return result;
@@ -257,7 +254,6 @@ template <ScriptContext context> class SquirrelManager
 		else if (context == ScriptContext::SERVER)
 			result = ServerSq_call(sqvm2, args + 1, false, false);
 
-		spdlog::info("sq_call returned {}", result);
 		return result;
 	}
 

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -154,7 +154,6 @@ template <ScriptContext context> class SquirrelManager
 			else
 				ServerRegisterSquirrelFunc(sqvm, funcReg, 1);
 		}
-		
 	}
 
 	void VMDestroyed() { sqvm = nullptr; }
@@ -193,7 +192,7 @@ template <ScriptContext context> class SquirrelManager
 			{
 				ServerSq_pushroottable(sqvm2);
 				SQRESULT callResult = ServerSq_call(sqvm2, 1, false, false);
-				spdlog::info("sq_call returned {}", callResult);	
+				spdlog::info("sq_call returned {}", callResult);
 			}
 		}
 	}


### PR DESCRIPTION
Mod changes: https://github.com/R2Northstar/NorthstarMods/pull/217

Features:

 - Server mods can now send chat messages outside of just intercepting incoming ones: this includes impersonating players, sender-less "announcement"/anonymous style messages, and whisper versions of both.
 - The client can intercept incoming chat messages. Client-side chat formatting has been completely replaced by script to open up customisation options.
 - Client mods can display custom announcement messages in the local player's chat.
 - Anonymous messages all support ANSI escape codes for colours, so servers and mods can do fun things like this:
   !["Welcome to Northstars of the Crane" shown in rainbow text in the Titanfall 2 lobby chat window](https://user-images.githubusercontent.com/16081865/153715770-20d7d97a-39a6-486f-9760-1287b760f4b7.png)
