### PR TITLE
Disable DevTextBuffer by default

### DIFF
--- a/NorthstarDedicatedTest/miscclientfixes.cpp
+++ b/NorthstarDedicatedTest/miscclientfixes.cpp
@@ -9,7 +9,6 @@ CrashingWeaponActivityFuncType CrashingWeaponActivityFunc1;
 typedef bool (*DevTextBufferDumpToFileType)(int a1);
 DevTextBufferDumpToFileType DevTextBufferDumpToFileClient;
 
-
 void* CrashingWeaponActivityFunc0Hook(void* a1)
 {
 	// this return is safe, other functions that use this value seemingly dont care about it being null

--- a/NorthstarDedicatedTest/miscclientfixes.cpp
+++ b/NorthstarDedicatedTest/miscclientfixes.cpp
@@ -6,6 +6,9 @@
 typedef void* (*CrashingWeaponActivityFuncType)(void* a1);
 CrashingWeaponActivityFuncType CrashingWeaponActivityFunc0;
 CrashingWeaponActivityFuncType CrashingWeaponActivityFunc1;
+typedef bool (*DevTextBufferDumpToFileType)(int a1);
+DevTextBufferDumpToFileType DevTextBufferDumpToFileClient;
+
 
 void* CrashingWeaponActivityFunc0Hook(void* a1)
 {
@@ -25,6 +28,12 @@ void* CrashingWeaponActivityFunc1Hook(void* a1)
 	return CrashingWeaponActivityFunc1(a1);
 }
 
+bool DevTextBufferDumpToFileHookClient(int a1)
+{
+	// Prevent arbitrary file writes from squirrel
+	return true;
+}
+
 void InitialiseMiscClientFixes(HMODULE baseAddress)
 {
 	if (IsDedicated())
@@ -40,6 +49,15 @@ void InitialiseMiscClientFixes(HMODULE baseAddress)
 		hook, (char*)baseAddress + 0x5A92D0, &CrashingWeaponActivityFunc0Hook, reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc0));
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x5A9310, &CrashingWeaponActivityFunc1Hook, reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc1));
+
+	if (!strstr(GetCommandLineA(), "-allowdevtextbuffer"))
+	{
+		ENABLER_CREATEHOOK(
+			hook,
+			(char*)baseAddress + 0x39D9F0,
+			&DevTextBufferDumpToFileHookClient,
+			reinterpret_cast<LPVOID*>(&DevTextBufferDumpToFileClient));
+	}
 
 	// experimental: allow cl_extrapolate to be enabled without cheats
 	{

--- a/NorthstarDedicatedTest/miscclientfixes.cpp
+++ b/NorthstarDedicatedTest/miscclientfixes.cpp
@@ -7,7 +7,7 @@
 typedef void* (*CrashingWeaponActivityFuncType)(void* a1);
 CrashingWeaponActivityFuncType CrashingWeaponActivityFunc0;
 CrashingWeaponActivityFuncType CrashingWeaponActivityFunc1;
-typedef bool (*DevTextBufferDumpToFileType)(uint64_t a1);
+typedef bool (*DevTextBufferDumpToFileType)(char* a1);
 DevTextBufferDumpToFileType DevTextBufferDumpToFileClient;
 
 ConVar* cl_devtextbuffer_enable;
@@ -30,7 +30,7 @@ void* CrashingWeaponActivityFunc1Hook(void* a1)
 	return CrashingWeaponActivityFunc1(a1);
 }
 
-bool DevTextBufferDumpToFileHookClient(uint64_t a1)
+bool DevTextBufferDumpToFileHookClient(char* a1)
 {
 	// Prevent arbitrary file writes from squirrel
 	if (!cl_devtextbuffer_enable->m_Value.m_nValue)


### PR DESCRIPTION
This is code ported from an older PR that is still in development. Could possibly look at checking if `sv_cheats` is enabled, but adding any kind of branching in the inner function seems to crash on a stack canary for some reason.