### PR TITLE
Mention reproducing bugs and feature usage description in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,9 @@ WHEN OPENING A PULL REQUEST KEEP IN MIND:
 -> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
 -> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)
 
+-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
+-> For features, description on how to use the feature is appreciated and will help your PR get merged faster
+
 -> Please use a sensible title for your pull request
 
 -> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).


### PR DESCRIPTION
Adds the following two lines to the template to give hints as to what helps a PR get merged faster.

```
-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use the feature is appreciated and will help your PR get merged faster
```