### PR TITLE
Update to match recent LatencyFleX changes 

### DIFF
--- a/NorthstarDedicatedTest/latencyflex.cpp
+++ b/NorthstarDedicatedTest/latencyflex.cpp
@@ -29,7 +29,7 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 	m_lfxModule = ::LoadLibraryA("latencyflex_layer.dll");
 	if (m_lfxModule == nullptr && ::GetLastError() == ERROR_MOD_NOT_FOUND)
 	{
-		//Fallback to previous LatencyFleX library.
+		// Fallback to previous LatencyFleX library.
 		m_lfxModule = ::LoadLibraryA("latencyflex_wine.dll");
 		useFallbackEntrypoints = true;
 	}
@@ -40,8 +40,8 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 		return;
 	}
 
-	m_winelfx_WaitAndBeginFrame =
-		reinterpret_cast<PFN_winelfx_WaitAndBeginFrame>(reinterpret_cast<void*>(GetProcAddress(m_lfxModule, !useFallbackEntrypoints ? "lfx_WaitAndBeginFrame" : "winelfx_WaitAndBeginFrame")));
+	m_winelfx_WaitAndBeginFrame = reinterpret_cast<PFN_winelfx_WaitAndBeginFrame>(reinterpret_cast<void*>(
+		GetProcAddress(m_lfxModule, !useFallbackEntrypoints ? "lfx_WaitAndBeginFrame" : "winelfx_WaitAndBeginFrame")));
 	spdlog::info("LatencyFleX initialized.");
 
 	Cvar_r_latencyflex = new ConVar("r_latencyflex", "1", FCVAR_ARCHIVE, "Whether or not to use LatencyFleX input latency reduction.");

--- a/NorthstarDedicatedTest/latencyflex.cpp
+++ b/NorthstarDedicatedTest/latencyflex.cpp
@@ -27,8 +27,9 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 	// https://ishitatsuyuki.github.io/post/latencyflex/
 	bool useFallbackEntrypoints = false;
 	m_lfxModule = ::LoadLibraryA("latencyflex_layer.dll");
-	if (m_lfxModule == nullptr && ::GetLastError() == ERROR_MOD_NOT_FOUND) {
-		//Fallback to previous LatencyFlex library.
+	if (m_lfxModule == nullptr && ::GetLastError() == ERROR_MOD_NOT_FOUND)
+	{
+		//Fallback to previous LatencyFleX library.
 		m_lfxModule = ::LoadLibraryA("latencyflex_wine.dll");
 		useFallbackEntrypoints = true;
 	}

--- a/NorthstarDedicatedTest/latencyflex.cpp
+++ b/NorthstarDedicatedTest/latencyflex.cpp
@@ -26,12 +26,12 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 	// LatencyFleX is an open source vendor agnostic replacement for Nvidia Reflex input latency reduction technology.
 	// https://ishitatsuyuki.github.io/post/latencyflex/
 	bool useFallbackEntrypoints = false;
-        m_lfxModule = ::LoadLibraryA("latencyflex_layer.dll");
-        if (m_lfxModule == nullptr && ::GetLastError() == ERROR_MOD_NOT_FOUND) {
-            //Fallback to previous LatencyFlex library.
-            m_lfxModule = ::LoadLibraryA("latencyflex_wine.dll");
-            useFallbackEntrypoints = true;
-        }
+	m_lfxModule = ::LoadLibraryA("latencyflex_layer.dll");
+	if (m_lfxModule == nullptr && ::GetLastError() == ERROR_MOD_NOT_FOUND) {
+		//Fallback to previous LatencyFlex library.
+		m_lfxModule = ::LoadLibraryA("latencyflex_wine.dll");
+		useFallbackEntrypoints = true;
+	}
 
 	if (m_lfxModule == nullptr)
 	{


### PR DESCRIPTION
The main entry point for LatencyFleX was changed from latencyflex_wine.dll to latencyflex_layer.dll to prepare library for eventual windows release/to be more generic. This updates our implementation to match, while still supporting the previous libraries for existing users (As the official DXVK-NVAPI implementation of it does).

~~Currently in the process of testing, not ready to merge. Just opening this for visibility for now.~~