### PR TITLE
Log all clientcommands if `ns_should_log_all_clientcommands` is set

### DIFF
--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -486,7 +486,7 @@ char CGameClient__ExecuteStringCommandHook(void* self, uint32_t unknown, const c
 	// Only log clientcommands if the convar `ns_should_log_all_clientcommands` equals 1
 	if (Cvar_ns_should_log_all_clientcommands->GetBool())
 	{
-		spdlog::info("{} with UID {} sent stringcommand {}", (char*)self + 0x16, (char*)self + 0xF500, pCommandString);
+		spdlog::info("{} (UID: {}) executed command: \"{}\"", (char*)self + 0x16, (char*)self + 0xF500, pCommandString);
 	}
 
 	if (CVar_sv_quota_stringcmdspersecond->GetInt() != -1)

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -484,7 +484,7 @@ CCommand__TokenizeType CCommand__Tokenize;
 char CGameClient__ExecuteStringCommandHook(void* self, uint32_t unknown, const char* pCommandString)
 {
 	// Only log clientcommands if the convar `ns_should_log_all_clientcommands` equals 1
-	if (Cvar_ns_should_log_all_clientcommands->GetInt() == 1)
+	if (Cvar_ns_should_log_all_clientcommands->GetBool())
 	{
 		spdlog::info("{} with UID {} sent stringcommand {}", (char*)self + 0x16, (char*)self + 0xF500, pCommandString);
 	}

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -486,7 +486,7 @@ char CGameClient__ExecuteStringCommandHook(void* self, uint32_t unknown, const c
 	// Only log clientcommands if the convar `ns_should_log_all_clientcommands` equals 1
 	if (Cvar_ns_should_log_all_clientcommands->GetInt() == 1)
 	{
-		spdlog::info("{} sent stringcommand {}", (char*)self + 0x16, pCommandString);
+		spdlog::info("{} with UID {} sent stringcommand {}", (char*)self + 0x16, (char*)self + 0xF500, pCommandString);
 	}
 
 	if (CVar_sv_quota_stringcmdspersecond->GetInt() != -1)

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -18,6 +18,9 @@
 
 const char* AUTHSERVER_VERIFY_STRING = "I am a northstar server!";
 
+// This convar defines whether to log all client commands
+ConVar* Cvar_ns_should_log_all_clientcommands;
+
 // hook types
 
 typedef void* (*CBaseServer__ConnectClientType)(
@@ -480,6 +483,12 @@ CCommand__TokenizeType CCommand__Tokenize;
 
 char CGameClient__ExecuteStringCommandHook(void* self, uint32_t unknown, const char* pCommandString)
 {
+	// Only log clientcommands if the convar `ns_should_log_all_clientcommands` equals 1
+	if (Cvar_ns_should_log_all_clientcommands->GetInt() == 1)
+	{
+		spdlog::info("{} sent stringcommand {}", (char*)self + 0x16, pCommandString);
+	}
+
 	if (CVar_sv_quota_stringcmdspersecond->GetInt() != -1)
 	{
 		// note: this isn't super perfect, legit clients can trigger it in lobby, mostly good enough tho imo
@@ -672,6 +681,11 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 		"100",
 		FCVAR_GAMEDLL,
 		"Netchannel processing is limited to so many milliseconds, abort connection if exceeding budget");
+	Cvar_ns_should_log_all_clientcommands = new ConVar(
+		"ns_should_log_all_clientcommands",
+		"0",
+		FCVAR_NONE,
+		"Whether to log all clientcommands");
 	Cvar_ns_player_auth_port = new ConVar("ns_player_auth_port", "8081", FCVAR_GAMEDLL, "");
 	Cvar_sv_querylimit_per_sec = new ConVar("sv_querylimit_per_sec", "15", FCVAR_GAMEDLL, "");
 	Cvar_sv_max_chat_messages_per_sec = new ConVar("sv_max_chat_messages_per_sec", "5", FCVAR_GAMEDLL, "");

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -681,11 +681,8 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 		"100",
 		FCVAR_GAMEDLL,
 		"Netchannel processing is limited to so many milliseconds, abort connection if exceeding budget");
-	Cvar_ns_should_log_all_clientcommands = new ConVar(
-		"ns_should_log_all_clientcommands",
-		"0",
-		FCVAR_NONE,
-		"Whether to log all clientcommands");
+	Cvar_ns_should_log_all_clientcommands =
+		new ConVar("ns_should_log_all_clientcommands", "0", FCVAR_NONE, "Whether to log all clientcommands");
 	Cvar_ns_player_auth_port = new ConVar("ns_player_auth_port", "8081", FCVAR_GAMEDLL, "");
 	Cvar_sv_querylimit_per_sec = new ConVar("sv_querylimit_per_sec", "15", FCVAR_GAMEDLL, "");
 	Cvar_sv_max_chat_messages_per_sec = new ConVar("sv_max_chat_messages_per_sec", "5", FCVAR_GAMEDLL, "");


### PR DESCRIPTION
This is the native version of https://github.com/R2Northstar/NorthstarMods/pull/391. I re-used the same convar name as in that PR.

Setting `ns_should_log_all_clientcommands` to `1` will enable the logging. By default the value is `0`, i.e. no logging of client commands.

Sample output:

```
[2022-06-25 00:41:32.602] [info] XXXXXXXXX with UID YYYYYYYY sent stringcommand CC_RespawnPlayer Pilot
```

together with a command blocked by exploitfixes:

```
...
[2022-06-25 00:40:01.157] [info] XXXXXXXXX with UID YYYYYYYY sent stringcommand emit 
[2022-06-25 00:40:01.157] [info] [SERVER SCRIPT] ############################
[2022-06-25 00:40:01.157] [info] [SERVER SCRIPT] CommandString: load_recent_checkpoint was not added via AddClientCommandCallback but is being called in CodeCallback_ClientCommand
[2022-06-25 00:40:01.157] [info] [SERVER SCRIPT] ############################
[2022-06-25 00:40:01.158] [warning] Blocked exploititive client command "emit".
...
```

When `ns_should_log_all_clientcommands` is set to `0`, the 
```
[2022-06-25 00:40:01.157] [info] XXXXXXXXX with UID YYYYYYYY sent stringcommand ZZZZZ
```
part will not be printed.

Convar setting and logging worked as expected in testing.

I'm 100% sure about the placements of the convar check and spdlog print as well as the `´new ConVar()` registration, so if someone could make sure their spots are ok, would be much appreciated <3