### PR TITLE
Several new server base classes

### DIFF
--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -113,15 +113,20 @@
     <ClInclude Include="bits.h" />
     <ClInclude Include="buildainfile.h" />
     <ClInclude Include="chatcommand.h" />
+    <ClInclude Include="client.h" />
     <ClInclude Include="clientchathooks.h" />
     <ClInclude Include="debugoverlay.h" />
     <ClInclude Include="clientruihooks.h" />
     <ClInclude Include="clientvideooverrides.h" />
     <ClInclude Include="localchatwriter.h" />
+    <ClInclude Include="net.h" />
+    <ClInclude Include="net_chan.h" />
     <ClInclude Include="ns_version.h" />
     <ClInclude Include="plugins.h" />
     <ClInclude Include="plugin_abi.h" />
+    <ClInclude Include="protocol.h" />
     <ClInclude Include="scriptutility.h" />
+    <ClInclude Include="server.h" />
     <ClInclude Include="serverchathooks.h" />
     <ClInclude Include="clientauthhooks.h" />
     <ClInclude Include="color.h" />
@@ -566,6 +571,8 @@
     <ClInclude Include="ExploitFixes.h" />
     <ClInclude Include="ExploitFixes_UTF8Parser.h" />
     <ClInclude Include="NSMem.h" />
+    <ClInclude Include="stringtable.h" />
+    <ClInclude Include="valve_utl.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
@@ -574,6 +581,7 @@
     <ClCompile Include="bits.cpp" />
     <ClCompile Include="buildainfile.cpp" />
     <ClCompile Include="chatcommand.cpp" />
+    <ClCompile Include="client.cpp" />
     <ClCompile Include="clientauthhooks.cpp" />
     <ClCompile Include="clientchathooks.cpp" />
     <ClCompile Include="clientruihooks.cpp" />
@@ -604,6 +612,8 @@
     <ClCompile Include="logging.cpp" />
     <ClCompile Include="masterserver.cpp" />
     <ClCompile Include="modmanager.cpp" />
+    <ClCompile Include="net.cpp" />
+    <ClCompile Include="net_chan.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
@@ -618,6 +628,7 @@
     <ClCompile Include="scriptserverbrowser.cpp" />
     <ClCompile Include="scriptsrson.cpp" />
     <ClCompile Include="scriptutility.cpp" />
+    <ClCompile Include="server.cpp" />
     <ClCompile Include="serverauthentication.cpp" />
     <ClCompile Include="miscserverscript.cpp" />
     <ClCompile Include="serverchathooks.cpp" />

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj.filters
@@ -1518,6 +1518,27 @@
     <ClInclude Include="scriptutility.h">
       <Filter>Header Files\Shared</Filter>
     </ClInclude>
+    <ClInclude Include="client.h">
+      <Filter>Header Files\Client</Filter>
+    </ClInclude>
+    <ClInclude Include="net_chan.h">
+      <Filter>Header Files\Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="net.h">
+      <Filter>Header Files\Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="valve_utl.h">
+      <Filter>Header Files\Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="protocol.h">
+      <Filter>Header Files\Shared</Filter>
+    </ClInclude>
+    <ClInclude Include="server.h">
+      <Filter>Header Files\Server</Filter>
+    </ClInclude>
+    <ClInclude Include="stringtable.h">
+      <Filter>Header Files\Shared</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -1687,6 +1708,18 @@
     </ClCompile>
     <ClCompile Include="scriptutility.cpp">
       <Filter>Source Files\Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="client.cpp">
+      <Filter>Source Files\Client</Filter>
+    </ClCompile>
+    <ClCompile Include="net_chan.cpp">
+      <Filter>Source Files\Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="net.cpp">
+      <Filter>Source Files\Shared</Filter>
+    </ClCompile>
+    <ClCompile Include="server.cpp">
+      <Filter>Source Files\Server</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -68,7 +68,7 @@ void BanPlayerCommand(const CCommand& args)
 		return;
 
 	// assuming maxplayers 32
-	for (int i = 0; i < 32; i++)
+	for (int i = 0; i < 32; i++) // !FIXME: Use g_ServerGlobalVariables->m_nMaxClients!!
 	{
 		void* player = GetPlayerByIndex(i);
 

--- a/NorthstarDedicatedTest/bitbuf.h
+++ b/NorthstarDedicatedTest/bitbuf.h
@@ -96,7 +96,7 @@ class BitBufferBase
 	}
 
   public:
-	INLINE bool IsOverflowed()
+	INLINE bool IsOverflowed() const
 	{
 		return m_Overflow;
 	}
@@ -105,7 +105,7 @@ class BitBufferBase
 		m_Overflow = true;
 	}
 
-	INLINE const char* GetName()
+	INLINE const char* GetName() const
 	{
 		return m_BufferName;
 	}

--- a/NorthstarDedicatedTest/client.cpp
+++ b/NorthstarDedicatedTest/client.cpp
@@ -1,0 +1,200 @@
+//===============================================================================//
+//
+// Purpose:
+//
+// $NoKeywords: $
+//
+//===============================================================================//
+// client.cpp: implementation of the CClient class.
+//
+///////////////////////////////////////////////////////////////////////////////////
+#include "pch.h"
+#include "client.h"
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the client from buffer by index
+//---------------------------------------------------------------------------------
+CClient* CClient::GetClient(int nIndex) const
+{
+	return reinterpret_cast<CClient*>((reinterpret_cast<uintptr_t>(g_pClient) + (nIndex * sizeof(CClient))));
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the handle of this client
+//---------------------------------------------------------------------------------
+uint16_t CClient::GetHandle(void) const
+{
+	return m_nHandle;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the userID of this client
+//---------------------------------------------------------------------------------
+uint32_t CClient::GetUserID(void) const
+{
+	return m_nUserID;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the originID of this client
+//---------------------------------------------------------------------------------
+uint64_t CClient::GetOriginID(void) const
+{
+	return m_nOriginID;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the signon state of this client
+//---------------------------------------------------------------------------------
+SIGNONSTATE CClient::GetSignonState(void) const
+{
+	return m_nSignonState;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the persistence state of this client
+//---------------------------------------------------------------------------------
+PERSISTENCE CClient::GetPersistenceState(void) const
+{
+	return m_nPersistenceState;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the net channel of this client
+//---------------------------------------------------------------------------------
+CNetChan* CClient::GetNetChan(void) const
+{
+	return m_NetChannel;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the name of this client (managed by server)
+//---------------------------------------------------------------------------------
+const char* CClient::GetServerName(void) const
+{
+	return m_szServerName;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: gets the name of this client (obtained from connectionless packet)
+//---------------------------------------------------------------------------------
+const char* CClient::GetClientName(void) const
+{
+	return m_szClientName;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the handle of this client
+//---------------------------------------------------------------------------------
+void CClient::SetHandle(uint16_t nHandle)
+{
+	m_nHandle = nHandle;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the userID of this client
+//---------------------------------------------------------------------------------
+void CClient::SetUserID(uint32_t nUserID)
+{
+	m_nUserID = nUserID;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the originID of this client
+//---------------------------------------------------------------------------------
+void CClient::SetOriginID(uint64_t nOriginID)
+{
+	m_nOriginID = nOriginID;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the signon state of this client
+//---------------------------------------------------------------------------------
+void CClient::SetSignonState(SIGNONSTATE nSignonState)
+{
+	m_nSignonState = nSignonState;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the persistence state of this client
+//---------------------------------------------------------------------------------
+void CClient::SetPersistenceState(PERSISTENCE nPersistenceState)
+{
+	m_nPersistenceState = nPersistenceState;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: sets the net channel of this client
+// !TODO  : Remove this and rebuild INetChannel
+//---------------------------------------------------------------------------------
+void CClient::SetNetChan(CNetChan* pNetChan)
+{
+	m_NetChannel = pNetChan;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: checks if client is connected to server
+// Output : true if connected, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsConnected(void) const
+{
+	return m_nSignonState >= SIGNONSTATE::SIGNONSTATE_CONNECTED;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: checks if client is spawned to server
+// Output : true if connected, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsSpawned(void) const
+{
+	return m_nSignonState >= SIGNONSTATE::SIGNONSTATE_NEW;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: checks if client is active to server
+// Output : true if connected, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsActive(void) const
+{
+	return m_nSignonState == SIGNONSTATE::SIGNONSTATE_FULL;
+}
+//---------------------------------------------------------------------------------
+// Purpose: checks if client's persistence data is ready
+// Output : true if ready, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsPersistenceReady(void) const
+{
+	return m_nPersistenceState == PERSISTENCE::PERSISTENCE_READY;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: checks if client is a fake client
+// Output : true if connected, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsFakeClient(void) const
+{
+	return m_bFakePlayer;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: checks if this client is an actual human player
+// Output : true if human, false otherwise
+//---------------------------------------------------------------------------------
+bool CClient::IsHumanPlayer(void) const
+{
+	if (!IsConnected())
+		return false;
+
+	if (IsFakeClient())
+		return false;
+
+	return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+CClient* g_pClient = nullptr;
+
+void InitialiseBaseClient(HMODULE baseAddress)
+{
+	g_pClient = (CClient*)GetModuleHandleA("engine.dll") + 0x12A53F90;
+}

--- a/NorthstarDedicatedTest/client.h
+++ b/NorthstarDedicatedTest/client.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "protocol.h"
+#include "net_chan.h"
+
+//-----------------------------------------------------------------------------
+// Forward declarations
+//-----------------------------------------------------------------------------
+class CServer;
+class CClient;
+
+struct IClientMessageHandler
+{
+	void* __vftable;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+extern CClient* g_pClient;
+
+class CClient : INetChannelHandler, IClientMessageHandler
+{
+  public:
+	CClient* GetClient(int nIndex) const;
+	uint16_t GetHandle(void) const;
+	uint32_t GetUserID(void) const;
+	uint64_t GetOriginID(void) const;
+	SIGNONSTATE GetSignonState(void) const;
+	PERSISTENCE GetPersistenceState(void) const;
+	CNetChan* GetNetChan(void) const;
+	const char* GetServerName(void) const;
+	const char* GetClientName(void) const;
+	void SetHandle(uint16_t nHandle);
+	void SetUserID(uint32_t nUserID);
+	void SetOriginID(uint64_t nOriginID);
+	void SetSignonState(SIGNONSTATE nSignonState);
+	void SetPersistenceState(PERSISTENCE nPersistenceState);
+	void SetNetChan(CNetChan* pNetChan);
+	bool IsConnected(void) const;
+	bool IsSpawned(void) const;
+	bool IsActive(void) const;
+	bool IsPersistenceAvailable(void) const;
+	bool IsPersistenceReady(void) const;
+	bool IsFakeClient(void) const;
+	bool IsHumanPlayer(void) const;
+	bool Connect(const char* szName, void* pNetChannel, bool bFakePlayer, void* a5, char* szMessage, int nMessageSize);
+	static bool
+	VConnect(CClient* pClient, const char* szName, void* pNetChannel, bool bFakePlayer, void* a5, char* szMessage, int nMessageSize);
+	void Clear(void);
+	static void VClear(CClient* pBaseClient);
+
+  private:
+	uint32_t m_nUserID;
+	uint16_t m_nHandle;
+	char m_szServerName[64];
+	int64_t m_nReputation;
+	char pad_0014[182];
+	char m_szClientName[64];
+	char pad_0015[252];
+	void* m_ConVars; // [KeyValues*]
+	char pad_0368[8];
+	CServer* m_pServer;
+	char pad_0378[32];
+	CNetChan* m_NetChannel;
+	char pad_03A8[8];
+	SIGNONSTATE m_nSignonState;
+	int32_t m_nDeltaTick;
+	uint64_t m_nOriginID;
+	int32_t m_nStringTableAckTick;
+	int32_t m_nSignonTick;
+	char pad_03C0[460];
+	bool m_bFakePlayer;
+	bool m_bReceivedPacket;
+	bool m_bLowViolence;
+	bool m_bFullyAuthenticated;
+	char pad_05A4[24];
+	PERSISTENCE m_nPersistenceState;
+	char pad_05C0[184964];
+};
+
+void InitialiseBaseClient(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -42,10 +42,10 @@
 #include "debugoverlay.h"
 #include "clientvideooverrides.h"
 #include "clientruihooks.h"
-#include <string.h>
 #include "version.h"
-#include "pch.h"
 #include "scriptutility.h"
+#include "server.h"
+#include "client.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
@@ -272,6 +272,8 @@ bool InitialiseNorthstar()
 	AddDllLoadCallback("server.dll", InitialiseServerSquirrelUtilityFunctions);
 
 	AddDllLoadCallback("engine.dll", InitialisePlaylistHooks);
+	AddDllLoadCallback("engine.dll", InitialiseBaseServer);
+	AddDllLoadCallback("engine.dll", InitialiseBaseClient);
 
 	AddDllLoadCallback("filesystem_stdio.dll", InitialiseFilesystem);
 	AddDllLoadCallback("engine.dll", InitialiseEngineRpakFilesystem);

--- a/NorthstarDedicatedTest/net.cpp
+++ b/NorthstarDedicatedTest/net.cpp
@@ -1,0 +1,110 @@
+//=============================================================================//
+//
+// Purpose: Net system utilities
+//
+//=============================================================================//
+
+#include "pch.h"
+#include "net.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: returns the WSA error code
+//-----------------------------------------------------------------------------
+const char* NET_ErrorString(int iCode)
+{
+	switch (iCode)
+	{
+	case WSAEINTR:
+		return "WSAEINTR";
+	case WSAEBADF:
+		return "WSAEBADF";
+	case WSAEACCES:
+		return "WSAEACCES";
+	case WSAEDISCON:
+		return "WSAEDISCON";
+	case WSAEFAULT:
+		return "WSAEFAULT";
+	case WSAEINVAL:
+		return "WSAEINVAL";
+	case WSAEMFILE:
+		return "WSAEMFILE";
+	case WSAEWOULDBLOCK:
+		return "WSAEWOULDBLOCK";
+	case WSAEINPROGRESS:
+		return "WSAEINPROGRESS";
+	case WSAEALREADY:
+		return "WSAEALREADY";
+	case WSAENOTSOCK:
+		return "WSAENOTSOCK";
+	case WSAEDESTADDRREQ:
+		return "WSAEDESTADDRREQ";
+	case WSAEMSGSIZE:
+		return "WSAEMSGSIZE";
+	case WSAEPROTOTYPE:
+		return "WSAEPROTOTYPE";
+	case WSAENOPROTOOPT:
+		return "WSAENOPROTOOPT";
+	case WSAEPROTONOSUPPORT:
+		return "WSAEPROTONOSUPPORT";
+	case WSAESOCKTNOSUPPORT:
+		return "WSAESOCKTNOSUPPORT";
+	case WSAEOPNOTSUPP:
+		return "WSAEOPNOTSUPP";
+	case WSAEPFNOSUPPORT:
+		return "WSAEPFNOSUPPORT";
+	case WSAEAFNOSUPPORT:
+		return "WSAEAFNOSUPPORT";
+	case WSAEADDRINUSE:
+		return "WSAEADDRINUSE";
+	case WSAEADDRNOTAVAIL:
+		return "WSAEADDRNOTAVAIL";
+	case WSAENETDOWN:
+		return "WSAENETDOWN";
+	case WSAENETUNREACH:
+		return "WSAENETUNREACH";
+	case WSAENETRESET:
+		return "WSAENETRESET";
+	case WSAECONNABORTED:
+		return "WSWSAECONNABORTEDAEINTR";
+	case WSAECONNRESET:
+		return "WSAECONNRESET";
+	case WSAENOBUFS:
+		return "WSAENOBUFS";
+	case WSAEISCONN:
+		return "WSAEISCONN";
+	case WSAENOTCONN:
+		return "WSAENOTCONN";
+	case WSAESHUTDOWN:
+		return "WSAESHUTDOWN";
+	case WSAETOOMANYREFS:
+		return "WSAETOOMANYREFS";
+	case WSAETIMEDOUT:
+		return "WSAETIMEDOUT";
+	case WSAECONNREFUSED:
+		return "WSAECONNREFUSED";
+	case WSAELOOP:
+		return "WSAELOOP";
+	case WSAENAMETOOLONG:
+		return "WSAENAMETOOLONG";
+	case WSAEHOSTDOWN:
+		return "WSAEHOSTDOWN";
+	case WSAEPROCLIM:
+		return "WSAEPROCLIM";
+	case WSASYSNOTREADY:
+		return "WSASYSNOTREADY";
+	case WSAVERNOTSUPPORTED:
+		return "WSAVERNOTSUPPORTED";
+	case WSANOTINITIALISED:
+		return "WSANOTINITIALISED";
+	case WSAHOST_NOT_FOUND:
+		return "WSAHOST_NOT_FOUND";
+	case WSATRY_AGAIN:
+		return "WSATRY_AGAIN";
+	case WSANO_RECOVERY:
+		return "WSANO_RECOVERY";
+	case WSANO_DATA:
+		return "WSANO_DATA";
+	default:
+		return "UNKNOWN_ERROR";
+	}
+}

--- a/NorthstarDedicatedTest/net.h
+++ b/NorthstarDedicatedTest/net.h
@@ -1,0 +1,3 @@
+#pragma once
+
+const char* NET_ErrorString(int iCode);

--- a/NorthstarDedicatedTest/net_chan.cpp
+++ b/NorthstarDedicatedTest/net_chan.cpp
@@ -1,0 +1,194 @@
+//=============================================================================//
+//
+// Purpose: Netchannel system utilities
+//
+//=============================================================================//
+
+#include "pch.h"
+#include "cvar.h"
+#include "net.h"
+#include "net_chan.h"
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel name
+// Output : const char*
+//-----------------------------------------------------------------------------
+std::string CNetChan::GetName(void) const
+{
+	return std::string(this->m_Name + 1);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel address
+// Output : const char*
+//-----------------------------------------------------------------------------
+std::string CNetChan::GetAddress(void) const
+{
+	char szAdr[INET6_ADDRSTRLEN] {};
+	if (!inet_ntop(AF_INET6, &this->remote_address.adr, szAdr, INET6_ADDRSTRLEN))
+	{
+		spdlog::warn("{:s} - Address conversion failed: {:s}", __FUNCTION__, NET_ErrorString(WSAGetLastError()));
+	}
+	return std::string(szAdr);
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel data rate
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetDataRate(void) const
+{
+	return this->m_Rate;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel buffer size (NET_FRAMES_BACKUP)
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetBufferSize(void) const
+{
+	return NET_FRAMES_BACKUP;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel latency
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetLatency(int flow) const
+{
+	return this->m_DataFlow[flow].latency;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel average choke
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetAvgChoke(int flow) const
+{
+	return this->m_DataFlow[flow].avgchoke;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel average latency
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetAvgLatency(int flow) const
+{
+	return this->m_DataFlow[flow].avglatency;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel average loss
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetAvgLoss(int flow) const
+{
+	return this->m_DataFlow[flow].avgloss;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel average packets
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetAvgPackets(int flow) const
+{
+	return this->m_DataFlow[flow].avgpacketspersec;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel average data
+// Input  : flow -
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetAvgData(int flow) const
+{
+	return this->m_DataFlow[flow].avgbytespersec;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel total data
+// Input  : flow -
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetTotalData(int flow) const
+{
+	return this->m_DataFlow[flow].totalbytes;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel total packets
+// Input  : flow -
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetTotalPackets(int flow) const
+{
+	return this->m_DataFlow[flow].totalpackets;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel sequence number
+// Input  : flow -
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetSequenceNr(int flow) const
+{
+	if (flow == FLOW_OUTGOING)
+	{
+		return this->m_nOutSequenceNr;
+	}
+	else if (flow == FLOW_INCOMING)
+	{
+		return this->m_nInSequenceNr;
+	}
+
+	return NULL;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel connect time
+// Output : double
+//-----------------------------------------------------------------------------
+double CNetChan::GetConnectTime(void) const
+{
+	return this->connect_time;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel timeout
+// Output : float
+//-----------------------------------------------------------------------------
+float CNetChan::GetTimeoutSeconds(void) const
+{
+	return this->m_Timeout;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: gets the netchannel socket
+// Output : int
+//-----------------------------------------------------------------------------
+int CNetChan::GetSocket(void) const
+{
+	return this->m_Socket;
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: checks if the reliable stream is overflowed
+// Output : true if overflowed, false otherwise
+//-----------------------------------------------------------------------------
+bool CNetChan::IsOverflowed(void) const
+{
+	return this->m_StreamReliable.IsOverflowed();
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: clears the netchannel
+//-----------------------------------------------------------------------------
+void CNetChan::Clear(bool bStopProcessing)
+{
+	//v_NetChan_Clear(this, bStopProcessing);
+}

--- a/NorthstarDedicatedTest/net_chan.h
+++ b/NorthstarDedicatedTest/net_chan.h
@@ -1,0 +1,239 @@
+//=============================================================================//
+//
+// Purpose:
+//
+//=============================================================================//
+
+#ifndef NET_CHAN_H
+#define NET_CHAN_H
+
+#include "bitbuf.h"
+#include "valve_utl.h"
+#include "serverauthentication.h"
+
+#define NET_FRAMES_BACKUP 128
+#define NAT_CHANNEL_MAXNAME 32
+#define NET_FRAMES_MASK (NET_FRAMES_BACKUP - 1)
+
+#define NET_FRAMES_BACKUP 128
+#define FLOW_OUTGOING 0
+#define FLOW_INCOMING 1
+#define MAX_FLOWS 2 // in & out
+
+//-----------------------------------------------------------------------------
+// Purpose: forward declarations
+//-----------------------------------------------------------------------------
+class CClient;
+
+//-----------------------------------------------------------------------------
+struct netframe_t
+{
+	float one;
+	float two;
+	float three;
+	float four;
+	float five;
+	float six;
+};
+
+//-----------------------------------------------------------------------------
+struct netflow_t
+{
+	float nextcompute;
+	float avgbytespersec;
+	float avgpacketspersec;
+	float avgloss;
+	float avgchoke;
+	float avglatency;
+	float latency;
+	int64_t totalpackets;
+	int64_t totalbytes;
+	netframe_t frames[NET_FRAMES_BACKUP];
+	netframe_t current_frame;
+};
+
+//-----------------------------------------------------------------------------
+struct dataFragments_t
+{
+	char* data;
+	int64_t block_size;
+	bool m_bIsCompressed;
+	uint8_t gap11[7];
+	int64_t m_nRawSize;
+	bool m_bFirstFragment;
+	bool m_bLastFragment;
+	bool m_bIsOutbound;
+	int transferID;
+	int m_nTransferSize;
+	int m_nCurrentOffset;
+};
+
+struct VecNetDataFragments
+{
+	void** items;
+	__int64 m_nAllocationCount;
+	__int64 m_nGrowSize;
+	int m_Size;
+	int padding_;
+};
+
+struct CNetMessage
+{
+	void* iNetMessageVTable;
+	int m_nGroup;
+	bool m_bReliable;
+	char padding[3];
+	void* m_NetChannel;
+};
+
+
+struct VecNetMessages
+{
+	CNetMessage** items;
+	__int64 m_nAllocationCount;
+	__int64 m_nGrowSize;
+	int m_Size;
+	int padding_;
+};
+
+
+//-----------------------------------------------------------------------------
+enum EBufType
+{
+	BUF_RELIABLE = 0,
+	BUF_UNRELIABLE,
+	BUF_VOICE
+};
+
+class INetChannelHandler
+{
+	void* __vftable;
+};
+
+typedef enum
+{
+	NA_NULL = 0,
+	NA_LOOPBACK,
+	NA_IP,
+} netadrtype_t;
+
+class netadr_t
+{
+  public:
+	inline netadrtype_t GetType(void) const
+	{
+		return this->type;
+	}
+	inline std::string GetAddress(void) const
+	{
+		char szAdr[INET6_ADDRSTRLEN] {};
+		inet_ntop(AF_INET6, &this->adr, szAdr, INET6_ADDRSTRLEN);
+
+		return szAdr;
+	}
+	inline uint16_t GetPort(void) const
+	{
+		return this->port;
+	}
+	inline bool IsReliable(void) const
+	{
+		return this->reliable;
+	}
+	netadrtype_t type;
+	IN6_ADDR adr;
+	uint16_t port;
+	bool field_16;
+	bool reliable;
+};
+
+//-----------------------------------------------------------------------------
+class CNetChan // [WARNING: SOME MEMBERS ARE WRONG AS THIS IS TAKEN FROM R5R, 'remote_address' DOES ALIGN].
+{
+  public:
+	std::string GetName(void) const;
+	std::string GetAddress(void) const;
+	int GetDataRate(void) const;
+	int GetBufferSize(void) const;
+
+	float GetLatency(int flow) const;
+	float GetAvgChoke(int flow) const;
+	float GetAvgLatency(int flow) const;
+	float GetAvgLoss(int flow) const;
+	float GetAvgPackets(int flow) const;
+	float GetAvgData(int flow) const;
+
+	int GetTotalData(int flow) const;
+	int GetTotalPackets(int flow) const;
+	int GetSequenceNr(int flow) const;
+
+	float GetTimeoutSeconds(void) const;
+	double GetConnectTime(void) const;
+	int GetSocket(void) const;
+
+	bool IsOverflowed(void) const;
+	void Clear(bool bStopProcessing);
+	//-----------------------------------------------------------------------------
+  private:
+	bool m_bProcessingMessages;
+	bool m_bShouldDelete;
+	bool m_bStopProcessing;
+	bool shutting_down;
+	int m_nOutSequenceNr;
+	int m_nInSequenceNr;
+	int m_nOutSequenceNrAck;
+	int m_nChokedPackets;
+	int unknown_challenge_var;
+	int m_nLastRecvFlags;
+	RTL_SRWLOCK LOCK;
+	BFWrite m_StreamReliable;
+	CUtlMemory m_ReliableDataBuffer;
+	BFWrite m_StreamUnreliable;
+	CUtlMemory m_UnreliableDataBuffer;
+	struct BFWrite m_StreamVoice;
+	CUtlMemory m_VoiceDataBuffer;
+	int m_Socket;
+	int m_MaxReliablePayloadSize;
+	double last_received;
+	double connect_time;
+	unsigned int m_Rate;
+	int padding_maybe;
+	double m_fClearTime;
+	VecNetDataFragments m_WaitingList;
+	dataFragments_t m_ReceiveList;
+	int m_nSubOutFragmentsAck;
+	int m_nSubInFragments;
+	int m_nNonceHost;
+	unsigned int m_nNonceRemote;
+	bool m_bReceivedRemoteNonce;
+	bool m_bInReliableState;
+	bool m_bPendingRemoteNonceAck;
+	unsigned int m_nSubOutSequenceNr;
+	int m_nLastRecvNonce;
+	bool m_bUseCompression;
+	unsigned int dword168;
+	float m_Timeout;
+	INetChannelHandler* m_MessageHandler;
+	VecNetMessages m_NetMessages;
+	unsigned int qword198;
+	int m_nQueuedPackets;
+	float m_flRemoteFrameTime;
+	float m_flRemoteFrameTimeStdDeviation;
+	unsigned __int8 m_bUnkTickBool;
+	int m_nMaxRoutablePayloadSize;
+	int m_nSplitPacketSequence;
+	__int64 m_StreamSendBuffer;
+	BFWrite m_StreamSend;
+	unsigned __int8 m_bInMatch_maybe;
+	netflow_t m_DataFlow[2];
+	int m_nLifetimePacketsDropped;
+	int m_nSessionPacketsDropped;
+	int m_nSequencesSkipped_MAYBE;
+	int m_nSessionRecvs;
+	unsigned int m_nLiftimeRecvs;
+	char TODO[6972];
+	char m_Name[35];
+	unsigned __int8 m_bRetrySendLong;
+	netadr_t remote_address;
+};
+
+#endif // NET_CHAN_H

--- a/NorthstarDedicatedTest/protocol.h
+++ b/NorthstarDedicatedTest/protocol.h
@@ -1,0 +1,25 @@
+#pragma once
+
+/*-----------------------------------------------------------------------------
+ * _protocol.h
+ *-----------------------------------------------------------------------------*/
+
+enum class SIGNONSTATE : int
+{
+	SIGNONSTATE_NONE = 0, // no state yet; about to connect.
+	SIGNONSTATE_CHALLENGE = 1, // client challenging server; all OOB packets.
+	SIGNONSTATE_CONNECTED = 2, // client is connected to server; netchans ready.
+	SIGNONSTATE_NEW = 3, // just got serverinfo and string tables.
+	SIGNONSTATE_PRESPAWN = 4, // received signon buffers.
+	SIGNONSTATE_GETTING_DATA = 5, // getting persistence data.
+	SIGNONSTATE_SPAWN = 6, // ready to receive entity packets.
+	SIGNONSTATE_FIRST_SNAP = 7, // received baseline snapshot.
+	SIGNONSTATE_FULL = 8, // we are fully connected; first non-delta packet received.
+	SIGNONSTATE_CHANGELEVEL = 9, // server is changing level; please wait.
+};
+
+enum class PERSISTENCE : int
+{
+	PERSISTENCE_NONE = 0, // no persistence data for this client yet.
+	PERSISTENCE_READY = 3 // persistence is ready for this client.
+};

--- a/NorthstarDedicatedTest/server.cpp
+++ b/NorthstarDedicatedTest/server.cpp
@@ -1,0 +1,60 @@
+//=============================================================================//
+//
+// Purpose:
+//
+// $NoKeywords: $
+//
+//=============================================================================//
+// server.cpp: implementation of the CServer class.
+//
+/////////////////////////////////////////////////////////////////////////////////
+#include "pch.h"
+#include "server.h"
+#include "client.h"
+
+//---------------------------------------------------------------------------------
+// Purpose: Gets the number of human players on the server
+// Output : int
+//---------------------------------------------------------------------------------
+int CServer::GetNumHumanPlayers(void) const
+{
+	int nHumans = 0;
+	for (int i = 0; i < 32; i++) // !FIXME: Use g_ServerGlobalVariables->m_nMaxClients!
+	{
+		CClient* pClient = g_pClient->GetClient(i);
+		if (!pClient)
+			continue;
+
+		if (pClient->IsHumanPlayer())
+			nHumans++;
+	}
+
+	return nHumans;
+}
+
+//---------------------------------------------------------------------------------
+// Purpose: Gets the number of fake clients on the server
+// Output : int
+//---------------------------------------------------------------------------------
+int CServer::GetNumFakeClients(void) const
+{
+	int nBots = 0;
+	for (int i = 0; i < 32; i++) // !FIXME: Use g_ServerGlobalVariables->m_nMaxClients!
+	{
+		CClient* pClient = g_pClient->GetClient(i);
+		if (!pClient)
+			continue;
+
+		if (pClient->IsConnected() && pClient->IsFakeClient())
+			nBots++;
+	}
+
+	return nBots;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+CServer* g_pServer = nullptr; // Link this to the global server array below.
+
+void InitialiseBaseServer(HMODULE baseAddress) {
+
+}

--- a/NorthstarDedicatedTest/server.h
+++ b/NorthstarDedicatedTest/server.h
@@ -1,0 +1,97 @@
+#pragma once
+#include "net_chan.h"
+#include "valve_utl.h"
+#include "stringtable.h"
+#include "stringtable.h"
+#include "gameutils.h" // For 'server_state_t' (this should be moved to this header).
+
+#define MAX_MAP_NAME 64
+
+struct user_creds_s
+{
+	netadr_t m_nAddr;
+	int32_t m_nProtocolVer;
+	int32_t m_nchallenge;
+	uint8_t gap2[8];
+	uint64_t m_nNucleusID;
+	uint8_t* m_nUserID;
+};
+
+class IServer
+{
+	IServer* m_pVTable;
+};
+
+class CServer : public IServer
+{
+  public:
+	int GetTick(void) const
+	{
+		return m_nTickCount;
+	}
+#ifndef CLIENT_DLL // Only the connectionless packet handler is implemented on the client via the IServer base class.
+	int GetNumHumanPlayers(void) const;
+	int GetNumFakeClients(void) const;
+	const char* GetMapName(void) const
+	{
+		return m_szMapname;
+	}
+	const char* GetMapGroupName(void) const
+	{
+		return m_szMapGroupName;
+	}
+	int GetNumClasses(void) const
+	{
+		return m_nServerClasses;
+	}
+	int GetClassBits(void) const
+	{
+		return m_nServerClassBits;
+	}
+	bool IsActive(void) const
+	{
+		return m_State >= server_state_t::ss_active;
+	}
+	bool IsLoading(void) const
+	{
+		return m_State == server_state_t::ss_loading;
+	}
+	bool IsDedicated(void) const
+	{
+		//return g_bDedicated;
+	}
+	static CClient* Authenticate(CServer* pServer, user_creds_s* pInpacket);
+#endif // !CLIENT_DLL
+
+  private:
+	server_state_t m_State;
+	int m_Socket;
+	int m_nTickCount;
+	bool m_bResetMaxTeams;
+	char m_szMapname[64];
+	char m_szMapGroupName[64];
+	char m_Password[32];
+	uint32_t worldmapCRC;
+	uint32_t clientDllCRC;
+	void* unkData;
+	CNetworkStringTableContainer* m_StringTables;
+	CNetworkStringTable* m_pInstanceBaselineTable;
+	CNetworkStringTable* m_pLightStyleTable;
+	CNetworkStringTable* m_pUserInfoTable;
+	CNetworkStringTable* m_pServerQueryTable;
+	bool m_bReplay;
+	bool m_bUpdateFrame;
+	bool m_bUseReputation;
+	bool m_bSimulating;
+	int m_nPad;
+	BFWrite m_Signon;
+	CUtlMemory m_SignonBuffer;
+	int m_nServerClasses;
+	int m_nServerClassBits;
+	char m_szConDetails[64];
+	char m_szHostInfo[128];
+	char m_PadArray[303824];
+};
+extern CServer* g_pServer;
+
+void InitialiseBaseServer(HMODULE baseAddress);

--- a/NorthstarDedicatedTest/serverauthentication.cpp
+++ b/NorthstarDedicatedTest/serverauthentication.cpp
@@ -15,6 +15,7 @@
 #include <thread>
 #include "configurables.h"
 #include "NSMem.h"
+#include "client.h"
 
 const char* AUTHSERVER_VERIFY_STRING = "I am a northstar server!";
 

--- a/NorthstarDedicatedTest/serverauthentication.h
+++ b/NorthstarDedicatedTest/serverauthentication.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "convar.h"
+#include "net_chan.h"
 #include "httplib.h"
 #include <unordered_map>
 #include <string>
@@ -33,28 +34,23 @@ struct AdditionalPlayerData
 };
 
 #pragma once
-typedef enum
-{
-	NA_NULL = 0,
-	NA_LOOPBACK,
-	NA_IP,
-} netadrtype_t;
 
 #pragma pack(push, 1)
-typedef struct netadr_s
+typedef struct netadr_s // !FIXME: USE NEW STRUCT IN NET_CHAN.H!
 {
-	netadrtype_t type;
+	//netadrtype_t type;
+	int type;
 	unsigned char ip[16]; // IPv6
 	// IPv4's 127.0.0.1 is [::ffff:127.0.0.1], that is:
 	// 00 00 00 00 00 00 00 00    00 00 FF FF 7F 00 00 01
 	unsigned short port;
-} netadr_t;
+} netadr_t_old;
 #pragma pack(pop)
 
 #pragma pack(push, 1)
 typedef struct netpacket_s
 {
-	netadr_t adr; // sender address
+	netadr_t_old adr; // sender address
 	// int				source;		// received source
 	char unk[10];
 	double received_time;

--- a/NorthstarDedicatedTest/stringtable.h
+++ b/NorthstarDedicatedTest/stringtable.h
@@ -1,0 +1,42 @@
+#ifndef NETWORKSTRINGTABLE_H
+#define NETWORKSTRINGTABLE_H
+
+typedef int TABLEID;
+
+class INetworkStringTable
+{
+	INetworkStringTable* m_pVTable;
+};
+
+class CNetworkStringTable : public INetworkStringTable
+{
+  public:
+	TABLEID GetTableId(void) const;
+	int GetMaxStrings(void) const;
+	const char* GetTableName(void) const;
+	int GetEntryBits(void) const;
+	void SetTick(int tick_count);
+	bool Lock(bool bLock);
+
+	TABLEID m_id;
+	bool m_bLocked; // Might be wrong!
+	char* m_pszTableName;
+	int m_nMaxEntries;
+	int m_nEntryBits;
+	int m_nTickCount;
+	int m_nLastChangedTick;
+	uint32_t m_nFlags;
+	// !TODO
+};
+
+class CNetworkStringTableContainer : public INetworkStringTable
+{
+  public:
+	bool m_bAllowCreation; // creat guard Guard
+	int m_nTickCount; // current tick
+	bool m_bLocked; // currently locked?
+	bool m_bEnableRollback; // enables rollback feature
+	// CUtlVector < CNetworkStringTable* > m_Tables;	// the string tables
+};
+
+#endif // NETWORKSTRINGTABLE_H

--- a/NorthstarDedicatedTest/valve_utl.h
+++ b/NorthstarDedicatedTest/valve_utl.h
@@ -1,0 +1,39 @@
+#pragma once
+
+struct __declspec(align(8)) CUtlMemory
+{
+	void* m_pMemory;
+	int64_t m_nAllocationCount;
+	int64_t m_nGrowSize;
+};
+
+struct __declspec(align(4)) CUtlVector
+{
+	void* vtable;
+	CUtlMemory m_Memory;
+	int m_Size;
+};
+
+struct CUtlVectorMT
+{
+	__int64* items;
+	__int64 m_nAllocationCount;
+	__int64 m_nGrowSize;
+	int m_Size;
+	int padding_;
+	_RTL_CRITICAL_SECTION LOCK;
+};
+
+struct CUtlMemoryPool
+{
+	int m_BlockSize;
+	int m_BlocksPerBlob;
+	int m_GrowMode;
+	int m_BlocksAllocated;
+	int unk;
+	__int16 m_nAlignment;
+	__int16 m_NumBlobs;
+	__int64 m_pszAllocOwner;
+	__int64 m_Prev_MAYBE;
+	__int64 m_Next_MAYBE;
+};


### PR DESCRIPTION
Implemented:
* CServer
* CClient
* CNetChan
* A few smaller ones

Not all members align, however a lot do (structs have been taken from R5R).
CServer is aligned entirely
CClient is fairly well aligned (name, netchan, etc).
CNetChan also seems ok for the most part but towards the end i added padding as they did something (needs reversing), but you can obtain the addresses and signonstate, etc.

Example usage:
```cpp
CClient* pClient = g_pClient->GetClient(i);
spdlog::info("{}", pClient->GetServerName());
spdlog::info("{}", pClient->GetNetChan()->GetAddress());
```

I recommend replacing `GetPlayerByIndex()` with this entirely, and also fixup some of the fields like where OriginID is since i couldn't find it but i think you had some offsets to it, so you can add the members at this offset of the structure.
Persistence data should also be added still, but i left these parts as i don't know the exact sizes and how Northstar uses them.

I also added a few fixme comments.
