### PR TITLE
Fix formatting to stop clang-format failing in CI

### DIFF
--- a/NorthstarDedicatedTest/ExploitFixes.cpp
+++ b/NorthstarDedicatedTest/ExploitFixes.cpp
@@ -131,7 +131,9 @@ KHOOK(CClient_ProcessSetConVar, ("engine.dll", "48 8B D1 48 8B 49 18 48 8B 01 48
 			auto realVar = g_pCVar->FindVar(entry->name);
 
 			if (realVar)
-				memcpy(entry->name, realVar->m_ConCommandBase.m_pszName, strlen(realVar->m_ConCommandBase.m_pszName) + 1); // Force name to match case
+				memcpy(
+					entry->name, realVar->m_ConCommandBase.m_pszName,
+					strlen(realVar->m_ConCommandBase.m_pszName) + 1); // Force name to match case
 
 			bool isValidFlags = true;
 			if (areWeServer)
@@ -155,7 +157,6 @@ KHOOK(CClient_ProcessSetConVar, ("engine.dll", "48 8B D1 48 8B 49 18 48 8B 01 48
 					return BLOCKED_INFO(
 						"Invalid flags (" << std::hex << "0x" << realVar->m_ConCommandBase.m_nFlags << "), var is " << entry->name);
 				}
-				
 			}
 		}
 		else
@@ -199,7 +200,6 @@ KHOOK(CClient_ProcessUsercmds, ("engine.dll", "40 55 56 48 83 EC 58"), bool, __f
 	if ((msg->m_nNewCommands + msg->m_nBackupCommands) > NUMCMD_SANITY_LIMIT)
 	{
 		return BLOCKED_INFO("Command count is too high (new: " << msg->m_nNewCommands << ", backup: " << msg->m_nBackupCommands << ")");
-
 	}
 
 	if (msg->m_nLength <= 0)
@@ -278,7 +278,6 @@ KHOOK(ReadUsercmd, ("server.dll", "4C 89 44 24 ? 53 55 56 57"), void, __fastcall
 											 << ", commandTime : " << cmd->command_time << ")");
 		goto INVALID_CMD; // No simulation of bogus-timed cmds
 	}
-		
 
 	if (!cmd->move.IsValid())
 	{

--- a/NorthstarDedicatedTest/ExploitFixes.cpp
+++ b/NorthstarDedicatedTest/ExploitFixes.cpp
@@ -7,16 +7,18 @@
 
 ConVar* ns_exploitfixes_log;
 #define SHOULD_LOG (ns_exploitfixes_log->m_Value.m_nValue > 0)
-#define BLOCKED_INFO(s) \
-	([=]() -> bool {                   \
-		if (SHOULD_LOG) \
-		{ \
-			std::stringstream stream; \
-			stream << "ExploitFixes.cpp: " << BLOCK_PREFIX << s; \
-			spdlog::error(stream.str()); \
-		} \
-		return false; \
-	}())
+#define BLOCKED_INFO(s)                                                                                                                    \
+	(                                                                                                                                      \
+		[=]() -> bool                                                                                                                      \
+		{                                                                                                                                  \
+			if (SHOULD_LOG)                                                                                                                \
+			{                                                                                                                              \
+				std::stringstream stream;                                                                                                  \
+				stream << "ExploitFixes.cpp: " << BLOCK_PREFIX << s;                                                                       \
+				spdlog::error(stream.str());                                                                                               \
+			}                                                                                                                              \
+			return false;                                                                                                                  \
+		}())
 
 // Make sure 3 or less floats are valid
 bool ValidateFloats(float a, float b = 0, float c = 0) { return !isnan(a) && !isnan(b) && !isnan(c); }
@@ -81,7 +83,7 @@ KHOOK(CClient_ProcessSetConVar, ("engine.dll", "48 8B D1 48 8B 49 18 48 8B 01 48
 
 	bool areWeServer;
 
-	{ 
+	{
 		// Figure out of we are the client or the server
 		//	To do this, we utilize the msg's m_pMessageHandler pointer
 		//	m_pMessageHandler points to a virtual class that handles all net messages
@@ -242,7 +244,8 @@ KHOOK(ReadUsercmd, ("server.dll", "4C 89 44 24 ? 53 55 56 57"), void, __fastcall
 	auto cmd = (SV_CUserCmd*)pCmd_move;
 	auto fromCmd = (SV_CUserCmd*)pCmd_from;
 
-	std::string BLOCK_PREFIX = "ReadUsercmd (command_number delta: " + std::to_string(cmd->command_number - fromCmd->command_number) + "): ";
+	std::string BLOCK_PREFIX =
+		"ReadUsercmd (command_number delta: " + std::to_string(cmd->command_number - fromCmd->command_number) + "): ";
 
 	if (cmd->worldViewAngles.IsInvalid())
 	{

--- a/NorthstarDedicatedTest/audio.cpp
+++ b/NorthstarDedicatedTest/audio.cpp
@@ -318,7 +318,7 @@ void CustomAudioManager::ClearAudioOverrides()
 		// this is cancer but it works
 		Sleep(50);
 	}
-	
+
 	// slightly (very) bad
 	// wait for all audio reads to complete so we don't kill preexisting audio buffers as we're writing to them
 	std::unique_lock lock(g_CustomAudioManager.m_loadingMutex);

--- a/NorthstarDedicatedTest/audio.cpp
+++ b/NorthstarDedicatedTest/audio.cpp
@@ -214,7 +214,7 @@ EventOverrideData::EventOverrideData(const std::string& data, const fs::path& pa
 			// thread off the file read
 			// should we spawn one thread per read? or should there be a cap to the number of reads at once?
 			std::thread readThread(
-				[pathString, fileSize, data] 
+				[pathString, fileSize, data]
 				{
 					std::shared_lock lock(g_CustomAudioManager.m_loadingMutex);
 					std::basic_ifstream<uint8_t> wavStream(pathString, std::ios::binary);


### PR DESCRIPTION
Before changing `.clang-format` we should first make sure that code appeals to the current version of `.clang-format`. Hence this PR.