### PR TITLE
add rui_drawEnable

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -114,6 +114,7 @@
     <ClInclude Include="buildainfile.h" />
     <ClInclude Include="chatcommand.h" />
     <ClInclude Include="clientchathooks.h" />
+    <ClInclude Include="clientruihooks.h" />
     <ClInclude Include="clientvideooverrides.h" />
     <ClInclude Include="localchatwriter.h" />
     <ClInclude Include="plugins.h" />
@@ -572,6 +573,7 @@
     <ClCompile Include="chatcommand.cpp" />
     <ClCompile Include="clientauthhooks.cpp" />
     <ClCompile Include="clientchathooks.cpp" />
+    <ClCompile Include="clientruihooks.cpp" />
     <ClCompile Include="clientvideooverrides.cpp" />
     <ClCompile Include="concommand.cpp" />
     <ClCompile Include="configurables.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1503,6 +1503,9 @@
     <ClInclude Include="version.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="clientruihooks.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1663,6 +1666,9 @@
     </ClCompile>
     <ClCompile Include="version.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="clientruihooks.cpp">
+      <Filter>Source Files\Client</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NorthstarDedicatedTest/clientruihooks.cpp
+++ b/NorthstarDedicatedTest/clientruihooks.cpp
@@ -1,0 +1,24 @@
+#include "pch.h"
+#include "clientruihooks.h"
+#include "convar.h"
+
+ConVar* Cvar_rui_drawEnable;
+
+typedef char (*DrawRUIFuncType)(void* a1, float* a2);
+DrawRUIFuncType DrawRUIFunc;
+
+char DrawRUIFuncHook(void* a1, float* a2)
+{
+	if (!Cvar_rui_drawEnable->GetBool())
+		return 0;
+
+	return DrawRUIFunc(a1, a2);
+}
+
+void InitialiseEngineClientRUIHooks(HMODULE baseAddress) 
+{
+	Cvar_rui_drawEnable = new ConVar("rui_drawEnable", "1", FCVAR_CLIENTDLL, "Controls whether RUI should be drawn");
+	
+	HookEnabler hook;
+	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xFC500, &DrawRUIFuncHook, reinterpret_cast<LPVOID*>(&DrawRUIFunc));
+}

--- a/NorthstarDedicatedTest/clientruihooks.cpp
+++ b/NorthstarDedicatedTest/clientruihooks.cpp
@@ -15,10 +15,10 @@ char DrawRUIFuncHook(void* a1, float* a2)
 	return DrawRUIFunc(a1, a2);
 }
 
-void InitialiseEngineClientRUIHooks(HMODULE baseAddress) 
+void InitialiseEngineClientRUIHooks(HMODULE baseAddress)
 {
 	Cvar_rui_drawEnable = new ConVar("rui_drawEnable", "1", FCVAR_CLIENTDLL, "Controls whether RUI should be drawn");
-	
+
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xFC500, &DrawRUIFuncHook, reinterpret_cast<LPVOID*>(&DrawRUIFunc));
 }

--- a/NorthstarDedicatedTest/clientruihooks.h
+++ b/NorthstarDedicatedTest/clientruihooks.h
@@ -1,0 +1,2 @@
+#pragma once
+void InitialiseEngineClientRUIHooks(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -40,6 +40,7 @@
 #include "plugin_abi.h"
 #include "plugins.h"
 #include "clientvideooverrides.h"
+#include "clientruihooks.h"
 #include <string.h>
 #include "version.h"
 #include "pch.h"
@@ -246,6 +247,7 @@ bool InitialiseNorthstar()
 		AddDllLoadCallbackForClient("client.dll", InitialiseLocalChatWriter);
 		AddDllLoadCallbackForClient("client.dll", InitialiseScriptServerToClientStringCommands);
 		AddDllLoadCallbackForClient("client.dll", InitialiseClientVideoOverrides);
+		AddDllLoadCallbackForClient("engine.dll", InitialiseEngineClientRUIHooks);
 
 		// audio hooks
 		AddDllLoadCallbackForClient("client.dll", InitialiseMilesAudioHooks);


### PR DESCRIPTION
allows rui rendering to be enabled/disabled with the cvar rui_drawEnable (this is something respawn can do on dev builds, with a cvar of the same name)
works fine in testing, haven't encountered any issues with it