### PR TITLE
Various minor naming convention fixes

### DIFF
--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -23,7 +23,7 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 		return;
 	}
 
-	if (g_ClientSquirrelManager->setupfunc("CHudChat_ProcessMessageStartThread") != SQRESULT_ERROR)
+	if (g_ClientSquirrelManager->SetupFunc("CHudChat_ProcessMessageStartThread") != SQRESULT_ERROR)
 	{
 		int senderId = inboxId & CUSTOM_MESSAGE_INDEX_MASK;
 		bool isAnonymous = senderId == 0;

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -43,7 +43,7 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 		g_ClientSquirrelManager->PushArg(isTeam);
 		g_ClientSquirrelManager->PushArg(isDead);
 		g_ClientSquirrelManager->PushArg(type);
-		g_ClientSquirrelManager->call(5);
+		g_ClientSquirrelManager->Call(5);
 	}
 	else
 	{

--- a/NorthstarDedicatedTest/clientchathooks.cpp
+++ b/NorthstarDedicatedTest/clientchathooks.cpp
@@ -38,11 +38,11 @@ static void CHudChat__AddGameLineHook(void* self, const char* message, int inbox
 			payload = message + 1;
 		}
 
-		g_ClientSquirrelManager->pusharg((int)senderId - 1);
-		g_ClientSquirrelManager->pusharg(payload);
-		g_ClientSquirrelManager->pusharg(isTeam);
-		g_ClientSquirrelManager->pusharg(isDead);
-		g_ClientSquirrelManager->pusharg(type);
+		g_ClientSquirrelManager->PushArg((int)senderId - 1);
+		g_ClientSquirrelManager->PushArg(payload);
+		g_ClientSquirrelManager->PushArg(isTeam);
+		g_ClientSquirrelManager->PushArg(isDead);
+		g_ClientSquirrelManager->PushArg(type);
 		g_ClientSquirrelManager->call(5);
 	}
 	else

--- a/NorthstarDedicatedTest/configurables.cpp
+++ b/NorthstarDedicatedTest/configurables.cpp
@@ -7,7 +7,7 @@ std::string GetNorthstarPrefix()
 	return NORTHSTAR_FOLDER_PREFIX;
 }
 
-void parseConfigurables()
+void ParseConfigurables()
 {
 	char* clachar = strstr(GetCommandLineA(), "-profile=");
 	if (clachar)

--- a/NorthstarDedicatedTest/configurables.h
+++ b/NorthstarDedicatedTest/configurables.h
@@ -4,4 +4,4 @@
 static std::string NORTHSTAR_FOLDER_PREFIX;
 
 std::string GetNorthstarPrefix();
-void parseConfigurables();
+void ParseConfigurables();

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -82,7 +82,7 @@ void WaitForDebugger(HMODULE baseAddress)
 	}
 }
 
-void freeLibrary(HMODULE hLib)
+void TryFreeLibrary(HMODULE hLib)
 {
 	if (!FreeLibrary(hLib))
 	{
@@ -132,7 +132,7 @@ bool LoadPlugins()
 		if (manifestResource == NULL)
 		{
 			spdlog::info("Could not find manifest for library {}", pathstring);
-			freeLibrary(datafile);
+			TryFreeLibrary(datafile);
 			continue;
 		}
 		spdlog::info("Loading resource from library");
@@ -140,12 +140,12 @@ bool LoadPlugins()
 		if (myResourceData == NULL)
 		{
 			spdlog::error("Failed to load resource from library");
-			freeLibrary(datafile);
+			TryFreeLibrary(datafile);
 			continue;
 		}
 		int manifestSize = SizeofResource(datafile, manifestResource);
 		std::string manifest = std::string((const char*)LockResource(myResourceData), 0, manifestSize);
-		freeLibrary(datafile);
+		TryFreeLibrary(datafile);
 
 		rapidjson_document manifestJSON;
 		manifestJSON.Parse(manifest.c_str());

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -196,7 +196,7 @@ bool InitialiseNorthstar()
 
 	initialised = true;
 
-	parseConfigurables();
+	ParseConfigurables();
 	InitialiseVersion();
 
 	// Fix some users' failure to connect to respawn datacenters

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -113,7 +113,7 @@ bool LoadPlugins()
 		if (fs::is_regular_file(entry) && entry.path().extension() == ".dll")
 			paths.emplace_back(entry.path().filename());
 	}
-	initGameState();
+	InitGameState();
 	for (fs::path path : paths)
 	{
 		std::string pathstring = (pluginPath / path).string();
@@ -181,7 +181,7 @@ bool LoadPlugins()
 			continue;
 		}
 		spdlog::info("Succesfully loaded {}", pathstring);
-		initPlugin(&getPluginObject);
+		initPlugin(&GetPluginObject);
 	}
 	return true;
 }

--- a/NorthstarDedicatedTest/gameutils.h
+++ b/NorthstarDedicatedTest/gameutils.h
@@ -93,7 +93,7 @@ class CCommandLine
 	// these seem to line up with what they should be though
 	virtual void CreateCmdLine(const char* commandline) {}
 	virtual void CreateCmdLine(int argc, char** argv) {}
-	virtual void unknown() {}
+	virtual void _Unknown() {}
 	virtual const char* GetCmdLine(void) const {}
 
 	virtual const char* CheckParm(const char* psz, const char** ppszValue = 0) const {}

--- a/NorthstarDedicatedTest/gameutils.h
+++ b/NorthstarDedicatedTest/gameutils.h
@@ -173,7 +173,7 @@ enum EngineState_t
 class CEngine
 {
   public:
-	virtual void unknown() {} // unsure if this is where
+	virtual CEngine _VectorDeletingConstructor() {} // See: (engine.dll + 0x1C8300)
 	virtual bool Load(bool dedicated, const char* baseDir) {}
 	virtual void Unload() {}
 	virtual void SetNextState(EngineState_t iNextState) {}

--- a/NorthstarDedicatedTest/plugins.cpp
+++ b/NorthstarDedicatedTest/plugins.cpp
@@ -58,7 +58,7 @@ static SRWLOCK gameStateLock;
 static SRWLOCK serverInfoLock;
 static SRWLOCK playerInfoLock;
 
-void* getPluginObject(PluginObject var)
+void* GetPluginObject(PluginObject var)
 {
 	switch (var)
 	{
@@ -73,24 +73,24 @@ void* getPluginObject(PluginObject var)
 	}
 }
 
-void initGameState()
+void InitGameState()
 {
 	// Initalize the Slim Reader / Writer locks
 	InitializeSRWLock(&gameStateLock);
 	InitializeSRWLock(&serverInfoLock);
 	InitializeSRWLock(&playerInfoLock);
 
-	gameStateExport.getGameStateChar = &getGameStateChar;
-	gameStateExport.getGameStateInt = &getGameStateInt;
-	gameStateExport.getGameStateBool = &getGameStateBool;
+	gameStateExport.getGameStateChar = &GetGameStateChar;
+	gameStateExport.getGameStateInt = &GetGameStateInt;
+	gameStateExport.getGameStateBool = &GetGameStateBool;
 
-	serverInfoExport.getServerInfoChar = &getServerInfoChar;
-	serverInfoExport.getServerInfoInt = &getServerInfoInt;
-	serverInfoExport.getServerInfoBool = &getServerInfoBool;
+	serverInfoExport.getServerInfoChar = &GetServerInfoChar;
+	serverInfoExport.getServerInfoInt = &GetServerInfoInt;
+	serverInfoExport.getServerInfoBool = &GetServerInfoBool;
 
-	playerInfoExport.getPlayerInfoChar = &getPlayerInfoChar;
-	playerInfoExport.getPlayerInfoInt = &getPlayerInfoInt;
-	playerInfoExport.getPlayerInfoBool = &getPlayerInfoBool;
+	playerInfoExport.getPlayerInfoChar = &GetPlayerInfoChar;
+	playerInfoExport.getPlayerInfoInt = &GetPlayerInfoInt;
+	playerInfoExport.getPlayerInfoBool = &GetPlayerInfoBool;
 
 	serverInfo.id = "";
 	serverInfo.name = "";
@@ -198,7 +198,7 @@ SQRESULT SQ_UpdateListenServer(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-int getServerInfoChar(char* out_buf, size_t out_buf_len, ServerInfoType var)
+int GetServerInfoChar(char* out_buf, size_t out_buf_len, ServerInfoType var)
 {
 	AcquireSRWLockShared(&serverInfoLock);
 	int n = 0;
@@ -224,7 +224,7 @@ int getServerInfoChar(char* out_buf, size_t out_buf_len, ServerInfoType var)
 
 	return n;
 }
-int getServerInfoInt(int* out_ptr, ServerInfoType var)
+int GetServerInfoInt(int* out_ptr, ServerInfoType var)
 {
 	AcquireSRWLockShared(&serverInfoLock);
 	int n = 0;
@@ -247,7 +247,7 @@ int getServerInfoInt(int* out_ptr, ServerInfoType var)
 
 	return n;
 }
-int getServerInfoBool(bool* out_ptr, ServerInfoType var)
+int GetServerInfoBool(bool* out_ptr, ServerInfoType var)
 {
 	AcquireSRWLockShared(&serverInfoLock);
 	int n = 0;
@@ -265,7 +265,7 @@ int getServerInfoBool(bool* out_ptr, ServerInfoType var)
 	return n;
 }
 
-int getGameStateChar(char* out_buf, size_t out_buf_len, GameStateInfoType var)
+int GetGameStateChar(char* out_buf, size_t out_buf_len, GameStateInfoType var)
 {
 	AcquireSRWLockShared(&gameStateLock);
 	int n = 0;
@@ -291,7 +291,7 @@ int getGameStateChar(char* out_buf, size_t out_buf_len, GameStateInfoType var)
 
 	return n;
 }
-int getGameStateInt(int* out_ptr, GameStateInfoType var)
+int GetGameStateInt(int* out_ptr, GameStateInfoType var)
 {
 	AcquireSRWLockShared(&gameStateLock);
 	int n = 0;
@@ -317,7 +317,7 @@ int getGameStateInt(int* out_ptr, GameStateInfoType var)
 
 	return n;
 }
-int getGameStateBool(bool* out_ptr, GameStateInfoType var)
+int GetGameStateBool(bool* out_ptr, GameStateInfoType var)
 {
 	AcquireSRWLockShared(&gameStateLock);
 	int n = 0;
@@ -338,7 +338,7 @@ int getGameStateBool(bool* out_ptr, GameStateInfoType var)
 	return n;
 }
 
-int getPlayerInfoChar(char* out_buf, size_t out_buf_len, PlayerInfoType var)
+int GetPlayerInfoChar(char* out_buf, size_t out_buf_len, PlayerInfoType var)
 {
 	AcquireSRWLockShared(&playerInfoLock);
 	int n = 0;
@@ -352,7 +352,7 @@ int getPlayerInfoChar(char* out_buf, size_t out_buf_len, PlayerInfoType var)
 
 	return n;
 }
-int getPlayerInfoInt(int* out_ptr, PlayerInfoType var)
+int GetPlayerInfoInt(int* out_ptr, PlayerInfoType var)
 {
 	AcquireSRWLockShared(&playerInfoLock);
 	int n = 0;
@@ -369,7 +369,7 @@ int getPlayerInfoInt(int* out_ptr, PlayerInfoType var)
 
 	return n;
 }
-int getPlayerInfoBool(bool* out_ptr, PlayerInfoType var)
+int GetPlayerInfoBool(bool* out_ptr, PlayerInfoType var)
 {
 	AcquireSRWLockShared(&playerInfoLock);
 	int n = 0;

--- a/NorthstarDedicatedTest/plugins.h
+++ b/NorthstarDedicatedTest/plugins.h
@@ -1,19 +1,19 @@
 #pragma once
 #include "plugin_abi.h"
 
-int getServerInfoChar(char* out_buf, size_t out_buf_len, ServerInfoType var);
-int getServerInfoInt(int* out_ptr, ServerInfoType var);
-int getServerInfoBool(bool* out_ptr, ServerInfoType var);
+int GetServerInfoChar(char* out_buf, size_t out_buf_len, ServerInfoType var);
+int GetServerInfoInt(int* out_ptr, ServerInfoType var);
+int GetServerInfoBool(bool* out_ptr, ServerInfoType var);
 
-int getGameStateChar(char* out_buf, size_t out_buf_len, GameStateInfoType var);
-int getGameStateInt(int* out_ptr, GameStateInfoType var);
-int getGameStateBool(bool* out_ptr, GameStateInfoType var);
+int GetGameStateChar(char* out_buf, size_t out_buf_len, GameStateInfoType var);
+int GetGameStateInt(int* out_ptr, GameStateInfoType var);
+int GetGameStateBool(bool* out_ptr, GameStateInfoType var);
 
-int getPlayerInfoChar(char* out_buf, size_t out_buf_len, PlayerInfoType var);
-int getPlayerInfoInt(int* out_ptr, PlayerInfoType var);
-int getPlayerInfoBool(bool* out_ptr, PlayerInfoType var);
+int GetPlayerInfoChar(char* out_buf, size_t out_buf_len, PlayerInfoType var);
+int GetPlayerInfoInt(int* out_ptr, PlayerInfoType var);
+int GetPlayerInfoBool(bool* out_ptr, PlayerInfoType var);
 
-void initGameState();
-void* getPluginObject(PluginObject var);
+void InitGameState();
+void* GetPluginObject(PluginObject var);
 
 void InitialisePluginCommands(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
+++ b/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
@@ -9,7 +9,7 @@ void ConCommand_ns_script_servertoclientstringcommand(const CCommand& arg)
 	if (g_ClientSquirrelManager->sqvm &&
 		g_ClientSquirrelManager->setupfunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
 	{
-		g_ClientSquirrelManager->pusharg(arg.ArgS());
+		g_ClientSquirrelManager->PushArg(arg.ArgS());
 		g_ClientSquirrelManager->call(1); // todo: doesn't throw or log errors from within this, probably not great behaviour
 	}
 }

--- a/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
+++ b/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
@@ -7,7 +7,7 @@
 void ConCommand_ns_script_servertoclientstringcommand(const CCommand& arg)
 {
 	if (g_ClientSquirrelManager->sqvm &&
-		g_ClientSquirrelManager->setupfunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
+		g_ClientSquirrelManager->SetupFunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
 	{
 		g_ClientSquirrelManager->PushArg(arg.ArgS());
 		g_ClientSquirrelManager->call(1); // todo: doesn't throw or log errors from within this, probably not great behaviour

--- a/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
+++ b/NorthstarDedicatedTest/scriptservertoclientstringcommand.cpp
@@ -10,7 +10,7 @@ void ConCommand_ns_script_servertoclientstringcommand(const CCommand& arg)
 		g_ClientSquirrelManager->SetupFunc("NSClientCodeCallback_RecievedServerToClientStringCommand") != SQRESULT_ERROR)
 	{
 		g_ClientSquirrelManager->PushArg(arg.ArgS());
-		g_ClientSquirrelManager->call(1); // todo: doesn't throw or log errors from within this, probably not great behaviour
+		g_ClientSquirrelManager->Call(1); // todo: doesn't throw or log errors from within this, probably not great behaviour
 	}
 }
 

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -76,7 +76,7 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 		return;
 	}
 
-	if (g_ServerSquirrelManager->setupfunc("CServerGameDLL_ProcessMessageStartThread") != SQRESULT_ERROR)
+	if (g_ServerSquirrelManager->SetupFunc("CServerGameDLL_ProcessMessageStartThread") != SQRESULT_ERROR)
 	{
 		g_ServerSquirrelManager->PushArg((int)senderPlayerId - 1);
 		g_ServerSquirrelManager->PushArg(text);

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -81,7 +81,7 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 		g_ServerSquirrelManager->PushArg((int)senderPlayerId - 1);
 		g_ServerSquirrelManager->PushArg(text);
 		g_ServerSquirrelManager->PushArg(isTeam);
-		g_ServerSquirrelManager->call(3);
+		g_ServerSquirrelManager->Call(3);
 	}
 	else
 		CServerGameDLL__OnReceivedSayTextMessageHookBase(self, senderPlayerId, text, isTeam);

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -78,9 +78,9 @@ static void CServerGameDLL__OnReceivedSayTextMessageHook(CServerGameDLL* self, u
 
 	if (g_ServerSquirrelManager->setupfunc("CServerGameDLL_ProcessMessageStartThread") != SQRESULT_ERROR)
 	{
-		g_ServerSquirrelManager->pusharg((int)senderPlayerId - 1);
-		g_ServerSquirrelManager->pusharg(text);
-		g_ServerSquirrelManager->pusharg(isTeam);
+		g_ServerSquirrelManager->PushArg((int)senderPlayerId - 1);
+		g_ServerSquirrelManager->PushArg(text);
+		g_ServerSquirrelManager->PushArg(isTeam);
 		g_ServerSquirrelManager->call(3);
 	}
 	else

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -226,28 +226,28 @@ template <ScriptContext context> class SquirrelManager
 		return result;
 	}
 
-	void pusharg(int arg)
+	void PushArg(int arg)
 	{
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)
 			ClientSq_pushinteger(sqvm2, arg);
 		else if (context == ScriptContext::SERVER)
 			ServerSq_pushinteger(sqvm2, arg);
 	}
-	void pusharg(const char* arg)
+	void PushArg(const char* arg)
 	{
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)
 			ClientSq_pushstring(sqvm2, arg, -1);
 		else if (context == ScriptContext::SERVER)
 			ServerSq_pushstring(sqvm2, arg, -1);
 	}
-	void pusharg(float arg)
+	void PushArg(float arg)
 	{
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)
 			ClientSq_pushfloat(sqvm2, arg);
 		else if (context == ScriptContext::SERVER)
 			ServerSq_pushfloat(sqvm2, arg);
 	}
-	void pusharg(bool arg)
+	void PushArg(bool arg)
 	{
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)
 			ClientSq_pushbool(sqvm2, arg);

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -200,7 +200,7 @@ template <ScriptContext context> class SquirrelManager
 		}
 	}
 
-	int setupfunc(const char* funcname)
+	int SetupFunc(const char* funcname)
 	{
 		int result = -2;
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -255,7 +255,7 @@ template <ScriptContext context> class SquirrelManager
 			ServerSq_pushbool(sqvm2, arg);
 	}
 
-	int call(int args)
+	int Call(int args)
 	{
 		int result = -2;
 		if (context == ScriptContext::CLIENT || context == ScriptContext::UI)


### PR DESCRIPTION
I have noticed a few functions here and there that don't comform to Northstar's "established" `PascalCase()` function naming.

I renamed them because it makes the sadness go away.