### PR TITLE
Fix debug builds

### DIFF
--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -627,7 +627,7 @@ void MasterServerManager::AuthenticateWithOwnServer(char* uid, char* playerToken
 					goto REQUEST_END_CLEANUP;
 				}
 
-				AuthData newAuthData;
+				AuthData newAuthData {};
 				strncpy(newAuthData.uid, authInfoJson["id"].GetString(), sizeof(newAuthData.uid));
 				newAuthData.uid[sizeof(newAuthData.uid) - 1] = 0;
 

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -129,7 +129,7 @@ void ServerAuthenticationManager::StartPlayerAuthServer()
 						return;
 					}
 
-					AuthData newAuthData;
+					AuthData newAuthData {};
 					strncpy(newAuthData.uid, request.get_param_value("id").c_str(), sizeof(newAuthData.uid));
 					newAuthData.uid[sizeof(newAuthData.uid) - 1] = 0;
 


### PR DESCRIPTION
Properly initializes AuthData structs where used.
This does not get done automatically in debug mode because c++ is weird like that