### PR TITLE
Fix #101, chat hook memory leak

### DIFF
--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -17,14 +17,14 @@ struct ChatTags
 
 static void CHudChat__AddGameLineHook(void* self, const char* message, int inboxId, bool isTeam, bool isDead)
 {
+	// This hook is called for each HUD, but we only want our logic to run once.
+	if (self != *CHudChat::allHuds)
+	{
+		return;
+	}
+
 	if (g_ClientSquirrelManager->setupfunc("CHudChat_ProcessMessageStartThread") != SQRESULT_ERROR)
 	{
-		// This hook is called for each HUD, but we only want our logic to run once.
-		if (!IsFirstHud(self))
-		{
-			return;
-		}
-
 		int senderId = inboxId & CUSTOM_MESSAGE_INDEX_MASK;
 		bool isAnonymous = senderId == 0;
 		bool isCustom = isAnonymous || (inboxId & CUSTOM_MESSAGE_INDEX_BIT);
@@ -46,7 +46,12 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 		g_ClientSquirrelManager->call(5);
 	}
 	else
-		CHudChat__AddGameLine(self, message, inboxId, isTeam, isDead);
+	{
+		for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
+		{
+			CHudChat__AddGameLine(hud, message, inboxId, isTeam, isDead);
+		}
+	}
 }
 
 // void NSChatWrite( int context, string str )

--- a/NorthstarDedicatedTest/localchatwriter.cpp
+++ b/NorthstarDedicatedTest/localchatwriter.cpp
@@ -65,34 +65,11 @@ class CGameFloatVar
 	float value;
 };
 
-class CHudChat
-{
-  public:
-	char unknown1[720];
-
-	vgui_Color m_sameTeamColor;
-	vgui_Color m_enemyTeamColor;
-	vgui_Color m_mainTextColor;
-	vgui_Color m_networkNameColor;
-
-	char unknown2[12];
-
-	int m_unknownContext;
-
-	char unknown3[8];
-
-	vgui_BaseRichText* m_richText;
-
-	CHudChat* next;
-	CHudChat* previous;
-};
-
 CGameSettings** gGameSettings;
 CGameFloatVar** gChatFadeLength;
 CGameFloatVar** gChatFadeSustain;
 
-// Linked list of CHudChats
-CHudChat** gHudChatList;
+CHudChat** CHudChat::allHuds;
 
 typedef void(__fastcall* ConvertANSIToUnicodeType)(LPCSTR ansi, int ansiCharLength, LPWSTR unicode, int unicodeCharLength);
 ConvertANSIToUnicodeType ConvertANSIToUnicode;
@@ -315,7 +292,7 @@ void LocalChatWriter::WriteLine(const char* str)
 
 void LocalChatWriter::InsertChar(wchar_t ch)
 {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -334,7 +311,7 @@ void LocalChatWriter::InsertText(const char* str)
 	WCHAR messageUnicode[288];
 	ConvertANSIToUnicode(str, -1, messageUnicode, 274);
 
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -347,7 +324,7 @@ void LocalChatWriter::InsertText(const char* str)
 
 void LocalChatWriter::InsertText(const wchar_t* str)
 {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -360,7 +337,7 @@ void LocalChatWriter::InsertText(const wchar_t* str)
 
 void LocalChatWriter::InsertColorChange(vgui_Color color)
 {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -387,7 +364,7 @@ static vgui_Color GetHudSwatchColor(CHudChat* hud, LocalChatWriter::SwatchColor 
 
 void LocalChatWriter::InsertSwatchColorChange(SwatchColor swatchColor)
 {
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -439,7 +416,7 @@ void LocalChatWriter::InsertDefaultFade()
 		fadeSustain = (*gChatFadeSustain)->value;
 	}
 
-	for (CHudChat* hud = *gHudChatList; hud != NULL; hud = hud->next)
+	for (CHudChat* hud = *CHudChat::allHuds; hud != NULL; hud = hud->next)
 	{
 		if (hud->m_unknownContext != (int)m_context)
 			continue;
@@ -447,14 +424,12 @@ void LocalChatWriter::InsertDefaultFade()
 	}
 }
 
-bool IsFirstHud(void* hud) { return hud == *gHudChatList; }
-
 void InitialiseLocalChatWriter(HMODULE baseAddress)
 {
 	gGameSettings = (CGameSettings**)((char*)baseAddress + 0x11BAA48);
 	gChatFadeLength = (CGameFloatVar**)((char*)baseAddress + 0x11BAB78);
 	gChatFadeSustain = (CGameFloatVar**)((char*)baseAddress + 0x11BAC08);
-	gHudChatList = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
+	CHudChat::allHuds = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
 
 	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
 }

--- a/NorthstarDedicatedTest/localchatwriter.h
+++ b/NorthstarDedicatedTest/localchatwriter.h
@@ -9,6 +9,32 @@ struct vgui_Color
 	unsigned char a;
 };
 
+class vgui_BaseRichText;
+
+class CHudChat
+{
+  public:
+	static CHudChat** allHuds;
+
+	char unknown1[720];
+
+	vgui_Color m_sameTeamColor;
+	vgui_Color m_enemyTeamColor;
+	vgui_Color m_mainTextColor;
+	vgui_Color m_networkNameColor;
+
+	char unknown2[12];
+
+	int m_unknownContext;
+
+	char unknown3[8];
+
+	vgui_BaseRichText* m_richText;
+
+	CHudChat* next;
+	CHudChat* previous;
+};
+
 class LocalChatWriter
 {
   public:
@@ -44,7 +70,5 @@ class LocalChatWriter
 	const char* ApplyAnsiEscape(const char* escape);
 	void InsertDefaultFade();
 };
-
-bool IsFirstHud(void* hud);
 
 void InitialiseLocalChatWriter(HMODULE baseAddress);


### PR DESCRIPTION
Mostly just moves things around in `CHudChat__AddGameLineHook` to avoid calling `squirrel->setupfunc` in cases where we might not call `squirrel->call`.

Fixes #101 