### PR TITLE
Add and implement GET_OFFSET/GET_OFFSET_PTR macro

### DIFF
--- a/NorthstarDedicatedTest/ExploitFixes.cpp
+++ b/NorthstarDedicatedTest/ExploitFixes.cpp
@@ -451,6 +451,9 @@ void ExploitFixes::LoadCallback(HMODULE baseAddress)
 
 	sv_cheats = g_pCVar->FindVar("sv_cheats");
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x5889A0, &function_containing_emit_hook, reinterpret_cast<LPVOID*>(&function_containing_emit));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x2a8a50, &GetEntByIndexHook, reinterpret_cast<LPVOID*>(&GetEntByIndex));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x5889A0),
+		&function_containing_emit_hook,
+		reinterpret_cast<LPVOID*>(&function_containing_emit));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x2a8a50), &GetEntByIndexHook, reinterpret_cast<LPVOID*>(&GetEntByIndex));
 }

--- a/NorthstarDedicatedTest/audio.cpp
+++ b/NorthstarDedicatedTest/audio.cpp
@@ -509,7 +509,7 @@ void InitialiseMilesAudioHooks(HMODULE baseAddress)
 
 	ENABLER_CREATEHOOK(
 		hook, (char*)milesAudioBase + 0xF110, &LoadSampleMetadata_Hook, reinterpret_cast<LPVOID*>(&LoadSampleMetadata_Original));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x57DAD0, &MilesLog_Hook, reinterpret_cast<LPVOID*>(&MilesLog_Original));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x57DAD0), &MilesLog_Hook, reinterpret_cast<LPVOID*>(&MilesLog_Original));
 
-	MilesStopAll = (MilesStopAll_Type)((char*)baseAddress + 0x580850);
+	MilesStopAll = (MilesStopAll_Type)(GET_OFFSET_PTR(void, baseAddress, 0x580850));
 }

--- a/NorthstarDedicatedTest/buildainfile.cpp
+++ b/NorthstarDedicatedTest/buildainfile.cpp
@@ -380,16 +380,19 @@ void InitialiseBuildAINFileHooks(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x385E20, &CAI_NetworkBuilder__BuildHook, reinterpret_cast<LPVOID*>(&CAI_NetworkBuilder__Build));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x3933A0, &LoadAINFileHook, reinterpret_cast<LPVOID*>(&LoadAINFile));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x385E20),
+		&CAI_NetworkBuilder__BuildHook,
+		reinterpret_cast<LPVOID*>(&CAI_NetworkBuilder__Build));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x3933A0), &LoadAINFileHook, reinterpret_cast<LPVOID*>(&LoadAINFile));
 
-	pUnkStruct0Count = (int*)((char*)baseAddress + 0x1063BF8);
-	pppUnkNodeStruct0s = (UnkNodeStruct0***)((char*)baseAddress + 0x1063BE0);
+	pUnkStruct0Count = GET_OFFSET_PTR(int, baseAddress, 0x1063BF8);
+	pppUnkNodeStruct0s = GET_OFFSET_PTR(UnkNodeStruct0**, baseAddress, 0x1063BE0);
 
-	pUnkLinkStruct1Count = (int*)((char*)baseAddress + 0x1063AA8);
-	pppUnkStruct1s = (UnkLinkStruct1***)((char*)baseAddress + 0x1063A90);
-	pUnkServerMapversionGlobal = (char**)((char*)baseAddress + 0xBFBE08);
-	pMapName = (char*)baseAddress + 0x1053370;
+	pUnkLinkStruct1Count = GET_OFFSET_PTR(int, baseAddress, 0x1063AA8);
+	pppUnkStruct1s = GET_OFFSET_PTR(UnkLinkStruct1**, baseAddress, 0x1063A90);
+	pUnkServerMapversionGlobal = GET_OFFSET_PTR(char*, baseAddress, 0xBFBE08);
+	pMapName = GET_OFFSET_PTR(char, baseAddress, 0x1053370);
 
 	uintptr_t base = (uintptr_t)baseAddress;
 

--- a/NorthstarDedicatedTest/chatcommand.cpp
+++ b/NorthstarDedicatedTest/chatcommand.cpp
@@ -31,7 +31,7 @@ void ConCommand_log(const CCommand& args)
 
 void InitialiseChatCommands(HMODULE baseAddress)
 {
-	ClientSayText = (ClientSayTextType)((char*)baseAddress + 0x54780);
+	ClientSayText = (ClientSayTextType)(GET_OFFSET_PTR(void, baseAddress, 0x54780));
 	RegisterConCommand("say", ConCommand_say, "Enters a message in public chat", FCVAR_CLIENTDLL);
 	RegisterConCommand("say_team", ConCommand_say_team, "Enters a message in team chat", FCVAR_CLIENTDLL);
 	RegisterConCommand("log", ConCommand_log, "Log a message to the local chat window", FCVAR_CLIENTDLL);

--- a/NorthstarDedicatedTest/clientauthhooks.cpp
+++ b/NorthstarDedicatedTest/clientauthhooks.cpp
@@ -43,5 +43,6 @@ void InitialiseClientAuthHooks(HMODULE baseAddress)
 		"whether the user has agreed to send their origin token to the northstar masterserver");
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1843A0, &AuthWithStryderHook, reinterpret_cast<LPVOID*>(&AuthWithStryder));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x1843A0), &AuthWithStryderHook, reinterpret_cast<LPVOID*>(&AuthWithStryder));
 }

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -87,7 +87,8 @@ static SQRESULT SQ_ChatWriteLine(void* sqvm)
 void InitialiseClientChatHooks(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook, reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x22E580), &CHudChat__AddGameLineHook, reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
 
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWrite", "int context, string text", "", SQ_ChatWrite);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWriteRaw", "int context, string text", "", SQ_ChatWriteRaw);

--- a/NorthstarDedicatedTest/clientruihooks.cpp
+++ b/NorthstarDedicatedTest/clientruihooks.cpp
@@ -20,5 +20,5 @@ void InitialiseEngineClientRUIHooks(HMODULE baseAddress)
 	Cvar_rui_drawEnable = new ConVar("rui_drawEnable", "1", FCVAR_CLIENTDLL, "Controls whether RUI should be drawn");
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xFC500, &DrawRUIFuncHook, reinterpret_cast<LPVOID*>(&DrawRUIFunc));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0xFC500), &DrawRUIFuncHook, reinterpret_cast<LPVOID*>(&DrawRUIFunc));
 }

--- a/NorthstarDedicatedTest/concommand.cpp
+++ b/NorthstarDedicatedTest/concommand.cpp
@@ -19,7 +19,7 @@ void RegisterConCommand(const char* name, void (*callback)(const CCommand&), con
 
 void InitialiseConCommands(HMODULE baseAddress)
 {
-	conCommandConstructor = (ConCommandConstructorType)((char*)baseAddress + 0x415F60);
+	conCommandConstructor = (ConCommandConstructorType)(GET_OFFSET_PTR(void, baseAddress, 0x415F60));
 	AddMiscConCommands();
 }
 

--- a/NorthstarDedicatedTest/convar.cpp
+++ b/NorthstarDedicatedTest/convar.cpp
@@ -33,17 +33,17 @@ CvarIsFlagSetType CvarIsFlagSet;
 //-----------------------------------------------------------------------------
 void InitialiseConVars(HMODULE baseAddress)
 {
-	conVarMalloc = (ConVarMallocType)((char*)baseAddress + 0x415C20);
-	conVarRegister = (ConVarRegisterType)((char*)baseAddress + 0x417230);
+	conVarMalloc = (ConVarMallocType)(GET_OFFSET_PTR(void, baseAddress, 0x415C20));
+	conVarRegister = (ConVarRegisterType)(GET_OFFSET_PTR(void, baseAddress, 0x417230));
 
-	g_pConVar_Vtable = (char*)baseAddress + 0x67FD28;
-	g_pIConVar_Vtable = (char*)baseAddress + 0x67FDC8;
+	g_pConVar_Vtable = GET_OFFSET_PTR(void, baseAddress, 0x67FD28);
+	g_pIConVar_Vtable = GET_OFFSET_PTR(void, baseAddress, 0x67FDC8);
 
 	g_pCVarInterface = new SourceInterface<CCvar>("vstdlib.dll", "VEngineCvar007");
 	g_pCVar = *g_pCVarInterface;
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x417FA0, &ConVar::IsFlagSet, reinterpret_cast<LPVOID*>(&CvarIsFlagSet));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x417FA0), &ConVar::IsFlagSet, reinterpret_cast<LPVOID*>(&CvarIsFlagSet));
 }
 
 //-----------------------------------------------------------------------------

--- a/NorthstarDedicatedTest/debugoverlay.cpp
+++ b/NorthstarDedicatedTest/debugoverlay.cpp
@@ -157,18 +157,18 @@ void InitialiseDebugOverlay(HMODULE baseAddress)
 		return;
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xABCB0, &DrawOverlayHook, reinterpret_cast<LPVOID*>(&DrawOverlay));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0xABCB0), &DrawOverlayHook, reinterpret_cast<LPVOID*>(&DrawOverlay));
 
-	RenderLine = reinterpret_cast<RenderLineType>((char*)baseAddress + 0x192A70);
+	RenderLine = reinterpret_cast<RenderLineType>(GET_OFFSET_PTR(void, baseAddress, 0x192A70));
 
-	RenderBox = reinterpret_cast<RenderBoxType>((char*)baseAddress + 0x192520);
+	RenderBox = reinterpret_cast<RenderBoxType>(GET_OFFSET_PTR(void, baseAddress, 0x192520));
 
-	RenderWireframeBox = reinterpret_cast<RenderBoxType>((char*)baseAddress + 0x193DA0);
+	RenderWireframeBox = reinterpret_cast<RenderBoxType>(GET_OFFSET_PTR(void, baseAddress, 0x193DA0));
 
 	sEngineModule = baseAddress;
 
 	// not in g_pCVar->FindVar by this point for whatever reason, so have to get from memory
-	ConVar* Cvar_enable_debug_overlays = (ConVar*)((char*)baseAddress + 0x10DB0990);
+	ConVar* Cvar_enable_debug_overlays = (ConVar*)(GET_OFFSET_PTR(void, baseAddress, 0x10DB0990));
 	Cvar_enable_debug_overlays->SetValue(false);
 	Cvar_enable_debug_overlays->m_pszDefaultValue = (char*)"0";
 	Cvar_enable_debug_overlays->AddFlags(FCVAR_CHEAT);

--- a/NorthstarDedicatedTest/dedicatedmaterialsystem.cpp
+++ b/NorthstarDedicatedTest/dedicatedmaterialsystem.cpp
@@ -48,12 +48,13 @@ HRESULT __stdcall D3D11CreateDeviceHook(
 void InitialiseDedicatedMaterialSystem(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xD9A0E, &D3D11CreateDeviceHook, reinterpret_cast<LPVOID*>(&D3D11CreateDevice));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0xD9A0E), &D3D11CreateDeviceHook, reinterpret_cast<LPVOID*>(&D3D11CreateDevice));
 
 	// not using these for now since they're related to nopping renderthread/gamewindow i.e. very hard
 	//{
 	//	// function that launches renderthread
-	//	char* ptr = (char*)baseAddress + 0x87047;
+	//	char* ptr = GET_OFFSET_PTR(void, baseAddress, 0x87047);
 	//	TempReadWrite rw(ptr);
 	//
 	//	// make it not launch renderthread
@@ -67,7 +68,7 @@ void InitialiseDedicatedMaterialSystem(HMODULE baseAddress)
 	//
 	//{
 	//	// some function that waits on renderthread job
-	//	char* ptr = (char*)baseAddress + 0x87d00;
+	//	char* ptr = GET_OFFSET_PTR(void, baseAddress, 0x87d00);
 	//	TempReadWrite rw(ptr);
 	//
 	//	// return immediately
@@ -118,6 +119,7 @@ void InitialiseDedicatedRtechGame(HMODULE baseAddress)
 
 	HookEnabler hook;
 	// unfortunately this is unstable, seems to freeze when changing maps
-	// ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xB0F0, &PakLoadAPI__LoadRpakHook, reinterpret_cast<LPVOID*>(&PakLoadAPI__LoadRpak));
-	// ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xB170, &PakLoadAPI__LoadRpak2Hook, reinterpret_cast<LPVOID*>(&PakLoadAPI__LoadRpak2));
+	// ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0xB0F0), &PakLoadAPI__LoadRpakHook,
+	// reinterpret_cast<LPVOID*>(&PakLoadAPI__LoadRpak)); ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0xB170),
+	// &PakLoadAPI__LoadRpak2Hook, reinterpret_cast<LPVOID*>(&PakLoadAPI__LoadRpak2));
 }

--- a/NorthstarDedicatedTest/filesystem.cpp
+++ b/NorthstarDedicatedTest/filesystem.cpp
@@ -40,11 +40,12 @@ void InitialiseFilesystem(HMODULE baseAddress)
 
 	// create hooks
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x5CBA0, &ReadFileFromVPKHook, reinterpret_cast<LPVOID*>(&readFileFromVPK));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x5CBA0), &ReadFileFromVPKHook, reinterpret_cast<LPVOID*>(&readFileFromVPK));
 	ENABLER_CREATEHOOK(hook, (*g_Filesystem)->m_vtable->ReadFromCache, &ReadFromCacheHook, reinterpret_cast<LPVOID*>(&readFromCache));
 	ENABLER_CREATEHOOK(
 		hook, (*g_Filesystem)->m_vtable->AddSearchPath, &AddSearchPathHook, reinterpret_cast<LPVOID*>(&addSearchPathOriginal));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x15F20, &ReadFileFromFilesystemHook, reinterpret_cast<LPVOID*>(&readFileFromFilesystem));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x15F20), &ReadFileFromFilesystemHook, reinterpret_cast<LPVOID*>(&readFileFromFilesystem));
 	ENABLER_CREATEHOOK(hook, (*g_Filesystem)->m_vtable->MountVPK, &MountVPKHook, reinterpret_cast<LPVOID*>(&mountVPK));
 }
 

--- a/NorthstarDedicatedTest/gameutils.cpp
+++ b/NorthstarDedicatedTest/gameutils.cpp
@@ -44,23 +44,23 @@ GetBaseLocalClientType GetBaseLocalClient;
 
 void InitialiseEngineGameUtilFunctions(HMODULE baseAddress)
 {
-	Cbuf_GetCurrentPlayer = (Cbuf_GetCurrentPlayerType)((char*)baseAddress + 0x120630);
-	Cbuf_AddText = (Cbuf_AddTextType)((char*)baseAddress + 0x1203B0);
-	Cbuf_Execute = (Cbuf_ExecuteType)((char*)baseAddress + 0x1204B0);
+	Cbuf_GetCurrentPlayer = (Cbuf_GetCurrentPlayerType)(GET_OFFSET_PTR(void, baseAddress, 0x120630));
+	Cbuf_AddText = (Cbuf_AddTextType)(GET_OFFSET_PTR(void, baseAddress, 0x1203B0));
+	Cbuf_Execute = (Cbuf_ExecuteType)(GET_OFFSET_PTR(void, baseAddress, 0x1204B0));
 
-	g_pHostState = (CHostState*)((char*)baseAddress + 0x7CF180);
-	g_pEngine = *(CEngine**)((char*)baseAddress + 0x7D70C8);
-	sv_m_State = (server_state_t*)((char*)baseAddress + 0x12A53D48);
+	g_pHostState = (CHostState*)(GET_OFFSET_PTR(void, baseAddress, 0x7CF180));
+	g_pEngine = *(CEngine**)(GET_OFFSET_PTR(void, baseAddress, 0x7D70C8));
+	sv_m_State = (server_state_t*)(GET_OFFSET_PTR(void, baseAddress, 0x12A53D48));
 
-	GetCurrentPlaylistName = (GetCurrentPlaylistType)((char*)baseAddress + 0x18C640);
-	SetCurrentPlaylist = (SetCurrentPlaylistType)((char*)baseAddress + 0x18EB20);
-	SetPlaylistVarOverride = (SetPlaylistVarOverrideType)((char*)baseAddress + 0x18ED00);
-	GetCurrentPlaylistVar = (GetCurrentPlaylistVarType)((char*)baseAddress + 0x18C680);
+	GetCurrentPlaylistName = (GetCurrentPlaylistType)(GET_OFFSET_PTR(void, baseAddress, 0x18C640));
+	SetCurrentPlaylist = (SetCurrentPlaylistType)(GET_OFFSET_PTR(void, baseAddress, 0x18EB20));
+	SetPlaylistVarOverride = (SetPlaylistVarOverrideType)(GET_OFFSET_PTR(void, baseAddress, 0x18ED00));
+	GetCurrentPlaylistVar = (GetCurrentPlaylistVarType)(GET_OFFSET_PTR(void, baseAddress, 0x18C680));
 
-	g_LocalPlayerUserID = (char*)baseAddress + 0x13F8E688;
-	g_LocalPlayerOriginToken = (char*)baseAddress + 0x13979C80;
+	g_LocalPlayerUserID = GET_OFFSET_PTR(char, baseAddress, 0x13F8E688);
+	g_LocalPlayerOriginToken = GET_OFFSET_PTR(char, baseAddress, 0x13979C80);
 
-	GetBaseLocalClient = (GetBaseLocalClientType)((char*)baseAddress + 0x78200);
+	GetBaseLocalClient = (GetBaseLocalClientType)(GET_OFFSET_PTR(void, baseAddress, 0x78200));
 
 	/* NOTE:
 		g_pCVar->FindVar("convar_name") now works. These are no longer needed.
@@ -77,12 +77,12 @@ void InitialiseEngineGameUtilFunctions(HMODULE baseAddress)
 			}
 		}*/
 
-	Cvar_hostport = (ConVar*)((char*)baseAddress + 0x13FA6070);
+	Cvar_hostport = (ConVar*)(GET_OFFSET_PTR(void, baseAddress, 0x13FA6070));
 }
 
 void InitialiseServerGameUtilFunctions(HMODULE baseAddress)
 {
-	Server_GetEntityByIndex = (Server_GetEntityByIndexType)((char*)baseAddress + 0xFB820);
+	Server_GetEntityByIndex = (Server_GetEntityByIndexType)(GET_OFFSET_PTR(void, baseAddress, 0xFB820));
 }
 
 void InitialiseTier0GameUtilFunctions(HMODULE baseAddress)

--- a/NorthstarDedicatedTest/keyvalues.cpp
+++ b/NorthstarDedicatedTest/keyvalues.cpp
@@ -17,7 +17,10 @@ void InitialiseKeyValues(HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x426C30, &KeyValues__LoadFromBufferHook, reinterpret_cast<LPVOID*>(&KeyValues__LoadFromBuffer));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x426C30),
+		&KeyValues__LoadFromBufferHook,
+		reinterpret_cast<LPVOID*>(&KeyValues__LoadFromBuffer));
 }
 
 void* savedFilesystemPtr;

--- a/NorthstarDedicatedTest/languagehooks.cpp
+++ b/NorthstarDedicatedTest/languagehooks.cpp
@@ -115,5 +115,6 @@ char* GetGameLanguageHook()
 void InitialiseTier0LanguageHooks(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xF560, &GetGameLanguageHook, reinterpret_cast<LPVOID*>(&GetGameLanguageOriginal));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0xF560), &GetGameLanguageHook, reinterpret_cast<LPVOID*>(&GetGameLanguageOriginal));
 }

--- a/NorthstarDedicatedTest/latencyflex.cpp
+++ b/NorthstarDedicatedTest/latencyflex.cpp
@@ -72,5 +72,5 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 	Cvar_r_latencyflex = new ConVar("r_latencyflex", "1", FCVAR_ARCHIVE, "Whether or not to use LatencyFleX input latency reduction.");
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1952C0, &OnRenderStartHook, reinterpret_cast<LPVOID*>(&OnRenderStart));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x1952C0), &OnRenderStartHook, reinterpret_cast<LPVOID*>(&OnRenderStart));
 }

--- a/NorthstarDedicatedTest/localchatwriter.cpp
+++ b/NorthstarDedicatedTest/localchatwriter.cpp
@@ -438,10 +438,10 @@ void LocalChatWriter::InsertDefaultFade()
 
 void InitialiseLocalChatWriter(HMODULE baseAddress)
 {
-	gGameSettings = (CGameSettings**)((char*)baseAddress + 0x11BAA48);
-	gChatFadeLength = (CGameFloatVar**)((char*)baseAddress + 0x11BAB78);
-	gChatFadeSustain = (CGameFloatVar**)((char*)baseAddress + 0x11BAC08);
-	CHudChat::allHuds = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
+	gGameSettings = (CGameSettings**)(GET_OFFSET_PTR(void, baseAddress, 0x11BAA48));
+	gChatFadeLength = (CGameFloatVar**)(GET_OFFSET_PTR(void, baseAddress, 0x11BAB78));
+	gChatFadeSustain = (CGameFloatVar**)(GET_OFFSET_PTR(void, baseAddress, 0x11BAC08));
+	CHudChat::allHuds = (CHudChat**)(GET_OFFSET_PTR(void, baseAddress, 0x11BA9E8));
 
-	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
+	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)(GET_OFFSET_PTR(void, baseAddress, 0x7339A0));
 }

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -411,15 +411,16 @@ void InitialiseEngineSpewFuncHooks(HMODULE baseAddress)
 {
 	HookEnabler hook;
 
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x11CA80, EngineSpewFuncHook, reinterpret_cast<LPVOID*>(&EngineSpewFunc));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x11CA80), EngineSpewFuncHook, reinterpret_cast<LPVOID*>(&EngineSpewFunc));
 
 	// Hook print function that status concmd uses to actually print data
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x15ABD0, Status_ConMsg_Hook, reinterpret_cast<LPVOID*>(&Status_ConMsg_Original));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x15ABD0), Status_ConMsg_Hook, reinterpret_cast<LPVOID*>(&Status_ConMsg_Original));
 
 	// Hook CClientState::ProcessPrint
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x1A1530,
+		GET_OFFSET_PTR(void, baseAddress, 0x1A1530),
 		CClientState_ProcessPrint_Hook,
 		reinterpret_cast<LPVOID*>(&CClientState_ProcessPrint_Original));
 
@@ -478,10 +479,10 @@ void InitialiseClientPrintHooks(HMODULE baseAddress)
 {
 	HookEnabler hook;
 
-	internalCenterPrint = (ICenterPrint*)((char*)baseAddress + 0x216E940);
+	internalCenterPrint = (ICenterPrint*)(GET_OFFSET_PTR(void, baseAddress, 0x216E940));
 
 	// "TextMsg" usermessage
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x198710, TextMsgHook, reinterpret_cast<LPVOID*>(&TextMsg_Original));
+	ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x198710), TextMsgHook, reinterpret_cast<LPVOID*>(&TextMsg_Original));
 
 	Cvar_cl_showtextmsg = new ConVar("cl_showtextmsg", "1", FCVAR_NONE, "Enable/disable text messages printing on the screen.");
 }

--- a/NorthstarDedicatedTest/masterserver.cpp
+++ b/NorthstarDedicatedTest/masterserver.cpp
@@ -1381,7 +1381,7 @@ void InitialiseSharedMasterServer(HMODULE baseAddress)
 
 	Cvar_ns_curl_log_enable = new ConVar("ns_curl_log_enable", "0", FCVAR_NONE, "");
 
-	Cvar_hostname = *(ConVar**)((char*)baseAddress + 0x1315bae8);
+	Cvar_hostname = *(ConVar**)(GET_OFFSET_PTR(void, baseAddress, 0x1315bae8));
 
 	g_MasterServerManager = new MasterServerManager;
 
@@ -1389,20 +1389,23 @@ void InitialiseSharedMasterServer(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x16E7D0, CHostState__State_NewGameHook, reinterpret_cast<LPVOID*>(&CHostState__State_NewGame));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x16E7D0),
+		CHostState__State_NewGameHook,
+		reinterpret_cast<LPVOID*>(&CHostState__State_NewGame));
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x16E520,
+		GET_OFFSET_PTR(void, baseAddress, 0x16E520),
 		CHostState__State_ChangeLevelMPHook,
 		reinterpret_cast<LPVOID*>(&CHostState__State_ChangeLevelMP));
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x16E5D0,
+		GET_OFFSET_PTR(void, baseAddress, 0x16E5D0),
 		CHostState__State_ChangeLevelSPHook,
 		reinterpret_cast<LPVOID*>(&CHostState__State_ChangeLevelSP));
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x16E640,
+		GET_OFFSET_PTR(void, baseAddress, 0x16E640),
 		CHostState__State_GameShutdownHook,
 		reinterpret_cast<LPVOID*>(&CHostState__State_GameShutdown));
 }

--- a/NorthstarDedicatedTest/maxplayers.cpp
+++ b/NorthstarDedicatedTest/maxplayers.cpp
@@ -114,48 +114,49 @@ void InitialiseMaxPlayersOverride_Engine(HMODULE baseAddress)
 		return;
 
 	// patch GetPlayerLimits to ignore the boundary limit
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x116458, 0xEB); // jle => jmp
+	ChangeOffset<unsigned char>(GET_OFFSET_PTR(void, baseAddress, 0x116458), 0xEB); // jle => jmp
 
 	// patch ED_Alloc to change nFirstIndex
-	ChangeOffset<int>((char*)baseAddress + 0x18F46C + 1, NEW_MAX_PLAYERS + 8 + 1); // original: 41 (sv.GetMaxClients() + 1)
+	ChangeOffset<int>(GET_OFFSET_PTR(int, baseAddress, 0x18F46C) + 1, NEW_MAX_PLAYERS + 8 + 1); // original: 41 (sv.GetMaxClients() + 1)
 
 	// patch CGameServer::SpawnServer to change GetMaxClients inline
-	ChangeOffset<int>((char*)baseAddress + 0x119543 + 2, NEW_MAX_PLAYERS + 8 + 1); // original: 41 (sv.GetMaxClients() + 1)
+	ChangeOffset<int>(GET_OFFSET_PTR(int, baseAddress, 0x119543) + 2, NEW_MAX_PLAYERS + 8 + 1); // original: 41 (sv.GetMaxClients() + 1)
 
 	// patch CGameServer::SpawnServer to change for loop
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x11957F + 2, NEW_MAX_PLAYERS); // original: 32
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x11957F) + 2, NEW_MAX_PLAYERS); // original: 32
 
 	// patch CGameServer::SpawnServer to change for loop (there are two)
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x119586 + 2, NEW_MAX_PLAYERS + 1); // original: 33 (32 + 1)
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x119586) + 2, NEW_MAX_PLAYERS + 1); // original: 33 (32 + 1)
 
 	// patch max players somewhere in CClientState
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x1A162C + 2, NEW_MAX_PLAYERS - 1); // original: 31 (32 - 1)
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x1A162C) + 2, NEW_MAX_PLAYERS - 1); // original: 31 (32 - 1)
 
 	// patch max players in userinfo stringtable creation
 	/*{
 		int maxPlayersPowerOf2 = 1;
 		while (maxPlayersPowerOf2 < NEW_MAX_PLAYERS)
 			maxPlayersPowerOf2 <<= 1;
-		ChangeOffset<unsigned char>((char*)baseAddress + 0x114B79 + 3, maxPlayersPowerOf2); // original: 32
+		ChangeOffset<unsigned char>(GET_OFFSET_PTR(void, baseAddress, 0x114B79) + 3, maxPlayersPowerOf2); // original: 32
 	}*/
 	// this is not supposed to work at all but it does on 64 players (how)
 	// proper fix below
 
 	// patch max players in userinfo stringtable creation loop
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x114C48 + 2, NEW_MAX_PLAYERS); // original: 32
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x114C48) + 2, NEW_MAX_PLAYERS); // original: 32
 
 	// do not load prebaked SendTable message list
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x75859, 0xEB); // jnz -> jmp
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x75859), 0xEB); // jnz -> jmp
 
 	HookEnabler hook;
 
-	// ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x209000, &MatchRecvPropsToSendProps_R_Hook,
-	// reinterpret_cast<LPVOID*>(&MatchRecvPropsToSendProps_R_Original)); ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1FACD0,
-	// &DataTable_SetupReceiveTableFromSendTable_Hook, reinterpret_cast<LPVOID*>(&DataTable_SetupReceiveTableFromSendTable_Original));
+	// ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress, 0x209000), &MatchRecvPropsToSendProps_R_Hook,
+	// reinterpret_cast<LPVOID*>(&MatchRecvPropsToSendProps_R_Original)); ENABLER_CREATEHOOK(hook, GET_OFFSET_PTR(void, baseAddress,
+	// 0x1FACD0), &DataTable_SetupReceiveTableFromSendTable_Hook,
+	// reinterpret_cast<LPVOID*>(&DataTable_SetupReceiveTableFromSendTable_Original));
 
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x22E220,
+		GET_OFFSET_PTR(void, baseAddress, 0x22E220),
 		&StringTables_CreateStringTable_Hook,
 		reinterpret_cast<LPVOID*>(&StringTables_CreateStringTable_Original));
 }
@@ -330,140 +331,163 @@ void InitialiseMaxPlayersOverride_Server(HMODULE baseAddress)
 	RandomIntZeroMax = (decltype(RandomIntZeroMax))(GetProcAddress(GetModuleHandleA("vstdlib.dll"), "RandomIntZeroMax"));
 
 	// patch max players amount
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x9A44D + 3, NEW_MAX_PLAYERS); // 0x20 (32) => 0x80 (128)
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x9A44D) + 3, NEW_MAX_PLAYERS); // 0x20 (32) => 0x80 (128)
 
 	// patch SpawnGlobalNonRewinding to change forced edict index
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x2BC403 + 2, NEW_MAX_PLAYERS + 1); // original: 33 (32 + 1)
+	ChangeOffset<BYTE>(GET_OFFSET_PTR(BYTE, baseAddress, 0x2BC403) + 2, NEW_MAX_PLAYERS + 1); // original: 33 (32 + 1)
 
 	constexpr int CPlayerResource_OriginalSize = 4776;
 	constexpr int CPlayerResource_AddedSize = PlayerResource_TotalSize;
 	constexpr int CPlayerResource_ModifiedSize = CPlayerResource_OriginalSize + CPlayerResource_AddedSize;
 
 	// CPlayerResource class allocation function - allocate a bigger amount to fit all new max player data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C560A + 1, CPlayerResource_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C560A) + 1, CPlayerResource_ModifiedSize);
 
 	// DT_PlayerResource::m_iPing SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5059 + 2, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C50A8 + 2, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C50E2 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5059) + 2, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C50A8) + 2, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C50E2) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_iPing DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94598, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB9459C, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB945C0, PlayerResource_Ping_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94598), CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB9459C), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB945C0), PlayerResource_Ping_Size);
 
 	// DT_PlayerResource::m_iTeam SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5110 + 2, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C519C + 2, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C517E + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5110) + 2, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C519C) + 2, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C517E) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_iTeam DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94600, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94604, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94628, PlayerResource_Team_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94600), CPlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94604), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94628), PlayerResource_Team_Size);
 
 	// DT_PlayerResource::m_iPRHealth SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C51C0 + 2, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5204 + 2, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C523E + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C51C0) + 2, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5204) + 2, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C523E) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_iPRHealth DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94668, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB9466C, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94690, PlayerResource_PRHealth_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94668), CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB9466C), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94690), PlayerResource_PRHealth_Size);
 
 	// DT_PlayerResource::m_bConnected SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C526C + 2, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C52B4 + 2, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C52EE + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C526C) + 2, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C52B4) + 2, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C52EE) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_bConnected DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB946D0, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB946D4, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB946F8, PlayerResource_Connected_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB946D0), CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB946D4), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB946F8), PlayerResource_Connected_Size);
 
 	// DT_PlayerResource::m_bAlive SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5321 + 2, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5364 + 2, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C539E + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5321) + 2, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5364) + 2, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C539E) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_bAlive DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94738, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB9473C, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94760, PlayerResource_Alive_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94738), CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB9473C), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94760), PlayerResource_Alive_Size);
 
 	// DT_PlayerResource::m_boolStats SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C53CC + 2, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5414 + 2, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C544E + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C53CC) + 2, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5414) + 2, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C544E) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_boolStats DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB947A0, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB947A4, NEW_MAX_PLAYERS + 1);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB947C8, PlayerResource_BoolStats_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB947A0), CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB947A4), NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB947C8), PlayerResource_BoolStats_Size);
 
 	// DT_PlayerResource::m_killStats SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C547C + 2, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C54E2 + 2, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C54FE + 4, PlayerResource_KillStats_Length);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C547C) + 2, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C54E2) + 2, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C54FE) + 4, PlayerResource_KillStats_Length);
 
 	// DT_PlayerResource::m_killStats DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94808, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB9480C, PlayerResource_KillStats_Length);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94830, PlayerResource_KillStats_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94808), CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB9480C), PlayerResource_KillStats_Length);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94830), PlayerResource_KillStats_Size);
 
 	// DT_PlayerResource::m_scoreStats SendProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5528 + 2, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5576 + 2, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C5584 + 4, PlayerResource_ScoreStats_Length);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5528) + 2, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5576) + 2, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C5584) + 4, PlayerResource_ScoreStats_Length);
 
 	// DT_PlayerResource::m_scoreStats DataMap
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xB94870, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94874, PlayerResource_ScoreStats_Length);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xB94898, PlayerResource_ScoreStats_Size);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xB94870), CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94874), PlayerResource_ScoreStats_Length);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xB94898), PlayerResource_ScoreStats_Size);
 
 	// CPlayerResource::UpdatePlayerData - m_bConnected
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C66EE + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C672E + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C66EE) + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C672E) + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_iPing
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C6394 + 4, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C63DB + 4, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C6394) + 4, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C63DB) + 4, CPlayerResource_OriginalSize + PlayerResource_Ping_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_iTeam
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C63FD + 4, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C6442 + 4, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C63FD) + 4, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C6442) + 4, CPlayerResource_OriginalSize + PlayerResource_Team_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_iPRHealth
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C645B + 4, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C64A0 + 4, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C645B) + 4, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C64A0) + 4, CPlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_bConnected
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C64AA + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C64F0 + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C64AA) + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C64F0) + 4, CPlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_bAlive
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C650A + 4, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C654F + 4, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C650A) + 4, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C654F) + 4, CPlayerResource_OriginalSize + PlayerResource_Alive_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_boolStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C6557 + 4, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C65A5 + 4, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C6557) + 4, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C65A5) + 4, CPlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_scoreStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C65C2 + 3, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C65E3 + 4, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C65C2) + 3, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C65E3) + 4, CPlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
 
 	// CPlayerResource::UpdatePlayerData - m_killStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C6654 + 3, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x5C665B + 3, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C6654) + 3, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x5C665B) + 3, CPlayerResource_OriginalSize + PlayerResource_KillStats_Start);
 
 	// GameLoop::RunUserCmds - rebuild
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x483D10, &RunUserCmds_Hook, reinterpret_cast<LPVOID*>(&RunUserCmds_Original));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x483D10), &RunUserCmds_Hook, reinterpret_cast<LPVOID*>(&RunUserCmds_Original));
 
-	*(DWORD*)((char*)baseAddress + 0x14E7390) = 0;
-	auto DT_PlayerResource_Construct = (__int64(__fastcall*)())((char*)baseAddress + 0x5C4FE0);
+	*(DWORD*)(GET_OFFSET_PTR(void, baseAddress, 0x14E7390)) = 0;
+	auto DT_PlayerResource_Construct = (__int64(__fastcall*)())(GET_OFFSET_PTR(void, baseAddress, 0x5C4FE0));
 	DT_PlayerResource_Construct();
 
 	constexpr int CTeam_OriginalSize = 3336;
@@ -471,18 +495,19 @@ void InitialiseMaxPlayersOverride_Server(HMODULE baseAddress)
 	constexpr int CTeam_ModifiedSize = CTeam_OriginalSize + CTeam_AddedSize;
 
 	// CTeam class allocation function - allocate a bigger amount to fit all new team player data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x23924A + 1, CTeam_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x23924A) + 1, CTeam_ModifiedSize);
 
 	// CTeam::CTeam - increase memset length to clean newly allocated data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x2395AE + 2, 256 + CTeam_AddedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x2395AE) + 2, 256 + CTeam_AddedSize);
 
 	// hook required to change the size of DT_Team::"player_array"
 	HookEnabler hook2;
-	ENABLER_CREATEHOOK(hook2, (char*)baseAddress + 0x12B130, &SendPropArray2_Hook, reinterpret_cast<LPVOID*>(&SendPropArray2_Original));
+	ENABLER_CREATEHOOK(
+		hook2, GET_OFFSET_PTR(void, baseAddress, 0x12B130), &SendPropArray2_Hook, reinterpret_cast<LPVOID*>(&SendPropArray2_Original));
 	hook2.~HookEnabler(); // force hook before calling construct function
 
-	*(DWORD*)((char*)baseAddress + 0xC945A0) = 0;
-	auto DT_Team_Construct = (__int64(__fastcall*)())((char*)baseAddress + 0x238F50);
+	*(DWORD*)(GET_OFFSET_PTR(void, baseAddress, 0xC945A0)) = 0;
+	auto DT_Team_Construct = (__int64(__fastcall*)())(GET_OFFSET_PTR(void, baseAddress, 0x238F50));
 	DT_Team_Construct();
 }
 
@@ -508,154 +533,172 @@ void InitialiseMaxPlayersOverride_Client(HMODULE baseAddress)
 	constexpr int C_PlayerResource_ModifiedSize = C_PlayerResource_OriginalSize + C_PlayerResource_AddedSize;
 
 	// C_PlayerResource class allocation function - allocate a bigger amount to fit all new max player data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164C41 + 1, C_PlayerResource_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164C41) + 1, C_PlayerResource_ModifiedSize);
 
 	// C_PlayerResource::C_PlayerResource - change loop end value
-	ChangeOffset<unsigned char>((char*)baseAddress + 0x1640C4 + 2, NEW_MAX_PLAYERS - 32);
+	ChangeOffset<unsigned char>(GET_OFFSET_PTR(BYTE, baseAddress, 0x1640C4) + 2, NEW_MAX_PLAYERS - 32);
 
 	// C_PlayerResource::C_PlayerResource - change m_szName address
-	ChangeOffset<unsigned int>(
-		(char*)baseAddress + 0x1640D0 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start); // appended to the end of the class
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1640D0) + 3,
+		C_PlayerResource_OriginalSize + PlayerResource_Name_Start); // appended to the end of the class
 
 	// C_PlayerResource::C_PlayerResource - change m_szName address
-	ChangeOffset<unsigned int>(
-		(char*)baseAddress + 0x1640D0 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start); // appended to the end of the class
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1640D0) + 3,
+		C_PlayerResource_OriginalSize + PlayerResource_Name_Start); // appended to the end of the class
 
 	// C_PlayerResource::C_PlayerResource - increase memset length to clean newly allocated data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1640D0 + 3, 2244 + C_PlayerResource_AddedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1640D0) + 3, 2244 + C_PlayerResource_AddedSize);
 
 	// C_PlayerResource::UpdatePlayerName - change m_szName address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x16431F + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x16431F) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName - change m_szName address 1
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1645B1 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1645B1) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName - change m_szName address 2
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1645C0 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1645C0) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName - change m_szName address 3
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1645DD + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1645DD) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_szName address 1
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164B71 + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164B71) + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_szName address 2
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164B9B + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164B9B) + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName2 (?) - change m_szName address 1
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164641 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164641) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName2 (?) - change m_szName address 2
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164650 + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164650) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName2 (?) - change m_szName address 3
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x16466D + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x16466D) + 3, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_szName2 (?) address 1
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164BA3 + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164BA3) + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_szName2 (?) address 2
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164BCE + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164BCE) + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_szName2 (?) address 3
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164BE7 + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x164BE7) + 4, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
 
 	// C_PlayerResource::m_szName
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc350f8, C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc350f8 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc350f8), C_PlayerResource_OriginalSize + PlayerResource_Name_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc350f8) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource size
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163415 + 6, C_PlayerResource_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163415) + 6, C_PlayerResource_ModifiedSize);
 
 	// DT_PlayerResource::m_iPing RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163492 + 2, C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1634D6 + 2, C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163515 + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163492) + 2, C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1634D6) + 2, C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163515) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_iPing
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc35170, C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc35170 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc35170), C_PlayerResource_OriginalSize + PlayerResource_Ping_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc35170) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_iTeam RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163549 + 2, C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1635C8 + 2, C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1635AD + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163549) + 2, C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1635C8) + 2, C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1635AD) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_iTeam
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc351e8, C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc351e8 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc351e8), C_PlayerResource_OriginalSize + PlayerResource_Team_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc351e8) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_iPRHealth RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1635F9 + 2, C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163625 + 2, C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163675 + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1635F9) + 2, C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x163625) + 2, C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163675) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_iPRHealth
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc35260, C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc35260 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc35260), C_PlayerResource_OriginalSize + PlayerResource_PRHealth_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc35260) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_bConnected RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1636A9 + 2, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1636D5 + 2, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163725 + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1636A9) + 2, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1636D5) + 2, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163725) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_bConnected
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc352d8, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc352d8 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc352d8), C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc352d8) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_bAlive RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163759 + 2, C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163785 + 2, C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1637D5 + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163759) + 2, C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163785) + 2, C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1637D5) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_bAlive
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc35350, C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc35350 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc35350), C_PlayerResource_OriginalSize + PlayerResource_Alive_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc35350) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_boolStats RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163809 + 2, C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163835 + 2, C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163885 + 5, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x163809) + 2, C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x163835) + 2, C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163885) + 5, NEW_MAX_PLAYERS + 1);
 
 	// C_PlayerResource::m_boolStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc353c8, C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc353c8 + 4, NEW_MAX_PLAYERS + 1);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc353c8), C_PlayerResource_OriginalSize + PlayerResource_BoolStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc353c8) + 4, NEW_MAX_PLAYERS + 1);
 
 	// DT_PlayerResource::m_killStats RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1638B3 + 2, C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1638E5 + 2, C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163935 + 5, PlayerResource_KillStats_Length);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1638B3) + 2, C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x1638E5) + 2, C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x163935) + 5, PlayerResource_KillStats_Length);
 
 	// C_PlayerResource::m_killStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc35440, C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc35440 + 4, PlayerResource_KillStats_Length);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xc35440), C_PlayerResource_OriginalSize + PlayerResource_KillStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc35440) + 4, PlayerResource_KillStats_Length);
 
 	// DT_PlayerResource::m_scoreStats RecvProp
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163969 + 2, C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x163995 + 2, C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1639E5 + 5, PlayerResource_ScoreStats_Length);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x163969) + 2, C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x163995) + 2, C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1639E5) + 5, PlayerResource_ScoreStats_Length);
 
 	// C_PlayerResource::m_scoreStats
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xc354b8, C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
-	ChangeOffset<unsigned short>((char*)baseAddress + 0xc354b8 + 4, PlayerResource_ScoreStats_Length);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0xc354b8), C_PlayerResource_OriginalSize + PlayerResource_ScoreStats_Start);
+	ChangeOffset<uint16_t>(GET_OFFSET_PTR(uint16_t, baseAddress, 0xc354b8) + 4, PlayerResource_ScoreStats_Length);
 
 	// C_PlayerResource::GetPlayerName - change m_bConnected address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164599 + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x164599) + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// C_PlayerResource::GetPlayerName2 (?) - change m_bConnected address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164629 + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x164629) + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// C_PlayerResource::GetPlayerName internal func - change m_bConnected address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164B13 + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x164B13) + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// Some other get name func (that seems to be unused) - change m_bConnected address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164860 + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x164860) + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
 	// Some other get name func 2 (that seems to be unused too) - change m_bConnected address
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x164834 + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
+	ChangeOffset<uint32_t>(
+		GET_OFFSET_PTR(uint32_t, baseAddress, 0x164834) + 3, C_PlayerResource_OriginalSize + PlayerResource_Connected_Start);
 
-	*(DWORD*)((char*)baseAddress + 0xC35068) = 0;
-	auto DT_PlayerResource_Construct = (__int64(__fastcall*)())((char*)baseAddress + 0x163400);
+	*(DWORD*)(GET_OFFSET_PTR(void, baseAddress, 0xC35068)) = 0;
+	auto DT_PlayerResource_Construct = (__int64(__fastcall*)())(GET_OFFSET_PTR(void, baseAddress, 0x163400));
 	DT_PlayerResource_Construct();
 
 	constexpr int C_Team_OriginalSize = 3200;
@@ -663,20 +706,21 @@ void InitialiseMaxPlayersOverride_Client(HMODULE baseAddress)
 	constexpr int C_Team_ModifiedSize = C_Team_OriginalSize + C_Team_AddedSize;
 
 	// C_Team class allocation function - allocate a bigger amount to fit all new team player data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x182321 + 1, C_Team_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x182321) + 1, C_Team_ModifiedSize);
 
 	// C_Team::C_Team - increase memset length to clean newly allocated data
-	ChangeOffset<unsigned int>((char*)baseAddress + 0x1804A2 + 2, 256 + C_Team_AddedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0x1804A2) + 2, 256 + C_Team_AddedSize);
 
 	// DT_Team size
-	ChangeOffset<unsigned int>((char*)baseAddress + 0xC3AA0C, C_Team_ModifiedSize);
+	ChangeOffset<uint32_t>(GET_OFFSET_PTR(uint32_t, baseAddress, 0xC3AA0C), C_Team_ModifiedSize);
 
 	// hook required to change the size of DT_Team::"player_array"
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1CEDA0, &RecvPropArray2_Hook, reinterpret_cast<LPVOID*>(&RecvPropArray2_Original));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x1CEDA0), &RecvPropArray2_Hook, reinterpret_cast<LPVOID*>(&RecvPropArray2_Original));
 	hook.~HookEnabler(); // force hook before calling construct function
 
-	*(DWORD*)((char*)baseAddress + 0xC3AFF8) = 0;
-	auto DT_Team_Construct = (__int64(__fastcall*)())((char*)baseAddress + 0x17F950);
+	*(DWORD*)(GET_OFFSET_PTR(void, baseAddress, 0xC3AFF8)) = 0;
+	auto DT_Team_Construct = (__int64(__fastcall*)())(GET_OFFSET_PTR(void, baseAddress, 0x17F950));
 	DT_Team_Construct();
 }

--- a/NorthstarDedicatedTest/miscclientfixes.cpp
+++ b/NorthstarDedicatedTest/miscclientfixes.cpp
@@ -37,13 +37,19 @@ void InitialiseMiscClientFixes(HMODULE baseAddress)
 	// vanilla compatibility to a degree tho will say i have about 0 clue what exactly these functions do, testing this it doesn't even seem
 	// like they do much of anything i can see tbh
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x5A92D0, &CrashingWeaponActivityFunc0Hook, reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc0));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x5A92D0),
+		&CrashingWeaponActivityFunc0Hook,
+		reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc0));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x5A9310, &CrashingWeaponActivityFunc1Hook, reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc1));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x5A9310),
+		&CrashingWeaponActivityFunc1Hook,
+		reinterpret_cast<LPVOID*>(&CrashingWeaponActivityFunc1));
 
 	// experimental: allow cl_extrapolate to be enabled without cheats
 	{
-		void* ptr = (char*)baseAddress + 0x275F9D9;
+		void* ptr = GET_OFFSET_PTR(void, baseAddress, 0x275F9D9);
 		*((char*)ptr) = (char)0;
 	}
 }

--- a/NorthstarDedicatedTest/miscserverfixes.cpp
+++ b/NorthstarDedicatedTest/miscserverfixes.cpp
@@ -128,5 +128,6 @@ static unsigned int CLZSS__SafeUncompressHook(void* self, const unsigned char* p
 void InitialiseMiscEngineServerFixes(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x432a10, &CLZSS__SafeUncompressHook, reinterpret_cast<LPVOID*>(&CLZSS__SafeUncompress));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x432a10), &CLZSS__SafeUncompressHook, reinterpret_cast<LPVOID*>(&CLZSS__SafeUncompress));
 }

--- a/NorthstarDedicatedTest/modlocalisation.cpp
+++ b/NorthstarDedicatedTest/modlocalisation.cpp
@@ -33,5 +33,6 @@ bool AddLocalisationFileHook(void* g_pVguiLocalize, const char* path, const char
 void InitialiseModLocalisation(HMODULE baseAddress)
 {
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x6D80, AddLocalisationFileHook, reinterpret_cast<LPVOID*>(&AddLocalisationFile));
+	ENABLER_CREATEHOOK(
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x6D80), AddLocalisationFileHook, reinterpret_cast<LPVOID*>(&AddLocalisationFile));
 }

--- a/NorthstarDedicatedTest/pch.h
+++ b/NorthstarDedicatedTest/pch.h
@@ -46,3 +46,9 @@ template <typename T, size_t index, typename... Args> constexpr T CallVFunc_Alt(
 	}
 
 #endif
+
+// Example usage: GET_OFFSET(int, playerPtr, 0x69) translates to *(int*)((uintptr_t)playerPtr + 0x69)
+#define GET_OFFSET(type, ptr, offset) (*(type*)(uintptr_t(ptr) + offset))
+
+// Just like GET_OFFSET, but doesn't dereference
+#define GET_OFFSET_PTR(type, ptr, offset) ((type*)(uintptr_t(ptr) + offset))

--- a/NorthstarDedicatedTest/playlist.cpp
+++ b/NorthstarDedicatedTest/playlist.cpp
@@ -85,13 +85,25 @@ void InitialisePlaylistHooks(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x222180, &Onclc_SetPlaylistVarOverrideHook, reinterpret_cast<LPVOID*>(&Onclc_SetPlaylistVarOverride));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x222180),
+		&Onclc_SetPlaylistVarOverrideHook,
+		reinterpret_cast<LPVOID*>(&Onclc_SetPlaylistVarOverride));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x18ED00, &SetPlaylistVarOverrideHook, reinterpret_cast<LPVOID*>(&SetPlaylistVarOverrideOriginal));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x18ED00),
+		&SetPlaylistVarOverrideHook,
+		reinterpret_cast<LPVOID*>(&SetPlaylistVarOverrideOriginal));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x18C680, &GetCurrentPlaylistVarHook, reinterpret_cast<LPVOID*>(&GetCurrentPlaylistVarOriginal));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x18C680),
+		&GetCurrentPlaylistVarHook,
+		reinterpret_cast<LPVOID*>(&GetCurrentPlaylistVarOriginal));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x18C430, &GetCurrentGamemodeMaxPlayersHook, reinterpret_cast<LPVOID*>(&GetCurrentGamemodeMaxPlayers));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x18C430),
+		&GetCurrentGamemodeMaxPlayersHook,
+		reinterpret_cast<LPVOID*>(&GetCurrentGamemodeMaxPlayers));
 
 	uintptr_t ba = (uintptr_t)baseAddress;
 

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -234,8 +234,8 @@ void InitialiseEngineRpakFilesystem(HMODULE baseAddress)
 {
 	g_PakLoadManager = new PakLoadManager;
 
-	g_pakLoadApi = *(PakLoadFuncs**)((char*)baseAddress + 0x5BED78);
-	pUnknownPakLoadSingleton = (void**)((char*)baseAddress + 0x7C5E20);
+	g_pakLoadApi = *(PakLoadFuncs**)(GET_OFFSET_PTR(void, baseAddress, 0x5BED78));
+	pUnknownPakLoadSingleton = (void**)(GET_OFFSET_PTR(void, baseAddress, 0x7C5E20));
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, g_pakLoadApi->LoadPakSync, &LoadPakSyncHook, reinterpret_cast<LPVOID*>(&LoadPakSyncOriginal));

--- a/NorthstarDedicatedTest/scriptbrowserhooks.cpp
+++ b/NorthstarDedicatedTest/scriptbrowserhooks.cpp
@@ -23,5 +23,5 @@ void InitialiseScriptExternalBrowserHooks(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x184E40, &OpenExternalWebBrowserHook, reinterpret_cast<LPVOID*>(&OpenExternalWebBrowser));
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x184E40), &OpenExternalWebBrowserHook, reinterpret_cast<LPVOID*>(&OpenExternalWebBrowser));
 }

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -682,25 +682,44 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x114430, &CBaseServer__ConnectClientHook, reinterpret_cast<LPVOID*>(&CBaseServer__ConnectClient));
-	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x101740, &CBaseClient__ConnectHook, reinterpret_cast<LPVOID*>(&CBaseClient__Connect));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x114430),
+		&CBaseServer__ConnectClientHook,
+		reinterpret_cast<LPVOID*>(&CBaseServer__ConnectClient));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x100F80, &CBaseClient__ActivatePlayerHook, reinterpret_cast<LPVOID*>(&CBaseClient__ActivatePlayer));
-	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x1012C0, &CBaseClient__DisconnectHook, reinterpret_cast<LPVOID*>(&CBaseClient__Disconnect));
+		hook, GET_OFFSET_PTR(void, baseAddress, 0x101740), &CBaseClient__ConnectHook, reinterpret_cast<LPVOID*>(&CBaseClient__Connect));
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x1022E0,
+		GET_OFFSET_PTR(void, baseAddress, 0x100F80),
+		&CBaseClient__ActivatePlayerHook,
+		reinterpret_cast<LPVOID*>(&CBaseClient__ActivatePlayer));
+	ENABLER_CREATEHOOK(
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x1012C0),
+		&CBaseClient__DisconnectHook,
+		reinterpret_cast<LPVOID*>(&CBaseClient__Disconnect));
+	ENABLER_CREATEHOOK(
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x1022E0),
 		&CGameClient__ExecuteStringCommandHook,
 		reinterpret_cast<LPVOID*>(&CGameClient__ExecuteStringCommand));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x2140A0, &CNetChan___ProcessMessagesHook, reinterpret_cast<LPVOID*>(&CNetChan___ProcessMessages));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x2140A0),
+		&CNetChan___ProcessMessagesHook,
+		reinterpret_cast<LPVOID*>(&CNetChan___ProcessMessages));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x104FB0, &CBaseClient__SendServerInfoHook, reinterpret_cast<LPVOID*>(&CBaseClient__SendServerInfo));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x104FB0),
+		&CBaseClient__SendServerInfoHook,
+		reinterpret_cast<LPVOID*>(&CBaseClient__SendServerInfo));
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x117800, &ProcessConnectionlessPacketHook, reinterpret_cast<LPVOID*>(&ProcessConnectionlessPacket));
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x117800),
+		&ProcessConnectionlessPacketHook,
+		reinterpret_cast<LPVOID*>(&ProcessConnectionlessPacket));
 
-	CCommand__Tokenize = (CCommand__TokenizeType)((char*)baseAddress + 0x418380);
+	CCommand__Tokenize = (CCommand__TokenizeType)(GET_OFFSET_PTR(void, baseAddress, 0x418380));
 
 	uintptr_t ba = (uintptr_t)baseAddress;
 

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -172,24 +172,24 @@ SQRESULT SQ_BroadcastMessage(void* sqvm)
 
 void InitialiseServerChatHooks_Engine(HMODULE baseAddress)
 {
-	g_pServerGameDLL = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98);
+	g_pServerGameDLL = (CServerGameDLL*)(GET_OFFSET_PTR(void, baseAddress, 0x13F0AA98));
 }
 
 void InitialiseServerChatHooks_Server(HMODULE baseAddress)
 {
-	CServerGameDLL__OnReceivedSayTextMessage = (CServerGameDLL__OnReceivedSayTextMessageType)((char*)baseAddress + 0x1595C0);
-	UTIL_PlayerByIndex = (UTIL_PlayerByIndexType)((char*)baseAddress + 0x26AA10);
-	CRecipientFilter__Construct = (CRecipientFilter__ConstructType)((char*)baseAddress + 0x1E9440);
-	CRecipientFilter__Destruct = (CRecipientFilter__DestructType)((char*)baseAddress + 0x1E9700);
-	CRecipientFilter__AddAllPlayers = (CRecipientFilter__AddAllPlayersType)((char*)baseAddress + 0x1E9940);
-	CRecipientFilter__AddRecipient = (CRecipientFilter__AddRecipientType)((char*)baseAddress + 0x1E9b30);
-	CRecipientFilter__MakeReliable = (CRecipientFilter__MakeReliableType)((char*)baseAddress + 0x1EA4E0);
+	CServerGameDLL__OnReceivedSayTextMessage = (CServerGameDLL__OnReceivedSayTextMessageType)(GET_OFFSET_PTR(void, baseAddress, 0x1595C0));
+	UTIL_PlayerByIndex = (UTIL_PlayerByIndexType)(GET_OFFSET_PTR(void, baseAddress, 0x26AA10));
+	CRecipientFilter__Construct = (CRecipientFilter__ConstructType)(GET_OFFSET_PTR(void, baseAddress, 0x1E9440));
+	CRecipientFilter__Destruct = (CRecipientFilter__DestructType)(GET_OFFSET_PTR(void, baseAddress, 0x1E9700));
+	CRecipientFilter__AddAllPlayers = (CRecipientFilter__AddAllPlayersType)(GET_OFFSET_PTR(void, baseAddress, 0x1E9940));
+	CRecipientFilter__AddRecipient = (CRecipientFilter__AddRecipientType)(GET_OFFSET_PTR(void, baseAddress, 0x1E9b30));
+	CRecipientFilter__MakeReliable = (CRecipientFilter__MakeReliableType)(GET_OFFSET_PTR(void, baseAddress, 0x1EA4E0));
 
-	UserMessageBegin = (UserMessageBeginType)((char*)baseAddress + 0x15C520);
-	MessageEnd = (MessageEndType)((char*)baseAddress + 0x158880);
-	MessageWriteByte = (MessageWriteByteType)((char*)baseAddress + 0x158A90);
-	MessageWriteString = (MessageWriteStringType)((char*)baseAddress + 0x158D00);
-	MessageWriteBool = (MessageWriteBoolType)((char*)baseAddress + 0x158A00);
+	UserMessageBegin = (UserMessageBeginType)(GET_OFFSET_PTR(void, baseAddress, 0x15C520));
+	MessageEnd = (MessageEndType)(GET_OFFSET_PTR(void, baseAddress, 0x158880));
+	MessageWriteByte = (MessageWriteByteType)(GET_OFFSET_PTR(void, baseAddress, 0x158A90));
+	MessageWriteString = (MessageWriteStringType)(GET_OFFSET_PTR(void, baseAddress, 0x158D00));
+	MessageWriteBool = (MessageWriteBoolType)(GET_OFFSET_PTR(void, baseAddress, 0x158A00));
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(

--- a/NorthstarDedicatedTest/squirrel.cpp
+++ b/NorthstarDedicatedTest/squirrel.cpp
@@ -107,7 +107,7 @@ void InitialiseClientSquirrel(HMODULE baseAddress)
 
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x12B00,
+		GET_OFFSET_PTR(void, baseAddress, 0x12B00),
 		&SQPrintHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientSQPrint)); // client print function
 	RegisterConCommand(
@@ -117,49 +117,52 @@ void InitialiseClientSquirrel(HMODULE baseAddress)
 	g_UISquirrelManager = new SquirrelManager<ScriptContext::UI>();
 
 	ENABLER_CREATEHOOK(
-		hook, (char*)baseAddress + 0x12BA0, &SQPrintHook<ScriptContext::UI>, reinterpret_cast<LPVOID*>(&UISQPrint)); // ui print function
+		hook,
+		GET_OFFSET_PTR(void, baseAddress, 0x12BA0),
+		&SQPrintHook<ScriptContext::UI>,
+		reinterpret_cast<LPVOID*>(&UISQPrint)); // ui print function
 	RegisterConCommand("script_ui", ExecuteCodeCommand<ScriptContext::UI>, "Executes script code on the ui vm", FCVAR_CLIENTDLL);
 
 	// inits for both client and ui, since they share some functions
-	ClientSq_compilebuffer = (sq_compilebufferType)((char*)baseAddress + 0x3110);
-	ClientSq_pushroottable = (sq_pushroottableType)((char*)baseAddress + 0x5860);
-	ClientSq_call = (sq_callType)((char*)baseAddress + 0x8650);
-	ClientRegisterSquirrelFunc = (RegisterSquirrelFuncType)((char*)baseAddress + 0x108E0);
+	ClientSq_compilebuffer = (sq_compilebufferType)(GET_OFFSET_PTR(void, baseAddress, 0x3110));
+	ClientSq_pushroottable = (sq_pushroottableType)(GET_OFFSET_PTR(void, baseAddress, 0x5860));
+	ClientSq_call = (sq_callType)(GET_OFFSET_PTR(void, baseAddress, 0x8650));
+	ClientRegisterSquirrelFunc = (RegisterSquirrelFuncType)(GET_OFFSET_PTR(void, baseAddress, 0x108E0));
 
-	ClientSq_newarray = (sq_newarrayType)((char*)baseAddress + 0x39F0);
-	ClientSq_arrayappend = (sq_arrayappendType)((char*)baseAddress + 0x3C70);
+	ClientSq_newarray = (sq_newarrayType)(GET_OFFSET_PTR(void, baseAddress, 0x39F0));
+	ClientSq_arrayappend = (sq_arrayappendType)(GET_OFFSET_PTR(void, baseAddress, 0x3C70));
 
-	ClientSq_pushstring = (sq_pushstringType)((char*)baseAddress + 0x3440);
-	ClientSq_pushinteger = (sq_pushintegerType)((char*)baseAddress + 0x36A0);
-	ClientSq_pushfloat = (sq_pushfloatType)((char*)baseAddress + 0x3800);
-	ClientSq_pushbool = (sq_pushboolType)((char*)baseAddress + 0x3710);
-	ClientSq_pusherror = (sq_pusherrorType)((char*)baseAddress + 0x8470);
+	ClientSq_pushstring = (sq_pushstringType)(GET_OFFSET_PTR(void, baseAddress, 0x3440));
+	ClientSq_pushinteger = (sq_pushintegerType)(GET_OFFSET_PTR(void, baseAddress, 0x36A0));
+	ClientSq_pushfloat = (sq_pushfloatType)(GET_OFFSET_PTR(void, baseAddress, 0x3800));
+	ClientSq_pushbool = (sq_pushboolType)(GET_OFFSET_PTR(void, baseAddress, 0x3710));
+	ClientSq_pusherror = (sq_pusherrorType)(GET_OFFSET_PTR(void, baseAddress, 0x8470));
 
-	ClientSq_getstring = (sq_getstringType)((char*)baseAddress + 0x60C0);
-	ClientSq_getinteger = (sq_getintegerType)((char*)baseAddress + 0x60E0);
-	ClientSq_getfloat = (sq_getfloatType)((char*)baseAddress + 0x6100);
-	ClientSq_getbool = (sq_getboolType)((char*)baseAddress + 0x6130);
+	ClientSq_getstring = (sq_getstringType)(GET_OFFSET_PTR(void, baseAddress, 0x60C0));
+	ClientSq_getinteger = (sq_getintegerType)(GET_OFFSET_PTR(void, baseAddress, 0x60E0));
+	ClientSq_getfloat = (sq_getfloatType)(GET_OFFSET_PTR(void, baseAddress, 0x6100));
+	ClientSq_getbool = (sq_getboolType)(GET_OFFSET_PTR(void, baseAddress, 0x6130));
 
-	ClientSq_sq_get = (sq_getType)((char*)baseAddress + 0x7C30);
+	ClientSq_sq_get = (sq_getType)(GET_OFFSET_PTR(void, baseAddress, 0x7C30));
 
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x26130,
+		GET_OFFSET_PTR(void, baseAddress, 0x26130),
 		&CreateNewVMHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientCreateNewVM)); // client createnewvm function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x26E70,
+		GET_OFFSET_PTR(void, baseAddress, 0x26E70),
 		&DestroyVMHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientDestroyVM)); // client destroyvm function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x79A50,
+		GET_OFFSET_PTR(void, baseAddress, 0x79A50),
 		&ScriptCompileErrorHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientSQCompileError)); // client compileerror function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x10190,
+		GET_OFFSET_PTR(void, baseAddress, 0x10190),
 		&CallScriptInitCallbackHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientCallScriptInitCallback)); // client callscriptinitcallback function
 }
@@ -170,50 +173,50 @@ void InitialiseServerSquirrel(HMODULE baseAddress)
 
 	HookEnabler hook;
 
-	ServerSq_compilebuffer = (sq_compilebufferType)((char*)baseAddress + 0x3110);
-	ServerSq_pushroottable = (sq_pushroottableType)((char*)baseAddress + 0x5840);
-	ServerSq_call = (sq_callType)((char*)baseAddress + 0x8620);
-	ServerRegisterSquirrelFunc = (RegisterSquirrelFuncType)((char*)baseAddress + 0x1DD10);
+	ServerSq_compilebuffer = (sq_compilebufferType)(GET_OFFSET_PTR(void, baseAddress, 0x3110));
+	ServerSq_pushroottable = (sq_pushroottableType)(GET_OFFSET_PTR(void, baseAddress, 0x5840));
+	ServerSq_call = (sq_callType)(GET_OFFSET_PTR(void, baseAddress, 0x8620));
+	ServerRegisterSquirrelFunc = (RegisterSquirrelFuncType)(GET_OFFSET_PTR(void, baseAddress, 0x1DD10));
 
-	ServerSq_newarray = (sq_newarrayType)((char*)baseAddress + 0x39F0);
-	ServerSq_arrayappend = (sq_arrayappendType)((char*)baseAddress + 0x3C70);
+	ServerSq_newarray = (sq_newarrayType)(GET_OFFSET_PTR(void, baseAddress, 0x39F0));
+	ServerSq_arrayappend = (sq_arrayappendType)(GET_OFFSET_PTR(void, baseAddress, 0x3C70));
 
-	ServerSq_pushstring = (sq_pushstringType)((char*)baseAddress + 0x3440);
-	ServerSq_pushinteger = (sq_pushintegerType)((char*)baseAddress + 0x36A0);
-	ServerSq_pushfloat = (sq_pushfloatType)((char*)baseAddress + 0x3800);
-	ServerSq_pushbool = (sq_pushboolType)((char*)baseAddress + 0x3710);
-	ServerSq_pusherror = (sq_pusherrorType)((char*)baseAddress + 0x8440);
+	ServerSq_pushstring = (sq_pushstringType)(GET_OFFSET_PTR(void, baseAddress, 0x3440));
+	ServerSq_pushinteger = (sq_pushintegerType)(GET_OFFSET_PTR(void, baseAddress, 0x36A0));
+	ServerSq_pushfloat = (sq_pushfloatType)(GET_OFFSET_PTR(void, baseAddress, 0x3800));
+	ServerSq_pushbool = (sq_pushboolType)(GET_OFFSET_PTR(void, baseAddress, 0x3710));
+	ServerSq_pusherror = (sq_pusherrorType)(GET_OFFSET_PTR(void, baseAddress, 0x8440));
 
-	ServerSq_getstring = (sq_getstringType)((char*)baseAddress + 0x60A0);
-	ServerSq_getinteger = (sq_getintegerType)((char*)baseAddress + 0x60C0);
-	ServerSq_getfloat = (sq_getfloatType)((char*)baseAddress + 0x60E0);
-	ServerSq_getbool = (sq_getboolType)((char*)baseAddress + 0x6110);
+	ServerSq_getstring = (sq_getstringType)(GET_OFFSET_PTR(void, baseAddress, 0x60A0));
+	ServerSq_getinteger = (sq_getintegerType)(GET_OFFSET_PTR(void, baseAddress, 0x60C0));
+	ServerSq_getfloat = (sq_getfloatType)(GET_OFFSET_PTR(void, baseAddress, 0x60E0));
+	ServerSq_getbool = (sq_getboolType)(GET_OFFSET_PTR(void, baseAddress, 0x6110));
 
-	ServerSq_sq_get = (sq_getType)((char*)baseAddress + 0x7C00);
+	ServerSq_sq_get = (sq_getType)(GET_OFFSET_PTR(void, baseAddress, 0x7C00));
 
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x1FE90,
+		GET_OFFSET_PTR(void, baseAddress, 0x1FE90),
 		&SQPrintHook<ScriptContext::SERVER>,
 		reinterpret_cast<LPVOID*>(&ServerSQPrint)); // server print function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x260E0,
+		GET_OFFSET_PTR(void, baseAddress, 0x260E0),
 		&CreateNewVMHook<ScriptContext::SERVER>,
 		reinterpret_cast<LPVOID*>(&ServerCreateNewVM)); // server createnewvm function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x26E20,
+		GET_OFFSET_PTR(void, baseAddress, 0x26E20),
 		&DestroyVMHook<ScriptContext::SERVER>,
 		reinterpret_cast<LPVOID*>(&ServerDestroyVM)); // server destroyvm function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x799E0,
+		GET_OFFSET_PTR(void, baseAddress, 0x799E0),
 		&ScriptCompileErrorHook<ScriptContext::SERVER>,
 		reinterpret_cast<LPVOID*>(&ServerSQCompileError)); // server compileerror function
 	ENABLER_CREATEHOOK(
 		hook,
-		(char*)baseAddress + 0x1D5C0,
+		GET_OFFSET_PTR(void, baseAddress, 0x1D5C0),
 		&CallScriptInitCallbackHook<ScriptContext::SERVER>,
 		reinterpret_cast<LPVOID*>(&ServerCallScriptInitCallback)); // server callscriptinitcallback function
 


### PR DESCRIPTION
A lot of code in northstar seems to use this really ugly format of `(type*)((char*)address + offset)` or whatever.

I made two simple macros to make it simpler and more readable to convert/interpret pointers at offsets and replaced the vast majority of the goofy `(char*)` offsets with them.