### PR TITLE
Set default val for net_chan_limit_msec_per_sec

### DIFF
--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -668,7 +668,7 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 		new ConVar("net_chan_limit_mode", "0", FCVAR_GAMEDLL, "The mode for netchan processing limits: 0 = log, 1 = kick");
 	Cvar_net_chan_limit_msec_per_sec = new ConVar(
 		"net_chan_limit_msec_per_sec",
-		"0",
+		"100",
 		FCVAR_GAMEDLL,
 		"Netchannel processing is limited to so many milliseconds, abort connection if exceeding budget");
 	Cvar_ns_player_auth_port = new ConVar("ns_player_auth_port", "8081", FCVAR_GAMEDLL, "");


### PR DESCRIPTION
Setting a default value for _net_chan_limit_msec_per_sec_ will fix the issue of singleplayer games spamming warnings in the console.