### PR TITLE
Fixed crash with plugin loading

### DIFF
--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -91,7 +91,11 @@ bool LoadPlugins()
 	std::vector<fs::path> paths;
 
 	std::string pluginPath = GetNorthstarPrefix() + "/plugins";
-
+	if (!fs::exists(pluginPath))
+	{
+		spdlog::warn("Could not find a plugins directory. Skipped loading plugins");
+		return false;
+	}
 	// ensure dirs exist
 	fs::recursive_directory_iterator iterator(pluginPath);
 	if (std::filesystem::begin(iterator) == std::filesystem::end(iterator))
@@ -104,9 +108,7 @@ bool LoadPlugins()
 		if (fs::is_regular_file(entry) && entry.path().extension() == ".dll")
 			paths.emplace_back(entry.path().filename());
 	}
-	// system("pause");
 	initGameState();
-	// spdlog::info("Loading the following DLLs in plugins folder:");
 	for (fs::path path : paths)
 	{
 		std::string pathstring = (pluginPath / path).string();


### PR DESCRIPTION
Apparently creating a `fs::recursive_directory_iterator` crashes if the directory does not exist. Oops!