### PR TITLE
Log rotation

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -524,6 +524,7 @@
     <ClInclude Include="languagehooks.h" />
     <ClInclude Include="latencyflex.h" />
     <ClInclude Include="logging.h" />
+    <ClInclude Include="logrotation.h" />
     <ClInclude Include="main.h" />
     <ClInclude Include="masterserver.h" />
     <ClInclude Include="maxplayers.h" />
@@ -569,6 +570,7 @@
     <ClCompile Include="hookutils.cpp" />
     <ClCompile Include="keyvalues.cpp" />
     <ClCompile Include="latencyflex.cpp" />
+    <ClCompile Include="logrotation.cpp" />
     <ClCompile Include="maxplayers.cpp" />
     <ClCompile Include="languagehooks.cpp" />
     <ClCompile Include="memalloc.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1449,6 +1449,9 @@
     <ClInclude Include="configurables.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
+    <ClInclude Include="logrotation.h">
+      <Filter>Source Files\Shared</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1582,6 +1585,9 @@
     </ClCompile>
     <ClCompile Include="configurables.cpp">
       <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="logrotation.cpp">
+      <Filter>Source Files\Shared</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -10,10 +10,12 @@
 #include <Psapi.h>
 #include <minidumpapiset.h>
 #include "configurables.h"
+#include "logrotation.h"
 
 // This needs to be called after hooks are loaded so we can access the command line args
 void CreateLogFiles()
 {
+	logRotation(7);
 	if (strstr(GetCommandLineA(), "-disablelogs"))
 	{
 		spdlog::default_logger()->set_level(spdlog::level::off);

--- a/NorthstarDedicatedTest/logrotation.cpp
+++ b/NorthstarDedicatedTest/logrotation.cpp
@@ -1,0 +1,80 @@
+#include "pch.h"
+#include <filesystem>
+#include <string>
+#include <time.h>
+#include <iostream>
+#include <regex>
+#include "configurables.h"
+
+namespace fs = std::filesystem;
+using namespace std;
+
+const int seconds_in_day = 86400;
+
+double getLogAge(const fs::path path)
+{
+	time_t logtime;
+	time_t currenttime;
+	struct tm timeinfo = {0};
+	int year, month, day;
+	string filename = path.filename().string();
+	// Check if log has a correct name
+	if (regex_search(filename, regex("nslog([0-9]{2}-){2}[0-9]{4}\ [0-9]{2}(-[0-9]{2}){2}.txt")))
+	{
+		// Log naming before 1.4.0, which released on January 06 2022
+		year = stoi(filename.substr(11, 4));
+		month = stoi(filename.substr(8, 2));
+		day = stoi(filename.substr(5, 2));
+	}
+	else if (regex_search(filename, regex("nsdump([0-9]{2}-){2}[0-9]{4}\ [0-9]{2}(-[0-9]{2}){2}.dmp")))
+	{
+		// Dumps
+		year = stoi(filename.substr(12, 4));
+		month = stoi(filename.substr(9, 2));
+		day = stoi(filename.substr(6, 2));
+	}
+	else if (regex_search(filename, regex("nslog[0-9]{4}(-[0-9]{2}){2}\ [0-9]{2}(-[0-9]{2}){2}.txt")))
+	{
+		// Log naming after 1.4.0
+		year = stoi(filename.substr(5, 4));
+		month = stoi(filename.substr(10, 2));
+		day = stoi(filename.substr(13, 2));
+	}
+	else
+	{
+		// Can't get log date
+		return 0;
+	}
+
+	// Only reads days
+	timeinfo.tm_year = year - 1900;
+	timeinfo.tm_mon = month - 1;
+	timeinfo.tm_mday = day;
+
+	logtime = mktime(&timeinfo);
+	time(&currenttime);
+	return difftime(currenttime, logtime);
+}
+
+void logRotation(int days = 7)
+{
+	string path = GetNorthstarPrefix() + "/logs";
+	struct stat info;
+	// Check if we can access log directory
+	if (stat(path.c_str(), &info) != 0 || !(info.st_mode & S_IFDIR))
+	{
+		return;
+	}
+	for (const auto& entry : fs::directory_iterator(path))
+	{
+		fs::path link = entry.path();
+		string extension = link.extension().string();
+		if (extension == ".txt" || extension == ".dmp")
+		{
+			if (getLogAge(link) > seconds_in_day * days)
+			{
+				remove(link);
+			}
+		}
+	}
+}

--- a/NorthstarDedicatedTest/logrotation.h
+++ b/NorthstarDedicatedTest/logrotation.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void logRotation(int days);


### PR DESCRIPTION
In following to #82, #76 and #73 

Removes .txt files and .dmp files older than x days (7 by default) based on file name