### PR TITLE
Use strtoull instead of strtoll for uint64s

### DIFF
--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -20,7 +20,7 @@ void ServerBanSystem::OpenBanlist()
 	{
 		std::string line;
 		while (std::getline(enabledModsStream, line))
-			m_vBannedUids.push_back(strtoll(line.c_str(), nullptr, 10));
+			m_vBannedUids.push_back(strtoull(line.c_str(), nullptr, 10));
 
 		enabledModsStream.close();
 	}
@@ -74,7 +74,7 @@ void BanPlayerCommand(const CCommand& args)
 
 		if (!strcmp((char*)player + 0x16, args.Arg(1)) || !strcmp((char*)player + 0xF500, args.Arg(1)))
 		{
-			g_ServerBanSystem->BanUID(strtoll((char*)player + 0xF500, nullptr, 10));
+			g_ServerBanSystem->BanUID(strtoull((char*)player + 0xF500, nullptr, 10));
 			CBaseClient__Disconnect(player, 1, "Banned from server");
 			break;
 		}
@@ -87,7 +87,7 @@ void UnbanPlayerCommand(const CCommand& args)
 		return;
 
 	// assumedly the player being unbanned here wasn't already connected, so don't need to iterate over players or anything
-	g_ServerBanSystem->UnbanUID(strtoll(args.Arg(1), nullptr, 10));
+	g_ServerBanSystem->UnbanUID(strtoull(args.Arg(1), nullptr, 10));
 }
 
 void ClearBanlistCommand(const CCommand& args)


### PR DESCRIPTION
I have no proof that this will actually ever cause a real problem, but it's definitely a good idea and is more proper.