### PR TITLE
dont allow multiple of the same account to connect without a commandline arg

### DIFF
--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -684,6 +684,7 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 	}
 
 	// patch to allow same of multiple account
+	if (CommandLine()->CheckParm("-allowdupeaccounts"))
 	{
 		NSMem::BytePatch(
 			ba + 0x114510,


### PR DESCRIPTION
probably should've done this earlier, unsure if changes much in practice really but probably just good to do