### PR TITLE
Compare uid from connect on activate

### DIFF
--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -389,11 +389,28 @@ bool CBaseClient__ConnectHook(void* self, char* name, __int64 netchan_ptr_arg, c
 		g_ServerAuthenticationManager->m_additionalPlayerData.insert(std::make_pair(self, additionalData));
 	}
 
+	g_ServerAuthenticationManager->m_additionalPlayerData[self].uid = nextPlayerUid;
+
 	return ret;
 }
 
 void CBaseClient__ActivatePlayerHook(void* self)
 {
+	bool uidMatches = false;
+	if (g_ServerAuthenticationManager->m_additionalPlayerData.count(self))
+	{
+		std::string strUid = std::to_string(g_ServerAuthenticationManager->m_additionalPlayerData[self].uid);
+		if (!strcmp(strUid.c_str(), (char*)self + 0xF500)) // connecting client's uid is the same as auth's uid
+		{
+			uidMatches = true;
+		}
+	}
+	if (!uidMatches)
+	{
+		CBaseClient__Disconnect(self, 1, "Authentication Failed");
+		return;
+	}
+
 	// if we're authed, write our persistent data
 	// RemovePlayerAuthData returns true if it removed successfully, i.e. on first call only, and we only want to write on >= second call
 	// (since this func is called on map loads)

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -387,9 +387,9 @@ bool CBaseClient__ConnectHook(void* self, char* name, __int64 netchan_ptr_arg, c
 		additionalData.usingLocalPdata = *((char*)self + 0x4a0) == (char)0x3;
 
 		g_ServerAuthenticationManager->m_additionalPlayerData.insert(std::make_pair(self, additionalData));
-	}
 
-	g_ServerAuthenticationManager->m_additionalPlayerData[self].uid = nextPlayerUid;
+		g_ServerAuthenticationManager->m_additionalPlayerData[self].uid = nextPlayerUid;
+	}
 
 	return ret;
 }

--- a/NorthstarDedicatedTest/serverauthentication.h
+++ b/NorthstarDedicatedTest/serverauthentication.h
@@ -28,6 +28,8 @@ struct AdditionalPlayerData
 
 	double lastSayTextLimitStart = -1.0;
 	int sayTextLimitCount = 0;
+
+	uint64_t uid;
 };
 
 #pragma once


### PR DESCRIPTION
Compare uid that is sent to `CBaseServer::ConnectClient` with the one present during `CBaseClient::ActivatePlayer` and kick if they don't match.