### PR TITLE
Attempt reconnect in case of DUPLICATE_SERVER

### DIFF
--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <regex>
 #include "version.h"
+#include <chrono>
 // NOTE for anyone reading this: we used to use httplib for requests here, but it had issues, so we're moving to curl now for masterserver
 // requests so httplib is used exclusively for server stuff now
 
@@ -824,6 +825,10 @@ void MasterServerManager::AddSelfToServerList(
 	std::thread requestThread(
 		[this, port, authPort, strName, strDescription, strMap, strPlaylist, maxPlayers, strPassword]
 		{
+			// Keep track of attempted connects in case of DUPLICATE_SERVER response
+			int retry_counter = 0;
+
+			START_REQUEST:
 			m_ownServerId[0] = 0;
 			m_ownServerAuthToken[0] = 0;
 
@@ -903,6 +908,26 @@ void MasterServerManager::AddSelfToServerList(
 				{
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
+
+					// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
+					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 1) {
+						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0) {
+
+							spdlog::info("Retrying request in 10 seconds.");
+							// Incremement retry counter
+							retry_counter++;
+
+							// Sleep for 10 seconds
+							std::this_thread::sleep_for(std::chrono::seconds(10));
+
+							// curl cleanup to retry request
+							curl_easy_cleanup(curl);
+							curl_mime_free(mime);
+
+							// go to beginning and retry
+							goto START_REQUEST;
+						}
+					}
 					goto REQUEST_END_CLEANUP;
 				}
 
@@ -924,6 +949,8 @@ void MasterServerManager::AddSelfToServerList(
 
 				strncpy(m_ownServerAuthToken, serverAddedJson["serverAuthToken"].GetString(), sizeof(m_ownServerAuthToken));
 				m_ownServerAuthToken[sizeof(m_ownServerAuthToken) - 1] = 0;
+
+				spdlog::info("Succesfully added server to the master server.");
 
 				// heartbeat thread
 				// ideally this should actually be done in main thread, rather than on it's own thread, so it'd stop if server freezes

--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -909,10 +909,11 @@ void MasterServerManager::AddSelfToServerList(
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
 
-					// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
+					// Check for enum member in JSON
 					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 1)
 					{
-						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0)
+						// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
+						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0 && retry_counter < 1)
 						{
 
 							spdlog::info("Retrying request in 10 seconds.");

--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -910,7 +910,7 @@ void MasterServerManager::AddSelfToServerList(
 					spdlog::error(readBuffer);
 
 					// Check for enum member in JSON
-					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 1)
+					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 10)
 					{
 						// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
 						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0 && retry_counter < 1)

--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -910,10 +910,10 @@ void MasterServerManager::AddSelfToServerList(
 					spdlog::error(readBuffer);
 
 					// Check for enum member in JSON
-					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 10)
+					if (serverAddedJson["error"].HasMember("enum"))
 					{
 						// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
-						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0 && retry_counter < 1)
+						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0 && retry_counter < 10)
 						{
 
 							spdlog::info("Retrying request in 10 seconds.");

--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -828,7 +828,7 @@ void MasterServerManager::AddSelfToServerList(
 			// Keep track of attempted connects in case of DUPLICATE_SERVER response
 			int retry_counter = 0;
 
-			START_REQUEST:
+		START_REQUEST:
 			m_ownServerId[0] = 0;
 			m_ownServerAuthToken[0] = 0;
 
@@ -910,8 +910,10 @@ void MasterServerManager::AddSelfToServerList(
 					spdlog::error(readBuffer);
 
 					// Check for DUPLICATE_SERVER error response, stop if we tried 10 times
-					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 1) {
-						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0) {
+					if (serverAddedJson["error"].HasMember("enum") && retry_counter < 1)
+					{
+						if (strncmp(serverAddedJson["error"]["enum"].GetString(), "DUPLICATE_SERVER", 17) == 0)
+						{
 
 							spdlog::info("Retrying request in 10 seconds.");
 							// Incremement retry counter


### PR DESCRIPTION
If gameserver receives DUPLICATE_SERVER response it will retry the auth request after a timeout of 10 seconds.
Retries will stop after 10 attempts.

Uses `GOTO`s to achieve this which is not particularly nice but I assume acceptable as we use the already as well in this part of the code.


For testing I spun a dedicated server, killed it after auth finished, then immediately created a new one. Output shows that it retried after failure until it was able to connect on the 2nd attempt. Then joining the server and playing around with it worked as expected.

![screenshot](https://user-images.githubusercontent.com/40122905/173461840-8bc06e58-0387-45f6-8f0b-aa94599f73b0.png)
