### PR TITLE
Hardcode version number

### DIFF
--- a/LauncherInjector/resources.rc
+++ b/LauncherInjector/resources.rc
@@ -1,6 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource1.h"
+#include "../NorthstarDedicatedTest/ns_version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -61,8 +62,8 @@ IDI_ICON1               ICON                    "ns_icon.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,0,0,1
- PRODUCTVERSION 0,0,0,1
+ FILEVERSION NORTHSTAR_VERSION
+ PRODUCTVERSION NORTHSTAR_VERSION
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -118,6 +118,7 @@
     <ClInclude Include="clientruihooks.h" />
     <ClInclude Include="clientvideooverrides.h" />
     <ClInclude Include="localchatwriter.h" />
+    <ClInclude Include="ns_version.h" />
     <ClInclude Include="plugins.h" />
     <ClInclude Include="plugin_abi.h" />
     <ClInclude Include="serverchathooks.h" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1509,6 +1509,9 @@
     <ClInclude Include="clientruihooks.h">
       <Filter>Header Files\Client</Filter>
     </ClInclude>
+    <ClInclude Include="ns_version.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/NorthstarDedicatedTest/ns_version.h
+++ b/NorthstarDedicatedTest/ns_version.h
@@ -1,0 +1,7 @@
+#pragma once
+#ifndef NORTHSTAR_VERSION
+// Turning off clang-format here so it doesn't mess with style as it needs to be this way for regex-ing with CI
+// clang-format off
+#define NORTHSTAR_VERSION 0,0,0,1
+// clang-format on
+#endif

--- a/NorthstarDedicatedTest/version.cpp
+++ b/NorthstarDedicatedTest/version.cpp
@@ -4,62 +4,27 @@
 char version[16];
 char NSUserAgent[32];
 
+// Turning off clang-format here so it doesn't mess with style as it needs to be this way for CI
+// clang-format off
+#define NORTHSTAR_VERSION 0,0,0,1
+// clang-format on
+
 void InitialiseVersion()
 {
-	HRSRC hResInfo;
-	DWORD dwSize;
-	HGLOBAL hResData;
-	LPVOID pRes, pResCopy;
-	UINT uLen = 0;
-	VS_FIXEDFILEINFO* lpFfi = NULL;
-	HINSTANCE hInst = ::GetModuleHandle(NULL);
+	int northstar_version[] = {NORTHSTAR_VERSION};
 
-	hResInfo = FindResourceW(hInst, MAKEINTRESOURCE(1), RT_VERSION);
-	if (hResInfo != NULL)
+	// We actually use the rightmost integer do determine whether or not we're a debug/dev build
+	// If it is set to 1, we are a dev build
+	// On github CI, we set this 1 to a 0 automatically as we replace the 0,0,0,1 with the real version number
+	if (northstar_version[3] == 1)
 	{
-		dwSize = SizeofResource(hInst, hResInfo);
-		hResData = LoadResource(hInst, hResInfo);
-		if (hResData != NULL)
-		{
-			pRes = LockResource(hResData);
-			pResCopy = LocalAlloc(LMEM_FIXED, dwSize);
-			if (pResCopy != 0)
-			{
-				CopyMemory(pResCopy, pRes, dwSize);
-				VerQueryValueW(pResCopy, L"\\", (LPVOID*)&lpFfi, &uLen);
-
-				DWORD dwFileVersionMS = lpFfi->dwFileVersionMS;
-				DWORD dwFileVersionLS = lpFfi->dwFileVersionLS;
-
-				DWORD dwLeftMost = HIWORD(dwFileVersionMS);
-				DWORD dwSecondLeft = LOWORD(dwFileVersionMS);
-				DWORD dwSecondRight = HIWORD(dwFileVersionLS);
-				DWORD dwRightMost = LOWORD(dwFileVersionLS);
-
-				// We actually use the rightmost integer do determine whether or not we're a debug/dev build
-				// If it is set to 1 (as in resources.rc), we are a dev build
-				// On github CI, we set this 1 to a 0 automatically as we replace the 0.0.0.1 with the real version number
-				if (dwRightMost == 1)
-				{
-					sprintf(version, "%d.%d.%d.%d+dev", dwLeftMost, dwSecondLeft, dwSecondRight, dwRightMost);
-					sprintf(NSUserAgent, "R2Northstar/%d.%d.%d+dev", dwLeftMost, dwSecondLeft, dwSecondRight);
-				}
-				else
-				{
-					sprintf(version, "%d.%d.%d.%d", dwLeftMost, dwSecondLeft, dwSecondRight, dwRightMost);
-					sprintf(NSUserAgent, "R2Northstar/%d.%d.%d", dwLeftMost, dwSecondLeft, dwSecondRight);
-				}
-				UnlockResource(hResData);
-				FreeResource(hResData);
-				LocalFree(pResCopy);
-				return;
-			}
-			UnlockResource(hResData);
-			FreeResource(hResData);
-			LocalFree(pResCopy);
-		}
+		sprintf(version, "%d.%d.%d.%d+dev", northstar_version[0], northstar_version[1], northstar_version[2], northstar_version[3]);
+		sprintf(NSUserAgent, "R2Northstar/%d.%d.%d+dev", northstar_version[0], northstar_version[1], northstar_version[2]);
 	}
-	// Could not locate version info for whatever reason
-	spdlog::error("Failed to load version info:\n{}", std::system_category().message(GetLastError()));
-	sprintf(NSUserAgent, "R2Northstar/0.0.0");
+	else
+	{
+		sprintf(version, "%d.%d.%d.%d", northstar_version[0], northstar_version[1], northstar_version[2], northstar_version[3]);
+		sprintf(NSUserAgent, "R2Northstar/%d.%d.%d", northstar_version[0], northstar_version[1], northstar_version[2]);
+	}
+	return;
 }

--- a/NorthstarDedicatedTest/version.cpp
+++ b/NorthstarDedicatedTest/version.cpp
@@ -7,7 +7,7 @@ char NSUserAgent[32];
 
 void InitialiseVersion()
 {
-	int northstar_version[] = {NORTHSTAR_VERSION};
+	constexpr int northstar_version[4]{NORTHSTAR_VERSION};
 
 	// We actually use the rightmost integer do determine whether or not we're a debug/dev build
 	// If it is set to 1, we are a dev build

--- a/NorthstarDedicatedTest/version.cpp
+++ b/NorthstarDedicatedTest/version.cpp
@@ -7,7 +7,7 @@ char NSUserAgent[32];
 
 void InitialiseVersion()
 {
-	constexpr int northstar_version[4]{NORTHSTAR_VERSION};
+	constexpr int northstar_version[4] {NORTHSTAR_VERSION};
 
 	// We actually use the rightmost integer do determine whether or not we're a debug/dev build
 	// If it is set to 1, we are a dev build

--- a/NorthstarDedicatedTest/version.cpp
+++ b/NorthstarDedicatedTest/version.cpp
@@ -1,13 +1,9 @@
 #include "version.h"
 #include "pch.h"
+#include "ns_version.h"
 
 char version[16];
 char NSUserAgent[32];
-
-// Turning off clang-format here so it doesn't mess with style as it needs to be this way for CI
-// clang-format off
-#define NORTHSTAR_VERSION 0,0,0,1
-// clang-format on
 
 void InitialiseVersion()
 {


### PR DESCRIPTION
This way, we don't get the wrong version number when launching Titanfall2.exe via `-northstar`
The hardcoded value should be overwritten by CI on release (https://github.com/R2Northstar/Northstar/pull/262)

Fixes #129