### PR TITLE
Add run_on requirements for server and client

### DIFF
--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -182,7 +182,7 @@ bool LoadPlugins()
 
 		if (!shouldLoad)
 		{
-			spdlog::info("{} will not be loaded due to run_on requirements.", pathstring);
+			spdlog::info("{} will not be loaded due to run_on requirements", pathstring);
 			continue;
 		}
 


### PR DESCRIPTION
Plugins must now specify whether or not they want to run on client and/or server.
DiscordRPC has already been updated