### PR TITLE
Update link to Discord server

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,5 +1,5 @@
 # Build Instructions
-The following steps will allow you to compile your own NorthstarLauncher executable from the code in this repository. If you still have questions, you may ask in the [Discord Server](https://discord.gg/r2northstar)
+The following steps will allow you to compile your own NorthstarLauncher executable from the code in this repository. If you still have questions, you may ask in the [Discord Server](https://discord.gg/northstar)
 
 *This guide assumes you have already installed Northstar as shown in [this page](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/basic-setup)*
 


### PR DESCRIPTION
We changed from `r2northstar` to `northstar` a while back which broke the link in the readme.