### PR TITLE
Localize error messages from masterserver

### DIFF
--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -490,6 +490,10 @@ void MasterServerManager::RequestMainMenuPromos()
 				{
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
+					if (mainMenuPromoJson["error"].HasMember("enum"))
+						s_authfail_reason = std::string(mainMenuPromoJson["error"]["enum"].GetString());
+					else
+						s_authfail_reason = std::string("No error message provided");
 					goto REQUEST_END_CLEANUP;
 				}
 
@@ -610,6 +614,10 @@ void MasterServerManager::AuthenticateWithOwnServer(char* uid, char* playerToken
 				{
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
+					if (authInfoJson["error"].HasMember("enum"))
+						s_authfail_reason = std::string(authInfoJson["error"]["enum"].GetString());
+					else
+						s_authfail_reason = std::string("No error message provided");
 					goto REQUEST_END_CLEANUP;
 				}
 
@@ -757,6 +765,10 @@ void MasterServerManager::AuthenticateWithServer(char* uid, char* playerToken, c
 				{
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
+					if (connectionInfoJson["error"].HasMember("enum"))
+						s_authfail_reason = std::string(connectionInfoJson["error"]["enum"].GetString());
+					else
+						s_authfail_reason = std::string("No error message provided");
 					goto REQUEST_END_CLEANUP;
 				}
 

--- a/NorthstarDedicatedTest/masterserver.h
+++ b/NorthstarDedicatedTest/masterserver.h
@@ -98,6 +98,8 @@ class MasterServerManager
 	bool m_scriptAuthenticatingWithGameServer = false;
 	bool m_successfullyAuthenticatedWithGameServer = false;
 
+	std::string s_authfail_reason {};
+
 	bool m_hasPendingConnectionInfo = false;
 	RemoteServerConnectionInfo m_pendingConnectionInfo;
 

--- a/NorthstarDedicatedTest/scriptserverbrowser.cpp
+++ b/NorthstarDedicatedTest/scriptserverbrowser.cpp
@@ -355,6 +355,13 @@ SQRESULT SQ_WasAuthSuccessful(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
+// bool function NSWasAuthSuccessful()
+SQRESULT SQ_GetAuthFailReason(void* sqvm)
+{
+	ClientSq_pushstring(sqvm, g_MasterServerManager->s_authfail_reason.c_str(), -1);
+	return SQRESULT_NOTNULL;
+}
+
 // void function NSConnectToAuthedServer()
 SQRESULT SQ_ConnectToAuthedServer(void* sqvm)
 {
@@ -438,4 +445,6 @@ void InitialiseScriptServerBrowser(HMODULE baseAddress)
 
 	g_UISquirrelManager->AddFuncRegistration("void", "NSTryAuthWithLocalServer", "", "", SQ_TryAuthWithLocalServer);
 	g_UISquirrelManager->AddFuncRegistration("void", "NSCompleteAuthWithLocalServer", "", "", SQ_CompleteAuthWithLocalServer);
+
+	g_UISquirrelManager->AddFuncRegistration("string", "NSGetAuthFailReason", "", "", SQ_GetAuthFailReason);
 }


### PR DESCRIPTION
Adds this funky little dialog box when failing to authenticate with (master)server

![img](https://cdn.discordapp.com/attachments/951461326478262292/969739404446949406/unknown.png)

Needs to be updated with localization files for all languages