### PR TITLE
Fix duplicate script in scripts.rson + allow mods to force vpks to load through vpk.json

### DIFF
--- a/NorthstarDedicatedTest/modmanager.cpp
+++ b/NorthstarDedicatedTest/modmanager.cpp
@@ -329,6 +329,7 @@ void ModManager::LoadMods()
 					modVpk.m_bAutoLoad = !bUseVPKJson || (dVpkJson.HasMember("Preload") && dVpkJson["Preload"].IsObject() &&
 														  dVpkJson["Preload"].HasMember(vpkName) && dVpkJson["Preload"][vpkName].IsTrue());
 					modVpk.m_sVpkPath = vpkName;
+					spdlog::info("ADDED VPK: {}", vpkName);
 
 					if (m_hasLoadedMods && modVpk.m_bAutoLoad)
 						(*g_Filesystem)->m_vtable->MountVPK(*g_Filesystem, vpkName.c_str());
@@ -350,7 +351,9 @@ void ModManager::LoadMods()
 						spdlog::info("VANILLA VPK: {}", v->name.GetString());
 						ModVPKEntry& modVpk = mod.Vpks.emplace_back();
 						modVpk.m_bAutoLoad = true;
-						modVpk.m_sVpkPath = v->name.GetString();
+						std::string path = "vpk/client_";
+						path += v->name.GetString(); // for some reason these have to be done separately but fine
+						modVpk.m_sVpkPath = path;
 					}
 				}
 			}

--- a/NorthstarDedicatedTest/scriptsrson.cpp
+++ b/NorthstarDedicatedTest/scriptsrson.cpp
@@ -11,6 +11,7 @@ void ModManager::BuildScriptsRson()
 	spdlog::info("Building custom scripts.rson");
 	fs::path MOD_SCRIPTS_RSON_PATH = fs::path(GetCompiledAssetsPath() / MOD_SCRIPTS_RSON_SUFFIX);
 	fs::remove(MOD_SCRIPTS_RSON_PATH);
+	std::vector<std::string> scriptsAdded;
 
 	// not really important since it doesn't affect actual functionality at all, but the rson we output is really weird
 	// has a shitload of newlines added, even in places where we don't modify it at all
@@ -37,6 +38,12 @@ void ModManager::BuildScriptsRson()
 				_coolscript.gnut
 			]*/
 
+			// check if the same script has been added already.
+			if (std::find(scriptsAdded.begin(), scriptsAdded.end(), script.Path) != scriptsAdded.end())
+			{
+				continue;
+			}
+
 			scriptsRson += "When: \"";
 			scriptsRson += script.RsonRunOn;
 			scriptsRson += "\"\n";
@@ -44,8 +51,10 @@ void ModManager::BuildScriptsRson()
 			scriptsRson += "Scripts:\n[\n\t";
 			scriptsRson += script.Path;
 			scriptsRson += "\n]\n\n";
+			scriptsAdded.push_back(script.Path);
 		}
 	}
+	scriptsAdded.clear();
 
 	fs::create_directories(MOD_SCRIPTS_RSON_PATH.parent_path());
 


### PR DESCRIPTION
See title.

NOTE: the duplicate script in scripts.rson fix doesn't take into account the RunOn of the two scripts.