### PR TITLE
fixed custom rpaks being loaded more than once

### DIFF
--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -74,7 +74,6 @@ void PakLoadManager::RemoveLoadedPak(int32_t pakHandle)
 	loadedPaks.erase(pakHandle);
 }
 
-
 void HandlePakAliases(char** map)
 {
 	// convert the pak being loaded to it's aliased one, e.g. aliasing mp_hub_timeshift => sp_hub_timeshift
@@ -145,8 +144,6 @@ void LoadCustomMapPaks(char** pakName, bool* bNeedToFreePakName)
 		}
 	}
 }
-
-
 
 LoadPakSyncType LoadPakSyncOriginal;
 void* LoadPakSyncHook(char* path, void* unknownSingleton, int flags)

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -119,7 +119,6 @@ void LoadCustomMapPaks(char** pakName, bool* bNeedToFreePakName)
 	}
 }
 
-#include "pch.h"
 // these are hashed with STR_HASH
 std::unordered_map<int32_t, size_t> loadedPaks {};
 
@@ -141,7 +140,7 @@ void* LoadPakSyncHook(char* path, void* unknownSingleton, int flags)
 		LoadPreloadPaks();
 		LoadCustomMapPaks(&path, &bNeedToFreePakName);
 
-		bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
+		bShouldLoadPaks = true;
 	}
 
 	spdlog::info("LoadPakSync {}", path);
@@ -190,7 +189,7 @@ int LoadPakAsyncHook(char* path, void* unknownSingleton, int flags, void* callba
 		LoadPreloadPaks();
 		LoadCustomMapPaks(&path, &bNeedToFreePakName);
 
-		bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
+		bShouldLoadPaks = true;
 
 		// do this after custom paks load and in bShouldLoadPaks so we only ever call this on the root pakload call
 		// todo: could probably add some way to flag custom paks to not be loaded on dedicated servers in rpak.json
@@ -210,11 +209,9 @@ int LoadPakAsyncHook(char* path, void* unknownSingleton, int flags, void* callba
 	return ret;
 }
 
-#include "pch.h"
 UnloadPakType UnloadPakOriginal;
 void* UnloadPakHook(int pakHandle, void* callback)
 {
-	// using "" for a non-entry because idk how to nicely remove a member
 	if (loadedPaks.find(pakHandle) != loadedPaks.end())
 	{
 		// remove the entry

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -137,7 +137,7 @@ void* LoadPakSyncHook(char* path, void* unknownSingleton, int flags)
 		LoadPreloadPaks();
 		LoadCustomMapPaks(&path, &bNeedToFreePakName);
 
-		bShouldLoadPaks = true;
+		// bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
 	}
 
 	spdlog::info("LoadPakSync {}", path);
@@ -165,7 +165,7 @@ int LoadPakAsyncHook(char* path, void* unknownSingleton, int flags, void* callba
 		LoadPreloadPaks();
 		LoadCustomMapPaks(&path, &bNeedToFreePakName);
 
-		bShouldLoadPaks = true;
+		//bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
 
 		// do this after custom paks load and in bShouldLoadPaks so we only ever call this on the root pakload call
 		// todo: could probably add some way to flag custom paks to not be loaded on dedicated servers in rpak.json

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -165,7 +165,7 @@ int LoadPakAsyncHook(char* path, void* unknownSingleton, int flags, void* callba
 		LoadPreloadPaks();
 		LoadCustomMapPaks(&path, &bNeedToFreePakName);
 
-		//bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
+		// bShouldLoadPaks = true; // why are we ever loading these more than once? i dont understand why we were setting this to true again
 
 		// do this after custom paks load and in bShouldLoadPaks so we only ever call this on the root pakload call
 		// todo: could probably add some way to flag custom paks to not be loaded on dedicated servers in rpak.json

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -172,8 +172,6 @@ int LoadPakAsyncHook(char* path, void* unknownSingleton, int flags, void* callba
 {
 	size_t hash = STR_HASH(path);
 	// if the hash is already in the map, dont load the pak, it has already been loaded
-	
-
 	if (ContainsValue(hash))
 	{
 		return -1;
@@ -219,11 +217,9 @@ void* UnloadPakHook(int pakHandle, void* callback)
 	// using "" for a non-entry because idk how to nicely remove a member
 	if (loadedPaks.find(pakHandle) != loadedPaks.end())
 	{
-		// remove the entry 
+		// remove the entry
 		loadedPaks.erase(pakHandle);
 	}
-
-	
 
 	static bool bShouldUnloadPaks = true;
 	if (bShouldUnloadPaks)

--- a/NorthstarDedicatedTest/rpakfilesystem.h
+++ b/NorthstarDedicatedTest/rpakfilesystem.h
@@ -9,8 +9,16 @@ class PakLoadManager
 	void LoadPakAsync(const char* path, bool bMarkForUnload);
 	void UnloadPaks();
 
+	bool IsPakLoaded(int32_t pakHandle);
+	bool IsPakLoaded(size_t hash);
+	void AddLoadedPak(int32_t pakHandle, size_t hash);
+	void RemoveLoadedPak(int32_t pakHandle);
+
   private:
 	std::vector<int> m_pakHandlesToUnload;
+	// these size_t s are the asset path hashed with STR_HASH
+	std::unordered_map<int32_t, size_t> loadedPaks {};
+	std::unordered_map<size_t, int32_t> loadedPaksInv {};
 };
 
 extern PakLoadManager* g_PakLoadManager;


### PR DESCRIPTION
Potentially fixes #201 ? Definitely fixes an issue where every custom rpak was being loaded every time any other rpak was loaded ever, which was preventing us from having more than 1 custom rpak
