### PR TITLE
Add returntype enum to squirrel native functions

### DIFF
--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -401,6 +401,6 @@ int GetReturnTypeEnumFromString(const char* name)
 	}
 	else
 	{
-		return SqReturnStringOrNull; // previous default value
+		return SqReturnDefault; // previous default value
 	}
 }

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -381,25 +381,26 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, [](HMODULE baseAd
 		FCVAR_GAMEDLL | FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS | FCVAR_CHEAT);
 })
 
-int GetReturnTypeEnumFromString(const char* name) {
-	
+int GetReturnTypeEnumFromString(const char* name)
+{
 
 	static std::map<std::string, SQReturnTypeEnum> sqEnumStrMap = {
-		{"bool",	SqReturnBoolean },
-		{"float",	SqReturnFloat },
-		{"vector",	SqReturnVector },
-		{"int",		SqReturnInteger },
-		{"entity",	SqReturnEntity },
-		{"string",	SqReturnString },
-		{"array",	SqReturnArrays },
-		{"asset",	SqReturnAsset },
-		{"table",	SqReturnTable }
-	};
+		{"bool", SqReturnBoolean},
+		{"float", SqReturnFloat},
+		{"vector", SqReturnVector},
+		{"int", SqReturnInteger},
+		{"entity", SqReturnEntity},
+		{"string", SqReturnString},
+		{"array", SqReturnArrays},
+		{"asset", SqReturnAsset},
+		{"table", SqReturnTable}};
 
-	if (sqEnumStrMap.count(name)) {
+	if (sqEnumStrMap.count(name))
+	{
 		return sqEnumStrMap[name];
 	}
-	else {
-		return SqReturnStringOrNull; //previous default value
+	else
+	{
+		return SqReturnStringOrNull; // previous default value
 	}
 }

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -381,26 +381,25 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, [](HMODULE baseAd
 		FCVAR_GAMEDLL | FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS | FCVAR_CHEAT);
 })
 
-int getReturnTypeEnumFromString(const char* name)
-{
-	if (strcmp(name, "bool"))
-		return SQReturnTypeEnum::SqBoolean;
-	if (strcmp(name, "float"))
-		return SQReturnTypeEnum::SqFloat;
-	if (strcmp(name, "vector"))
-		return SQReturnTypeEnum::SqVector;
-	if (strcmp(name, "int"))
-		return SQReturnTypeEnum::SqInteger;
-	if (strcmp(name, "entity"))
-		return SQReturnTypeEnum::SqEntity;
-	if (strcmp(name, "string"))
-		return SQReturnTypeEnum::SqString;
-	if (strcmp(name, "array"))
-		return SQReturnTypeEnum::SqArrays;
-	if (strcmp(name, "asset"))
-		return SQReturnTypeEnum::SqAsset;
-	if (strcmp(name, "table"))
-		return SQReturnTypeEnum::SqTable;
+int GetReturnTypeEnumFromString(const char* name) {
+	
 
-	return SQReturnTypeEnum::SqStringOrNull;
+	static std::map<std::string, SQReturnTypeEnum> sqEnumStrMap = {
+		{"bool",	SqReturnBoolean },
+		{"float",	SqReturnFloat },
+		{"vector",	SqReturnVector },
+		{"int",		SqReturnInteger },
+		{"entity",	SqReturnEntity },
+		{"string",	SqReturnString },
+		{"array",	SqReturnArrays },
+		{"asset",	SqReturnAsset },
+		{"table",	SqReturnTable }
+	};
+
+	if (sqEnumStrMap.count(name)) {
+		return sqEnumStrMap[name];
+	}
+	else {
+		return SqReturnStringOrNull; //previous default value
+	}
 }

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -380,3 +380,27 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, [](HMODULE baseAd
 		"Executes script code on the server vm",
 		FCVAR_GAMEDLL | FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS | FCVAR_CHEAT);
 })
+
+int getReturnTypeEnumFromString(const char* name)
+{
+	if (strcmp(name, "bool"))
+		return SQReturnTypeEnum::SqBoolean;
+	if (strcmp(name, "float"))
+		return SQReturnTypeEnum::SqFloat;
+	if (strcmp(name, "vector"))
+		return SQReturnTypeEnum::SqVector;
+	if (strcmp(name, "int"))
+		return SQReturnTypeEnum::SqInteger;
+	if (strcmp(name, "entity"))
+		return SQReturnTypeEnum::SqEntity;
+	if (strcmp(name, "string"))
+		return SQReturnTypeEnum::SqString;
+	if (strcmp(name, "array"))
+		return SQReturnTypeEnum::SqArrays;
+	if (strcmp(name, "asset"))
+		return SQReturnTypeEnum::SqAsset;
+	if (strcmp(name, "table"))
+		return SQReturnTypeEnum::SqTable;
+
+	return SQReturnTypeEnum::SqStringOrNull;
+}

--- a/NorthstarDLL/squirrel.h
+++ b/NorthstarDLL/squirrel.h
@@ -7,7 +7,7 @@ typedef unsigned long SQUnsignedInteger;
 typedef char SQChar;
 typedef SQUnsignedInteger SQBool;
 
-int getReturnTypeEnumFromString(const char* name);
+int GetReturnTypeEnumFromString(const char* name);
 
 enum SQRESULT : SQInteger
 {
@@ -34,16 +34,16 @@ struct CompileBufferState
 
 
 enum SQReturnTypeEnum {
-	SqFloat = 0x1,
-	SqVector = 0x3,
-	SqInteger = 0x5,
-	SqBoolean = 0x6,
-	SqEntity = 0xD,
-	SqString = 0x21,
-	SqStringOrNull = 0x20,
-	SqArrays = 0x25,
-	SqAsset = 0x28,
-	SqTable = 0x26,
+	SqReturnFloat = 0x1,
+	SqReturnVector = 0x3,
+	SqReturnInteger = 0x5,
+	SqReturnBoolean = 0x6,
+	SqReturnEntity = 0xD,
+	SqReturnString = 0x21,
+	SqReturnStringOrNull = 0x20,
+	SqReturnArrays = 0x25,
+	SqReturnAsset = 0x28,
+	SqReturnTable = 0x26,
 };
 
 
@@ -201,7 +201,7 @@ template <ScriptContext context> class SquirrelManager
 		strcpy((char*)reg->argTypes, argTypes.c_str());
 
 		reg->funcPtr = func;
-		reg->returnValueTypeEnum = getReturnTypeEnumFromString(returnType.c_str());
+		reg->returnValueTypeEnum = GetReturnTypeEnumFromString(returnType.c_str());
 
 		m_funcRegistrations.push_back(reg);
 	}

--- a/NorthstarDLL/squirrel.h
+++ b/NorthstarDLL/squirrel.h
@@ -40,7 +40,7 @@ enum SQReturnTypeEnum {
 	SqReturnBoolean = 0x6,
 	SqReturnEntity = 0xD,
 	SqReturnString = 0x21,
-	SqReturnStringOrNull = 0x20,
+	SqReturnDefault = 0x20,
 	SqReturnArrays = 0x25,
 	SqReturnAsset = 0x28,
 	SqReturnTable = 0x26,

--- a/NorthstarDLL/squirrel.h
+++ b/NorthstarDLL/squirrel.h
@@ -7,6 +7,8 @@ typedef unsigned long SQUnsignedInteger;
 typedef char SQChar;
 typedef SQUnsignedInteger SQBool;
 
+int getReturnTypeEnumFromString(const char* name);
+
 enum SQRESULT : SQInteger
 {
 	SQRESULT_ERROR = -1,
@@ -30,6 +32,21 @@ struct CompileBufferState
 	}
 };
 
+
+enum SQReturnTypeEnum {
+	SqFloat = 0x1,
+	SqVector = 0x3,
+	SqInteger = 0x5,
+	SqBoolean = 0x6,
+	SqEntity = 0xD,
+	SqString = 0x21,
+	SqStringOrNull = 0x20,
+	SqArrays = 0x25,
+	SqAsset = 0x28,
+	SqTable = 0x26,
+};
+
+
 struct SQFuncRegistration
 {
 	const char* squirrelFuncName;
@@ -42,7 +59,7 @@ struct SQFuncRegistration
 	int32_t unknown1;
 	int64_t unknown2;
 	int32_t unknown3;
-	int32_t padding2;
+	int32_t returnValueTypeEnum;
 	int64_t unknown4;
 	int64_t unknown5;
 	int64_t unknown6;
@@ -53,7 +70,6 @@ struct SQFuncRegistration
 	SQFuncRegistration()
 	{
 		memset(this, 0, sizeof(SQFuncRegistration));
-		this->padding2 = 32;
 	}
 };
 
@@ -185,6 +201,7 @@ template <ScriptContext context> class SquirrelManager
 		strcpy((char*)reg->argTypes, argTypes.c_str());
 
 		reg->funcPtr = func;
+		reg->returnValueTypeEnum = getReturnTypeEnumFromString(returnType.c_str());
 
 		m_funcRegistrations.push_back(reg);
 	}


### PR DESCRIPTION
This PR should only be merged by @BobTheBob9

It adds a return type enum to the registration of native functions in squirrel. This is required for to return types like asset without needing to expect cast the return value first.

It will set the enum value depinding on the string return type and will keep the 32 value set before when the enum type is unknown
