### PR TITLE
NSMem Improvements

### DIFF
--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -145,7 +145,16 @@ bool NSMem::IsMemoryReadable(void* ptr, size_t size)
 
 bool KHook::Setup()
 {
-	targetFuncAddr = NSMem::PatternScan(targetFunc.moduleName, targetFunc.pattern, targetFunc.offset);
+	if (targetFunc.IsPatternScan())
+	{
+		targetFuncAddr = NSMem::PatternScan(targetFunc.moduleName, targetFunc.pattern, targetFunc.offset);
+	}
+	else
+	{
+		targetFuncAddr = NSMem::GetOffsetPtr<void*>(GetModuleHandleA(targetFunc.moduleName), targetFunc.offset);
+	}
+	
+
 	if (!targetFuncAddr)
 		return false;
 

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -1,0 +1,1 @@
+#include "NSMem.h"

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "NSMem.h"
 
-std::vector<int> NSMem::HexBytesToString(const char* str)
+std::vector<int> NSMem::StringToHexBytes(const char* str)
 {
 	std::vector<int> patternNums;
 	int size = strlen(str);
@@ -90,7 +90,7 @@ void* NSMem::PatternScan(void* module, const int* pattern, int patternSize, int 
 
 void* NSMem::PatternScan(const char* moduleName, const char* pattern, int offset)
 {
-	std::vector<int> patternNums = HexBytesToString(pattern);
+	std::vector<int> patternNums = StringToHexBytes(pattern);
 
 	return PatternScan(GetModuleHandleA(moduleName), &patternNums[0], patternNums.size(), offset);
 }
@@ -109,7 +109,7 @@ void NSMem::BytePatch(uintptr_t address, std::initializer_list<BYTE> vals)
 
 void NSMem::BytePatch(uintptr_t address, const char* bytesStr)
 {
-	std::vector<int> byteInts = HexBytesToString(bytesStr);
+	std::vector<int> byteInts = StringToHexBytes(bytesStr);
 	std::vector<BYTE> bytes;
 	for (int v : byteInts)
 		bytes.push_back(v);

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -63,6 +63,7 @@ void BuildFunctionAddressList(uintptr_t textSectionStart, size_t textSectionSize
 
 	bool inFunction = false;
 
+	BYTE last = 0;
 	for (uintptr_t curAddr = textSectionStart; curAddr < textSectionStart + textSectionSize; curAddr++)
 	{
 		BYTE b = *(BYTE*)curAddr;
@@ -75,6 +76,10 @@ void BuildFunctionAddressList(uintptr_t textSectionStart, size_t textSectionSize
 			{
 				inFunction = false;
 			}
+			else if (b == 0xCC && last == 0xCC) // This is almost certainly padding between functions
+			{
+				inFunction = false;
+			}
 		}
 		else
 		{
@@ -83,6 +88,8 @@ void BuildFunctionAddressList(uintptr_t textSectionStart, size_t textSectionSize
 			inFunction = true;
 			addressCacheOut.push_back(curAddr);
 		}
+
+		last = b;
 	}
 
 	spdlog::debug(
@@ -161,7 +168,7 @@ void* NSMem::PatternScan(const char* moduleName, const char* pattern, int offset
 	auto result = PatternScan(GetModuleHandleA(moduleName), &patternNums[0], patternNums.size(), offset);
 	uint64_t timeTaken = GetTickCount64() - start;
 
-	spdlog::debug("Found pattern in {}ms: \t\"{}\"", timeTaken, pattern);
+	spdlog::debug("Found pattern in {}ms: \"{}\"", timeTaken, pattern);
 	return result;
 }
 

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -154,7 +154,6 @@ bool KHook::Setup()
 		targetFuncAddr = NSMem::GetOffsetPtr<void*>(GetModuleHandleA(targetFunc.moduleName), targetFunc.offset);
 	}
 	
-
 	if (!targetFuncAddr)
 		return false;
 

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -1,1 +1,144 @@
+#include "pch.h"
 #include "NSMem.h"
+
+std::vector<int> NSMem::HexBytesToString(const char* str)
+{
+	std::vector<int> patternNums;
+	int size = strlen(str);
+	for (int i = 0; i < size; i++)
+	{
+		char c = str[i];
+
+		// If this is a space character, ignore it
+		if (c == ' ' || c == '\t')
+			continue;
+
+		if (c == '?')
+		{
+			// Add a wildcard (-1)
+			patternNums.push_back(-1);
+		}
+		else if (i < size - 1)
+		{
+			BYTE result = 0;
+			for (int j = 0; j < 2; j++)
+			{
+				int val = 0;
+				char c = *(str + i + j);
+				if (c >= 'a')
+				{
+					val = c - 'a' + 0xA;
+				}
+				else if (c >= 'A')
+				{
+					val = c - 'A' + 0xA;
+				}
+				else if (isdigit(c))
+				{
+					val = c - '0';
+				}
+				else
+				{
+					assert(false, "Failed to parse invalid hex string.");
+					val = -1;
+				}
+
+				result += (j == 0) ? val * 16 : val;
+			}
+			patternNums.push_back(result);
+		}
+
+		i++;
+	}
+
+	return patternNums;
+}
+
+void* NSMem::PatternScan(void* module, const int* pattern, int patternSize, int offset)
+{
+	if (!module)
+		return NULL;
+
+	auto dosHeader = (PIMAGE_DOS_HEADER)module;
+	auto ntHeaders = (PIMAGE_NT_HEADERS)((BYTE*)module + dosHeader->e_lfanew);
+
+	auto sizeOfImage = ntHeaders->OptionalHeader.SizeOfImage;
+
+	auto scanBytes = (BYTE*)module;
+
+	for (auto i = 0; i < sizeOfImage - patternSize; ++i)
+	{
+		bool found = true;
+		for (auto j = 0; j < patternSize; ++j)
+		{
+			if (scanBytes[i + j] != pattern[j] && pattern[j] != -1)
+			{
+				found = false;
+				break;
+			}
+		}
+
+		if (found)
+		{
+			uintptr_t addressInt = (uintptr_t)(&scanBytes[i]) + offset;
+			return (uint8_t*)addressInt;
+		}
+	}
+
+	return nullptr;
+}
+
+void* NSMem::PatternScan(const char* moduleName, const char* pattern, int offset)
+{
+	std::vector<int> patternNums = HexBytesToString(pattern);
+
+	return PatternScan(GetModuleHandleA(moduleName), &patternNums[0], patternNums.size(), offset);
+}
+
+void NSMem::BytePatch(uintptr_t address, const BYTE* vals, int size)
+{
+	WriteProcessMemory(GetCurrentProcess(), (LPVOID)address, vals, size, NULL);
+}
+
+void NSMem::BytePatch(uintptr_t address, std::initializer_list<BYTE> vals)
+{
+	std::vector<BYTE> bytes = vals;
+	if (!bytes.empty())
+		BytePatch(address, &bytes[0], bytes.size());
+}
+
+void NSMem::BytePatch(uintptr_t address, const char* bytesStr)
+{
+	std::vector<int> byteInts = HexBytesToString(bytesStr);
+	std::vector<BYTE> bytes;
+	for (int v : byteInts)
+		bytes.push_back(v);
+
+	if (!bytes.empty())
+		BytePatch(address, &bytes[0], bytes.size());
+}
+
+void NSMem::NOP(uintptr_t address, int size)
+{
+	BYTE* buf = (BYTE*)malloc(size);
+	memset(buf, 0x90, size);
+	BytePatch(address, buf, size);
+	free(buf);
+}
+
+bool NSMem::IsMemoryReadable(void* ptr, size_t size)
+{
+	static SYSTEM_INFO sysInfo;
+	if (!sysInfo.dwPageSize)
+		GetSystemInfo(&sysInfo); // This should always be 4096 unless ur playing on NES or some shit but whatever
+
+	MEMORY_BASIC_INFORMATION memInfo;
+
+	if (!VirtualQuery(ptr, &memInfo, sizeof(memInfo)))
+		return false;
+
+	if (memInfo.RegionSize < size)
+		return false;
+
+	return (memInfo.State & MEM_COMMIT) && !(memInfo.Protect & PAGE_NOACCESS);
+}

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -142,3 +142,30 @@ bool NSMem::IsMemoryReadable(void* ptr, size_t size)
 
 	return (memInfo.State & MEM_COMMIT) && !(memInfo.Protect & PAGE_NOACCESS);
 }
+
+bool KHook::Setup()
+{
+	targetFuncAddr = NSMem::PatternScan(targetFunc.moduleName, targetFunc.pattern, targetFunc.offset);
+	if (!targetFuncAddr)
+		return false;
+
+	return MH_CreateHook(targetFuncAddr, hookFunc, original) == MH_OK;
+}
+
+bool KHook::InitAllHooks()
+{
+
+	for (KHook* hook : _allHooks)
+	{
+		if (hook->Setup())
+		{
+			spdlog::info("KHook hooked at {}", hook->targetFuncAddr);
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	return MH_EnableHook(MH_ALL_HOOKS) == MH_OK;
+}

--- a/NorthstarDedicatedTest/NSMem.cpp
+++ b/NorthstarDedicatedTest/NSMem.cpp
@@ -153,7 +153,7 @@ bool KHook::Setup()
 	{
 		targetFuncAddr = NSMem::GetOffsetPtr<void*>(GetModuleHandleA(targetFunc.moduleName), targetFunc.offset);
 	}
-	
+
 	if (!targetFuncAddr)
 		return false;
 

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -145,6 +145,13 @@ struct KHook
 };
 
 // Convenient macro for initializing a KHook as a function declaration in a single line
+// Supports both pattern scans and static module offsets
+// 
+// EXAMPLE 1 (using pattern scan):
+//	KHOOK(GetPlayerName, { "engine.dll", "48 83 EC ? ? 28 48" }, const char*, __fastcall, (void* playerPtr)) { ...
+// 
+// EXAMPLE 2 (using a static module offset):
+//	KHOOK(Script_GetEntByIndex, { "server.dll", 0x2A8A50 }, void*, __fastcall, (int entityIndex)) { ...
 #define KHOOK(name, funcPatternInfo, returnType, convention, args)                                                                         \
 	returnType convention hk##name args;                                                                                                   \
 	auto o##name = (returnType(convention*) args)0;                                                                                        \

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -6,7 +6,7 @@
 #pragma region Pattern Scanning
 namespace NSMem
 {
-	std::vector<int> HexBytesToString(const char* str);
+	std::vector<int> StringToHexBytes(const char* str);
 
 	void* PatternScan(void* module, const int* pattern, int patternSize, int offset);
 

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -6,20 +6,64 @@
 #pragma region Pattern Scanning
 namespace NSMem
 {
+	// Returns an array of byte values from a hexadecimal string
+	// A byte value will be -1 where the input string contained a wildcard ('?')
 	std::vector<int> StringToHexBytes(const char* str);
 
+	/// <summary>
+	/// Find a byte pattern in a module (raw function alternative)
+	/// </summary>
+	/// <param name="module">Base address of the module (handle)</param>
+	/// <param name="pattern">Array of byte values to search for (-1 is for wildcard)</param>
+	/// <param name="patternSize">Size of the byte pattern array</param>
+	/// <param name="offset">Amount to shift output pointer address by</param>
+	/// <returns>Address of found result (+ offset), or NULL if not found</returns>
 	void* PatternScan(void* module, const int* pattern, int patternSize, int offset);
 
+	/// <summary>
+	/// Find a byte pattern in a module
+	/// </summary>
+	/// <param name="moduleName">Name of module, will be passed to GetModuleHandleA()</param>
+	/// <param name="pattern">The byte pattern to search for as a hex string (see StringToHexBytes())</param>
+	/// <param name="offset">Amount to shift output pointer address by</param>
+	/// <returns>Address of found result (+ offset), or NULL if not found</returns>
 	void* PatternScan(const char* moduleName, const char* pattern, int offset = 0);
 
+	/// <summary>
+	/// Byte patch memory at a given address
+	/// </summary>
+	/// <param name="address">Address to patch at</param>
+	/// <param name="vals">Array of byte values to replace with</param>
+	/// <param name="size">Size of byte value array</param>
 	void BytePatch(uintptr_t address, const BYTE* vals, int size);
 
+	/// <summary>
+	/// Byte patch memory at a given address
+	/// </summary>
+	/// <param name="address">Address to patch at</param>
+	/// <param name="vals">Initializer list of byte values to replace with</param>
 	void BytePatch(uintptr_t address, std::initializer_list<BYTE> vals);
 
+	/// <summary>
+	/// Byte patch memory at a given address
+	/// </summary>
+	/// <param name="address">Address to patch at</param>
+	/// <param name="bytesStr">Hex string of bytes to patch with (see StringToHexBytes())</param>
 	void BytePatch(uintptr_t address, const char* bytesStr);
 
+	/// <summary>
+	/// Byte patch instructions at a given address to NOP opcodes, making them do nothing
+	/// Functionally identical to using BytePatch(address, { 0x90, 0x90, 0x90, ... })
+	/// </summary>
+	/// <param name="address">Address to patch at</param>
+	/// <param name="size">Amount of bytes to patch</param>
 	void NOP(uintptr_t address, int size);
 
+	/// <summary>
+	/// Checks if we are able to read memory from a given address
+	/// </summary>
+	/// <param name="ptr">Address to check (start of region)</param>
+	/// <param name="size">Size of the region to check</param>
 	bool IsMemoryReadable(void* ptr, size_t size);
 } // namespace NSMem
 

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -68,6 +68,8 @@ namespace NSMem
 } // namespace NSMem
 
 #pragma region KHOOK
+// Info for KHook to use when finding where you would like to hook
+// Currently stores pattern scan information only
 struct KHookPatternInfo
 {
 	const char *moduleName, *pattern;
@@ -78,6 +80,8 @@ struct KHookPatternInfo
 	}
 };
 
+// General structure for creating a hook (function trampoline detour) at any function
+// Does not do anything until Setup() is called
 struct KHook
 {
 	KHookPatternInfo targetFunc;
@@ -85,8 +89,10 @@ struct KHook
 	void* hookFunc;
 	void** original;
 
+	// NOTE: This is not thread-safe, perhaps a std::mutex lock should be used (?)
 	static inline std::vector<KHook*> _allHooks;
 
+	// NOTE: Will add this instance to KHook::_allHooks after construction
 	KHook(KHookPatternInfo targetFunc, void* hookFunc, void** original) : targetFunc(targetFunc)
 	{
 		this->hookFunc = hookFunc;
@@ -121,6 +127,8 @@ struct KHook
 		return MH_EnableHook(MH_ALL_HOOKS) == MH_OK;
 	}
 };
+
+// Convenient macro for initializing a KHook as a function declaration in a single line
 #define KHOOK(name, funcPatternInfo, returnType, convention, args)                                                                         \
 	returnType convention hk##name args;                                                                                                   \
 	auto o##name = (returnType(convention*) args)0;                                                                                        \

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -65,6 +65,25 @@ namespace NSMem
 	/// <param name="ptr">Address to check (start of region)</param>
 	/// <param name="size">Size of the region to check</param>
 	bool IsMemoryReadable(void* ptr, size_t size);
+
+	/// <summary>
+	/// Offset a pointer and convert it to a type
+	/// </summary>
+	/// <returns>(T)(uintptr_t(base) + offset)</returns>
+	template <typename T> T GetOffsetPtr(void* base, int64_t offset)
+	{
+		return (T)(uintptr_t(base) + offset);
+	}
+
+	/// <summary>
+	/// Offset a pointer and dereference it as a type
+	/// </summary>
+	/// <returns>*(T*)(uintptr_t(base) + offset)</returns>
+	template <typename T> T& GetOffsetVal(void* base, int64_t offset)
+	{
+		return *(T*)(uintptr_t(base) + offset);
+	}
+
 } // namespace NSMem
 
 #pragma region KHOOK

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -92,10 +92,28 @@ namespace NSMem
 struct KHookPatternInfo
 {
 	const char *moduleName, *pattern;
-	int offset = 0;
 
-	KHookPatternInfo(const char* moduleName, const char* pattern, int offset = 0) : moduleName(moduleName), pattern(pattern), offset(offset)
+	// Will be used as static module offset if "pattern" is null
+	int64_t offset;
+
+	// Construct as a pattern scan
+	KHookPatternInfo(const char* moduleName, const char* pattern, int64_t offset = 0)
 	{
+		this->moduleName = moduleName;
+		this->pattern = pattern;
+		this->offset = offset;
+	}
+
+	// Construct as a static module offset
+	KHookPatternInfo(const char* moduleName, int64_t offset = 0)
+	{
+		this->moduleName = moduleName;
+		this->pattern = nullptr;
+		this->offset = offset;
+	}
+
+	bool IsPatternScan() {
+		return pattern != nullptr;
 	}
 };
 

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -89,7 +89,7 @@ namespace NSMem
 #pragma region KHOOK
 // Info for KHook to use when finding where you would like to hook
 // Currently stores pattern scan information only
-struct KHookPatternInfo
+struct KHookFuncInfo
 {
 	const char *moduleName, *pattern;
 
@@ -97,7 +97,7 @@ struct KHookPatternInfo
 	int64_t offset;
 
 	// Construct as a pattern scan
-	KHookPatternInfo(const char* moduleName, const char* pattern, int64_t offset = 0)
+	KHookFuncInfo(const char* moduleName, const char* pattern, int64_t offset = 0)
 	{
 		this->moduleName = moduleName;
 		this->pattern = pattern;
@@ -105,7 +105,7 @@ struct KHookPatternInfo
 	}
 
 	// Construct as a static module offset
-	KHookPatternInfo(const char* moduleName, int64_t offset = 0)
+	KHookFuncInfo(const char* moduleName, int64_t offset = 0)
 	{
 		this->moduleName = moduleName;
 		this->pattern = nullptr;
@@ -121,7 +121,7 @@ struct KHookPatternInfo
 // Does not do anything until Setup() is called
 struct KHook
 {
-	KHookPatternInfo targetFunc;
+	KHookFuncInfo targetFunc;
 	void* targetFuncAddr;
 	void* hookFunc;
 	void** original;
@@ -130,7 +130,7 @@ struct KHook
 	static inline std::vector<KHook*> _allHooks;
 
 	// NOTE: Will add this instance to KHook::_allHooks after construction
-	KHook(KHookPatternInfo targetFunc, void* hookFunc, void** original) : targetFunc(targetFunc)
+	KHook(KHookFuncInfo targetFunc, void* hookFunc, void** original) : targetFunc(targetFunc)
 	{
 		this->hookFunc = hookFunc;
 		this->original = original;
@@ -148,6 +148,6 @@ struct KHook
 #define KHOOK(name, funcPatternInfo, returnType, convention, args)                                                                         \
 	returnType convention hk##name args;                                                                                                   \
 	auto o##name = (returnType(convention*) args)0;                                                                                        \
-	KHook k##name = KHook(KHookPatternInfo funcPatternInfo, &hk##name, (void**)&o##name);                                                  \
+	KHook k##name = KHook(KHookFuncInfo funcPatternInfo, &hk##name, (void**)&o##name);                                                  \
 	returnType convention hk##name args
 #pragma endregion

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -119,32 +119,11 @@ struct KHook
 		_allHooks.push_back(this);
 	}
 
-	bool Setup()
-	{
-		targetFuncAddr = NSMem::PatternScan(targetFunc.moduleName, targetFunc.pattern, targetFunc.offset);
-		if (!targetFuncAddr)
-			return false;
-
-		return MH_CreateHook(targetFuncAddr, hookFunc, original) == MH_OK;
-	}
+	// Actually create/enable the hook
+	bool Setup();
 
 	// Returns true if succeeded
-	static bool InitAllHooks()
-	{
-		for (KHook* hook : _allHooks)
-		{
-			if (hook->Setup())
-			{
-				spdlog::info("KHook hooked at {}", hook->targetFuncAddr);
-			}
-			else
-			{
-				return false;
-			}
-		}
-
-		return MH_EnableHook(MH_ALL_HOOKS) == MH_OK;
-	}
+	static bool InitAllHooks();
 };
 
 // Convenient macro for initializing a KHook as a function declaration in a single line

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -112,7 +112,8 @@ struct KHookFuncInfo
 		this->offset = offset;
 	}
 
-	bool IsPatternScan() {
+	bool IsPatternScan()
+	{
 		return pattern != nullptr;
 	}
 };
@@ -146,15 +147,15 @@ struct KHook
 
 // Convenient macro for initializing a KHook as a function declaration in a single line
 // Supports both pattern scans and static module offsets
-// 
+//
 // EXAMPLE 1 (using pattern scan):
 //	KHOOK(GetPlayerName, { "engine.dll", "48 83 EC ? ? 28 48" }, const char*, __fastcall, (void* playerPtr)) { ...
-// 
+//
 // EXAMPLE 2 (using a static module offset):
 //	KHOOK(Script_GetEntByIndex, { "server.dll", 0x2A8A50 }, void*, __fastcall, (int entityIndex)) { ...
 #define KHOOK(name, funcPatternInfo, returnType, convention, args)                                                                         \
 	returnType convention hk##name args;                                                                                                   \
 	auto o##name = (returnType(convention*) args)0;                                                                                        \
-	KHook k##name = KHook(KHookFuncInfo funcPatternInfo, &hk##name, (void**)&o##name);                                                  \
+	KHook k##name = KHook(KHookFuncInfo funcPatternInfo, &hk##name, (void**)&o##name);                                                     \
 	returnType convention hk##name args
 #pragma endregion

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -6,147 +6,21 @@
 #pragma region Pattern Scanning
 namespace NSMem
 {
-	inline std::vector<int> HexBytesToString(const char* str)
-	{
-		std::vector<int> patternNums;
-		int size = strlen(str);
-		for (int i = 0; i < size; i++)
-		{
-			char c = str[i];
+	std::vector<int> HexBytesToString(const char* str);
 
-			// If this is a space character, ignore it
-			if (c == ' ' || c == '\t')
-				continue;
+	void* PatternScan(void* module, const int* pattern, int patternSize, int offset);
 
-			if (c == '?')
-			{
-				// Add a wildcard (-1)
-				patternNums.push_back(-1);
-			}
-			else if (i < size - 1)
-			{
-				BYTE result = 0;
-				for (int j = 0; j < 2; j++)
-				{
-					int val = 0;
-					char c = *(str + i + j);
-					if (c >= 'a')
-					{
-						val = c - 'a' + 0xA;
-					}
-					else if (c >= 'A')
-					{
-						val = c - 'A' + 0xA;
-					}
-					else if (isdigit(c))
-					{
-						val = c - '0';
-					}
-					else
-					{
-						assert(false, "Failed to parse invalid hex string.");
-						val = -1;
-					}
+	void* PatternScan(const char* moduleName, const char* pattern, int offset = 0);
 
-					result += (j == 0) ? val * 16 : val;
-				}
-				patternNums.push_back(result);
-			}
+	void BytePatch(uintptr_t address, const BYTE* vals, int size);
 
-			i++;
-		}
+	void BytePatch(uintptr_t address, std::initializer_list<BYTE> vals);
 
-		return patternNums;
-	}
+	void BytePatch(uintptr_t address, const char* bytesStr);
 
-	inline void* PatternScan(void* module, const int* pattern, int patternSize, int offset)
-	{
-		if (!module)
-			return NULL;
+	void NOP(uintptr_t address, int size);
 
-		auto dosHeader = (PIMAGE_DOS_HEADER)module;
-		auto ntHeaders = (PIMAGE_NT_HEADERS)((BYTE*)module + dosHeader->e_lfanew);
-
-		auto sizeOfImage = ntHeaders->OptionalHeader.SizeOfImage;
-
-		auto scanBytes = (BYTE*)module;
-
-		for (auto i = 0; i < sizeOfImage - patternSize; ++i)
-		{
-			bool found = true;
-			for (auto j = 0; j < patternSize; ++j)
-			{
-				if (scanBytes[i + j] != pattern[j] && pattern[j] != -1)
-				{
-					found = false;
-					break;
-				}
-			}
-
-			if (found)
-			{
-				uintptr_t addressInt = (uintptr_t)(&scanBytes[i]) + offset;
-				return (uint8_t*)addressInt;
-			}
-		}
-
-		return nullptr;
-	}
-
-	inline void* PatternScan(const char* moduleName, const char* pattern, int offset = 0)
-	{
-		std::vector<int> patternNums = HexBytesToString(pattern);
-
-		return PatternScan(GetModuleHandleA(moduleName), &patternNums[0], patternNums.size(), offset);
-	}
-
-	inline void BytePatch(uintptr_t address, const BYTE* vals, int size)
-	{
-		WriteProcessMemory(GetCurrentProcess(), (LPVOID)address, vals, size, NULL);
-	}
-
-	inline void BytePatch(uintptr_t address, std::initializer_list<BYTE> vals)
-	{
-		std::vector<BYTE> bytes = vals;
-		if (!bytes.empty())
-			BytePatch(address, &bytes[0], bytes.size());
-	}
-
-	inline void BytePatch(uintptr_t address, const char* bytesStr)
-	{
-		std::vector<int> byteInts = HexBytesToString(bytesStr);
-		std::vector<BYTE> bytes;
-		for (int v : byteInts)
-			bytes.push_back(v);
-
-		if (!bytes.empty())
-			BytePatch(address, &bytes[0], bytes.size());
-	}
-
-	inline void NOP(uintptr_t address, int size)
-	{
-		BYTE* buf = (BYTE*)malloc(size);
-		memset(buf, 0x90, size);
-		BytePatch(address, buf, size);
-		free(buf);
-	}
-
-	inline bool IsMemoryReadable(void* ptr, size_t size)
-	{
-		static SYSTEM_INFO sysInfo;
-		if (!sysInfo.dwPageSize)
-			GetSystemInfo(&sysInfo); // This should always be 4096 unless ur playing on NES or some shit but whatever
-
-		MEMORY_BASIC_INFORMATION memInfo;
-
-		if (!VirtualQuery(ptr, &memInfo, sizeof(memInfo)))
-			return false;
-
-		if (memInfo.RegionSize < size)
-			return false;
-
-		return (memInfo.State & MEM_COMMIT) && !(memInfo.Protect & PAGE_NOACCESS);
-	}
+	bool IsMemoryReadable(void* ptr, size_t size);
 } // namespace NSMem
 
 #pragma region KHOOK

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -603,6 +603,7 @@
     <ClCompile Include="logging.cpp" />
     <ClCompile Include="masterserver.cpp" />
     <ClCompile Include="modmanager.cpp" />
+    <ClCompile Include="NSMem.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -136,6 +136,12 @@
     <Filter Include="Header Files\Shared\ExploitFixes">
       <UniqueIdentifier>{7f609cee-d2c0-46a2-b06e-83b9f0511915}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Shared\Memory">
+      <UniqueIdentifier>{4d6b2bdf-7f2c-40bc-9365-f02d5ceff21f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Shared\Memory">
+      <UniqueIdentifier>{2a02017f-85ce-4836-a6f5-0c0f657a9aa0}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">
@@ -1513,7 +1519,7 @@
       <Filter>Header Files\Shared\ExploitFixes</Filter>
     </ClInclude>
     <ClInclude Include="NSMem.h">
-      <Filter>Header Files\Shared\ExploitFixes</Filter>
+      <Filter>Header Files\Shared\Memory</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -1681,6 +1687,9 @@
     </ClCompile>
     <ClCompile Include="clientruihooks.cpp">
       <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="NSMem.cpp">
+      <Filter>Source Files\Shared\Memory</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
These are some minor improvements to my NSMem namespace to make it easier to understand and more useful.

This PR does not change the (effective) functionality of any in-use NSMem functions, nor anything outside of NSMem, therefore I consider this PR a single-feature change, and it should not conflict with anything else whatsoever.

**Summary of changes:**
- Make `NSMem.cpp` and move function definitions there (not sure why I didn't do this originally, my bad)
- Rename `HexBytesToString()` to `StringToHexBytes()` (the name was visa-versa flipped around for some reason, another oversight by me lol)
- Add detailed comments/descriptions to all `NSMem::` functions and `KHOOK`-related classes
- Add utility functions `NSMem::GetOffsetPtr()` and `NSMem::GetOffsetVal()` for convenience (not used anywhere yet)
- Support using `KHOOK` _without_ pattern scanning (via offset) 
- Made pattern scanning 40-50x faster by searching function start addresses first

**Testing:**
- I have tested and verified the functionality of all changes. Let me know if there's a typo in a function comment or such.