### PR TITLE
Hidden console stuff

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -114,6 +114,7 @@
     <ClInclude Include="buildainfile.h" />
     <ClInclude Include="chatcommand.h" />
     <ClInclude Include="clientchathooks.h" />
+    <ClInclude Include="hideconsole.h" />
     <ClInclude Include="localchatwriter.h" />
     <ClInclude Include="plugins.h" />
     <ClInclude Include="plugin_abi.h" />
@@ -577,6 +578,7 @@
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="filesystem.cpp" />
     <ClCompile Include="gameutils.cpp" />
+    <ClCompile Include="hideconsole.cpp" />
     <ClCompile Include="hooks.cpp" />
     <ClCompile Include="hookutils.cpp" />
     <ClCompile Include="keyvalues.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1646,10 +1646,10 @@
     <ClCompile Include="plugins.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="hideconsole.cpp">
-      <Filter>Header Files\Client</Filter>
-    </ClCompile>
     <ClCompile Include="clientvideooverrides.cpp">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="hideconsole.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>
   </ItemGroup>

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1482,6 +1482,9 @@
     <ClInclude Include="plugin_abi.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="hideconsole.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1633,6 +1636,9 @@
     </ClCompile>
     <ClCompile Include="plugins.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="hideconsole.cpp">
+      <Filter>Source Files\Client</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1648,7 +1648,7 @@
     </ClCompile>
     <ClCompile Include="hideconsole.cpp">
       <Filter>Header Files\Client</Filter>
-    </ClInclude>
+    </ClCompile>
     <ClCompile Include="clientvideooverrides.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1486,6 +1486,8 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="hideconsole.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
     <ClInclude Include="clientvideooverrides.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
@@ -1645,6 +1647,8 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="hideconsole.cpp">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
     <ClCompile Include="clientvideooverrides.cpp">
       <Filter>Source Files\Client</Filter>
     </ClCompile>

--- a/NorthstarDedicatedTest/clientvideooverrides.cpp
+++ b/NorthstarDedicatedTest/clientvideooverrides.cpp
@@ -2,7 +2,7 @@
 #include "clientvideooverrides.h"
 #include "modmanager.h"
 
-typedef void*(*BinkOpenType)(const char* path, uint32_t flags);
+typedef void* (*BinkOpenType)(const char* path, uint32_t flags);
 BinkOpenType BinkOpen;
 
 void* BinkOpenHook(const char* path, uint32_t flags)
@@ -16,7 +16,7 @@ void* BinkOpenHook(const char* path, uint32_t flags)
 	{
 		if (!mod.Enabled)
 			continue;
-		
+
 		if (std::find(mod.BinkVideos.begin(), mod.BinkVideos.end(), filename) != mod.BinkVideos.end())
 			fileOwner = &mod;
 	}
@@ -34,5 +34,6 @@ void* BinkOpenHook(const char* path, uint32_t flags)
 void InitialiseClientVideoOverrides(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, GetProcAddress(GetModuleHandleA("bink2w64.dll"), "BinkOpen"), &BinkOpenHook, reinterpret_cast<LPVOID*>(&BinkOpen));
+	ENABLER_CREATEHOOK(
+		hook, GetProcAddress(GetModuleHandleA("bink2w64.dll"), "BinkOpen"), &BinkOpenHook, reinterpret_cast<LPVOID*>(&BinkOpen));
 }

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -245,6 +245,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallbackForClient("client.dll", InitialiseScriptServerToClientStringCommands);
 		AddDllLoadCallbackForClient("client.dll", InitialiseClientVideoOverrides);
 		AddDllLoadCallbackForClient("client.dll", InitialiseHiddenConsole);
+		AddDllLoadCallbackForClient("engine.dll", InitialiseEngineErrorHooks);
 
 		// audio hooks
 		AddDllLoadCallbackForClient("client.dll", InitialiseMilesAudioHooks);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -37,6 +37,7 @@
 #include "serverchathooks.h"
 #include "clientchathooks.h"
 #include "localchatwriter.h"
+#include "hideconsole.h"
 #include <string.h>
 #include "pch.h"
 #include "plugin_abi.h"
@@ -237,6 +238,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallback("client.dll", InitialisePluginCommands);
 		AddDllLoadCallback("client.dll", InitialiseClientChatHooks);
 		AddDllLoadCallback("client.dll", InitialiseLocalChatWriter);
+		AddDllLoadCallback("client.dll", InitialiseHiddenConsole);
 	}
 
 	AddDllLoadCallback("engine.dll", InitialiseEngineSpewFuncHooks);

--- a/NorthstarDedicatedTest/gameutils.cpp
+++ b/NorthstarDedicatedTest/gameutils.cpp
@@ -80,7 +80,7 @@ void InitialiseEngineGameUtilFunctions(HMODULE baseAddress)
 		}*/
 
 	Cvar_hostport = (ConVar*)((char*)baseAddress + 0x13FA6070);
-  
+
 	g_gameHwnd = (HWND*)((char*)baseAddress + 0x7d88a0);
 }
 

--- a/NorthstarDedicatedTest/gameutils.cpp
+++ b/NorthstarDedicatedTest/gameutils.cpp
@@ -50,6 +50,8 @@ Plat_FloatTimeType Plat_FloatTime;
 ThreadInServerFrameThreadType ThreadInServerFrameThread;
 GetBaseLocalClientType GetBaseLocalClient;
 
+HWND* g_gameHwnd;
+
 void InitialiseEngineGameUtilFunctions(HMODULE baseAddress)
 {
 	Cbuf_GetCurrentPlayer = (Cbuf_GetCurrentPlayerType)((char*)baseAddress + 0x120630);
@@ -88,6 +90,8 @@ void InitialiseEngineGameUtilFunctions(HMODULE baseAddress)
 	Cvar_net_datablock_enabled = (ConVar*)((char*)baseAddress + 0x12A4F6D0);
 	Cvar_match_defaultMap = (ConVar*)((char*)baseAddress + 0x8AB530);
 	Cvar_communities_hostname = (ConVar*)((char*)baseAddress + 0x13157E50);
+
+	g_gameHwnd = (HWND*)((char*)baseAddress + 0x7d88a0);
 }
 
 void InitialiseServerGameUtilFunctions(HMODULE baseAddress)

--- a/NorthstarDedicatedTest/gameutils.h
+++ b/NorthstarDedicatedTest/gameutils.h
@@ -252,6 +252,8 @@ extern ThreadInServerFrameThreadType ThreadInServerFrameThread;
 typedef void* (*GetBaseLocalClientType)();
 extern GetBaseLocalClientType GetBaseLocalClient;
 
+extern HWND* g_gameHwnd;
+
 void InitialiseEngineGameUtilFunctions(HMODULE baseAddress);
 void InitialiseServerGameUtilFunctions(HMODULE baseAddress);
 void InitialiseTier0GameUtilFunctions(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/hideconsole.cpp
+++ b/NorthstarDedicatedTest/hideconsole.cpp
@@ -19,9 +19,6 @@ void ChangeConsoleHiddenState()
 
 void InitialiseHiddenConsole(HMODULE baseAddress)
 {
-	if (IsDedicated())
-		return;
-
 	if (!strstr(GetCommandLineA(), "-showconsole"))
 	{
 		ShowWindow(GetConsoleWindow(), SW_HIDE);

--- a/NorthstarDedicatedTest/hideconsole.cpp
+++ b/NorthstarDedicatedTest/hideconsole.cpp
@@ -1,0 +1,34 @@
+#include "pch.h"
+#include "hideconsole.h"
+#include "dedicated.h"
+#include "convar.h"
+
+ConVar* Cvar_show_console_window;
+
+void ChangeConsoleHiddenState()
+{
+	if (Cvar_show_console_window->GetBool())
+	{
+		ShowWindow(GetConsoleWindow(), SW_SHOWNOACTIVATE);
+	}
+	else
+	{
+		ShowWindow(GetConsoleWindow(), SW_HIDE);
+	}
+}
+
+void InitialiseHiddenConsole(HMODULE baseAddress)
+{
+	if (IsDedicated())
+		return;
+
+	if (!strstr(GetCommandLineA(), "-showconsole"))
+	{
+		ShowWindow(GetConsoleWindow(), SW_HIDE);
+		Cvar_show_console_window = new ConVar("show_console_window", "0", FCVAR_NONE, "", false, 0, true, 1, ChangeConsoleHiddenState);
+	}
+	else
+	{
+		Cvar_show_console_window = new ConVar("show_console_window", "1", FCVAR_NONE, "", false, 0, true, 1, ChangeConsoleHiddenState);
+	}
+}

--- a/NorthstarDedicatedTest/hideconsole.h
+++ b/NorthstarDedicatedTest/hideconsole.h
@@ -1,0 +1,2 @@
+#pragma once
+void InitialiseHiddenConsole(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -5,6 +5,7 @@
 #include "hookutils.h"
 #include "dedicated.h"
 #include "convar.h"
+#include "gameutils.h"
 #include <iomanip>
 #include <sstream>
 #include <Psapi.h>

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -205,7 +205,9 @@ long __stdcall ExceptionFilter(EXCEPTION_POINTERS* exceptionInfo)
 			ShowWindow(GetConsoleWindow(), SW_RESTORE);
 
 			MessageBoxA(
-				0, "Northstar has crashed! Crash info can be found in R2Northstar/logs", "Northstar has crashed!", MB_ICONERROR | MB_OK);
+				GetConsoleWindow(), "Northstar has crashed! Crash info can be found in R2Northstar/logs", "Northstar has crashed!",
+				MB_ICONERROR | MB_OK);
+		}
 	}
 
 	logged = true;

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -195,6 +195,15 @@ long __stdcall ExceptionFilter(EXCEPTION_POINTERS* exceptionInfo)
 			spdlog::error("Failed to write minidump file {}!", stream.str());
 
 		if (!IsDedicated())
+		{
+			PostMessage(*g_gameHwnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+			ShowWindow(*g_gameHwnd, SW_HIDE);
+			ShowWindow(GetConsoleWindow(), SW_SHOW);
+			SetForegroundWindow(GetConsoleWindow());
+			SetFocus(GetConsoleWindow());
+			SetActiveWindow(GetConsoleWindow());
+			ShowWindow(GetConsoleWindow(), SW_RESTORE);
+
 			MessageBoxA(
 				0, "Northstar has crashed! Crash info can be found in R2Northstar/logs", "Northstar has crashed!", MB_ICONERROR | MB_OK);
 	}

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -205,8 +205,7 @@ long __stdcall ExceptionFilter(EXCEPTION_POINTERS* exceptionInfo)
 			ShowWindow(GetConsoleWindow(), SW_RESTORE);
 
 			MessageBoxA(
-				GetConsoleWindow(), "Northstar has crashed! Crash info can be found in R2Northstar/logs", "Northstar has crashed!",
-				MB_ICONERROR | MB_OK);
+				0, "Northstar has crashed! Crash info can be found in R2Northstar/logs", "Northstar has crashed!", MB_ICONERROR | MB_OK);
 		}
 	}
 

--- a/NorthstarDedicatedTest/logging.h
+++ b/NorthstarDedicatedTest/logging.h
@@ -5,3 +5,4 @@ void CreateLogFiles();
 void InitialiseLogging();
 void InitialiseEngineSpewFuncHooks(HMODULE baseAddress);
 void InitialiseClientPrintHooks(HMODULE baseAddress);
+void InitialiseEngineErrorHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/miscserverfixes.cpp
+++ b/NorthstarDedicatedTest/miscserverfixes.cpp
@@ -31,7 +31,4 @@ void InitialiseMiscServerFixes(HMODULE baseAddress)
 	}
 }
 
-void InitialiseMiscEngineServerFixes(HMODULE baseAddress) 
-{
-	
-}
+void InitialiseMiscEngineServerFixes(HMODULE baseAddress) {}

--- a/NorthstarDedicatedTest/modmanager.cpp
+++ b/NorthstarDedicatedTest/modmanager.cpp
@@ -306,8 +306,7 @@ void ModManager::LoadMods()
 				dVpkJson.Parse<rapidjson::ParseFlag::kParseCommentsFlag | rapidjson::ParseFlag::kParseTrailingCommasFlag>(
 					vpkJsonStringStream.str().c_str());
 
-				bUseVPKJson =
-					!dVpkJson.HasParseError() && dVpkJson.IsObject();
+				bUseVPKJson = !dVpkJson.HasParseError() && dVpkJson.IsObject();
 			}
 
 			for (fs::directory_entry file : fs::directory_iterator(mod.ModDirectory / "vpk"))
@@ -325,7 +324,8 @@ void ModManager::LoadMods()
 						(file.path().parent_path() / formattedPath.substr(strlen("english"), formattedPath.find(".bsp") - 3)).string();
 
 					ModVPKEntry& modVpk = mod.Vpks.emplace_back();
-					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() && dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
+					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
+														  dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = vpkName;
 
 					if (m_hasLoadedMods && modVpk.m_bAutoLoad)
@@ -353,8 +353,7 @@ void ModManager::LoadMods()
 				dRpakJson.Parse<rapidjson::ParseFlag::kParseCommentsFlag | rapidjson::ParseFlag::kParseTrailingCommasFlag>(
 					rpakJsonStringStream.str().c_str());
 
-				bUseRpakJson =
-					!dRpakJson.HasParseError() && dRpakJson.IsObject();
+				bUseRpakJson = !dRpakJson.HasParseError() && dRpakJson.IsObject();
 			}
 
 			// read pak aliases
@@ -378,11 +377,13 @@ void ModManager::LoadMods()
 					std::string pakName(file.path().filename().string());
 
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
-					modPak.m_bAutoLoad = !bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() && dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+					modPak.m_bAutoLoad =
+						!bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
+										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 					modPak.m_sPakPath = pakName;
 
 					// not using atm because we need to resolve path to rpak
-					//if (m_hasLoadedMods && modPak.m_bAutoLoad)
+					// if (m_hasLoadedMods && modPak.m_bAutoLoad)
 					//	g_PakLoadManager->LoadPakAsync(pakName.c_str());
 				}
 			}

--- a/NorthstarDedicatedTest/modmanager.h
+++ b/NorthstarDedicatedTest/modmanager.h
@@ -97,7 +97,8 @@ class Mod
 	std::string Pdiff; // only need one per mod
 
 	std::vector<ModRpakEntry> Rpaks;
-	std::unordered_map<std::string, std::string> RpakAliases; // paks we alias to other rpaks, e.g. to load sp_crashsite paks on the map mp_crashsite
+	std::unordered_map<std::string, std::string>
+		RpakAliases; // paks we alias to other rpaks, e.g. to load sp_crashsite paks on the map mp_crashsite
 
 	// other stuff
 

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -7,7 +7,7 @@ typedef void* (*LoadCommonPaksForMapType)(char* map);
 LoadCommonPaksForMapType LoadCommonPaksForMap;
 
 typedef void* (*LoadPakSyncType)(const char* path, void* unknownSingleton, int flags);
-typedef int(*LoadPakAsyncType)(const char* path, void* unknownSingleton, int flags, void* callback0, void* callback1);
+typedef int (*LoadPakAsyncType)(const char* path, void* unknownSingleton, int flags, void* callback0, void* callback1);
 
 // there are more i'm just too lazy to add
 struct PakLoadFuncs
@@ -59,20 +59,21 @@ void LoadPreloadPaks()
 		for (ModRpakEntry& pak : mod.Rpaks)
 			if (pak.m_bAutoLoad)
 				g_PakLoadManager->LoadPakAsync((modPakPath / pak.m_sPakPath).string().c_str());
-	} 
+	}
 
 	bShouldPreload = true;
 }
 
 LoadPakSyncType LoadPakSyncOriginal;
 void* LoadPakSyncHook(char* path, void* unknownSingleton, int flags)
-{ 
+{
 	HandlePakAliases(&path);
-	// note: we don't handle loading any preloaded custom paks synchronously since LoadPakSync is never actually called in retail, just load them async instead
+	// note: we don't handle loading any preloaded custom paks synchronously since LoadPakSync is never actually called in retail, just load
+	// them async instead
 	LoadPreloadPaks();
 
 	spdlog::info("LoadPakSync {}", path);
-	return LoadPakSyncOriginal(path, unknownSingleton, flags); 
+	return LoadPakSyncOriginal(path, unknownSingleton, flags);
 }
 
 LoadPakAsyncType LoadPakAsyncOriginal;

--- a/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
+++ b/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
@@ -7,14 +7,15 @@
 
 void ConCommand_ns_script_servertoclientstringcommand(const CCommand& arg)
 {
-	if (g_ClientSquirrelManager->sqvm && g_ClientSquirrelManager->setupfunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
+	if (g_ClientSquirrelManager->sqvm &&
+		g_ClientSquirrelManager->setupfunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
 	{
 		g_ClientSquirrelManager->pusharg(arg.ArgS());
 		g_ClientSquirrelManager->call(1); // todo: doesn't throw or log errors from within this, probably not great behaviour
 	}
 }
 
-void InitialiseScriptServerToClientStringCommands(HMODULE baseAddress) 
+void InitialiseScriptServerToClientStringCommands(HMODULE baseAddress)
 {
 	if (IsDedicated())
 		return;

--- a/NorthstarDedicatedTest/securitypatches.cpp
+++ b/NorthstarDedicatedTest/securitypatches.cpp
@@ -27,7 +27,9 @@ void InitialiseClientEngineSecurityPatches(HMODULE baseAddress)
 
 	// note: this could break some things
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1C6360, &IsValveModHook, reinterpret_cast<LPVOID*>(&IsValveMod));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x222E70, &SVC_CmdKeyValues__ReadFromBufferHook, reinterpret_cast<LPVOID*>(&SVC_CmdKeyValues__ReadFromBuffer));
+	ENABLER_CREATEHOOK(
+		hook, (char*)baseAddress + 0x222E70, &SVC_CmdKeyValues__ReadFromBufferHook,
+		reinterpret_cast<LPVOID*>(&SVC_CmdKeyValues__ReadFromBuffer));
 
 	// patches to make commands run from client/ui script still work
 	// note: this is likely preventable in a nicer way? test prolly


### PR DESCRIPTION
console is visible until game window opens
`-showconsole` startup arg keeps console open
`show_console_window` convar allows the console to be opened and closed at runtime
console always stays open on dedicated servers
hides the game window and displays the console on crash
~~parents crash message box to the console~~ this made it not make the message box and just crash with an error noise if you clsoed the console