### PR TITLE
Fix most clang/mingw issues

### DIFF
--- a/LauncherInjector/LauncherInjector.vcxproj
+++ b/LauncherInjector/LauncherInjector.vcxproj
@@ -56,7 +56,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/F8000000 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -74,7 +74,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/F8000000 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/LauncherInjector/main.cpp
+++ b/LauncherInjector/main.cpp
@@ -1,10 +1,10 @@
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <TlHelp32.h>
+#include <windows.h>
+#include <tlhelp32.h>
 #include <filesystem>
 #include <sstream>
 #include <fstream>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <iostream>
 
 namespace fs = std::filesystem;
@@ -225,7 +225,7 @@ bool ShouldLoadNorthstar(int argc, char* argv[])
 		std::stringstream runNorthstarFileBuffer;
 		runNorthstarFileBuffer << runNorthstarFile.rdbuf();
 		runNorthstarFile.close();
-		if (runNorthstarFileBuffer.str()._Starts_with("0"))
+		if (runNorthstarFileBuffer.str().starts_with("0"))
 			loadNorthstar = false;
 	}
 	return loadNorthstar;
@@ -236,7 +236,7 @@ bool LoadNorthstar()
 	FARPROC Hook_Init = nullptr;
 	{
 		swprintf_s(buffer, L"%s\\Northstar.dll", exePath);
-		hHookModule = LoadLibraryExW(buffer, 0i64, 8u);
+		hHookModule = LoadLibraryExW(buffer, 0, 8u);
 		if (hHookModule)
 			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
 		if (!hHookModule || Hook_Init == nullptr)

--- a/NorthstarDedicatedTest/ExploitFixes.cpp
+++ b/NorthstarDedicatedTest/ExploitFixes.cpp
@@ -204,7 +204,7 @@ KHOOK(ReadUsercmd, ("server.dll", "4C 89 44 24 ? 53 55 56 57"), void, __fastcall
 	oReadUsercmd(buf, pCmd_move, pCmd_from);
 
 	// Now let's make sure the CMD we read isnt messed up to prevent numerous exploits (including server crashing)
-	struct __declspec(align(4)) SV_CUserCmd
+	struct alignas(4) SV_CUserCmd
 	{
 		DWORD command_number;
 		DWORD tick_count;
@@ -291,7 +291,11 @@ KHOOK(
 
 	static void* targetRetAddr = NSMem::PatternScan("engine.dll", "84 C0 75 2C 49 8B 16");
 
+#ifdef _MSC_VER
 	if (_ReturnAddress() == targetRetAddr)
+#else
+	if (__builtin_return_address(0) == targetRetAddr)
+#endif
 	{
 		if (!ExploitFixes_UTF8Parser::CheckValid(a1, a2, strData))
 		{

--- a/NorthstarDedicatedTest/NSMem.h
+++ b/NorthstarDedicatedTest/NSMem.h
@@ -44,7 +44,7 @@ namespace NSMem
 					}
 					else
 					{
-						assert(false, "Failed to parse invalid hex string.");
+						assert(false);
 						val = -1;
 					}
 
@@ -188,6 +188,6 @@ struct KHook
 #define KHOOK(name, funcPatternInfo, returnType, convention, args)                                                                         \
 	returnType convention hk##name args;                                                                                                   \
 	auto o##name = (returnType(convention*) args)0;                                                                                        \
-	KHook k##name = KHook(KHookPatternInfo funcPatternInfo, &hk##name, (void**)&o##name);                                                  \
+	KHook k##name = KHook(KHookPatternInfo funcPatternInfo, reinterpret_cast<void*>(&hk##name), (void**)&o##name);                         \
 	returnType convention hk##name args
 #pragma endregion

--- a/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
+++ b/NorthstarDedicatedTest/NorthstarDedicatedTest.vcxproj
@@ -59,7 +59,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -86,7 +86,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>

--- a/NorthstarDedicatedTest/audio.cpp
+++ b/NorthstarDedicatedTest/audio.cpp
@@ -194,7 +194,7 @@ EventOverrideData::EventOverrideData(const std::string& data, const fs::path& pa
 			std::string pathString = file.path().string();
 
 			// Open the file.
-			std::basic_ifstream<uint8_t> wavStream(pathString, std::ios::binary);
+			std::ifstream wavStream(pathString, std::ios::binary);
 
 			if (wavStream.fail())
 			{
@@ -219,7 +219,7 @@ EventOverrideData::EventOverrideData(const std::string& data, const fs::path& pa
 				[pathString, fileSize, data]
 				{
 					std::shared_lock lock(g_CustomAudioManager.m_loadingMutex);
-					std::basic_ifstream<uint8_t> wavStream(pathString, std::ios::binary);
+					std::ifstream wavStream(pathString, std::ios::binary);
 
 					// would be weird if this got hit, since it would've worked previously
 					if (wavStream.fail())
@@ -230,9 +230,9 @@ EventOverrideData::EventOverrideData(const std::string& data, const fs::path& pa
 
 					// read from after the header first to preserve the empty header, then read the header last
 					wavStream.seekg(sizeof(EMPTY_WAVE), std::ios::beg);
-					wavStream.read(&data[sizeof(EMPTY_WAVE)], fileSize - sizeof(EMPTY_WAVE));
+					wavStream.read(reinterpret_cast<char*>(&data[sizeof(EMPTY_WAVE)]), fileSize - sizeof(EMPTY_WAVE));
 					wavStream.seekg(0, std::ios::beg);
-					wavStream.read(data, sizeof(EMPTY_WAVE));
+					wavStream.read(reinterpret_cast<char*>(data), sizeof(EMPTY_WAVE));
 					wavStream.close();
 
 					spdlog::info("Finished async read of audio sample {}", pathString);

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "pch.h"
 #include "bansystem.h"
 #include "serverauthentication.h"

--- a/NorthstarDedicatedTest/clientvideooverrides.cpp
+++ b/NorthstarDedicatedTest/clientvideooverrides.cpp
@@ -35,5 +35,8 @@ void InitialiseClientVideoOverrides(HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
-		hook, GetProcAddress(GetModuleHandleA("bink2w64.dll"), "BinkOpen"), &BinkOpenHook, reinterpret_cast<LPVOID*>(&BinkOpen));
+		hook,
+		reinterpret_cast<void*>(GetProcAddress(GetModuleHandleA("bink2w64.dll"), "BinkOpen")),
+		&BinkOpenHook,
+		reinterpret_cast<LPVOID*>(&BinkOpen));
 }

--- a/NorthstarDedicatedTest/convar.cpp
+++ b/NorthstarDedicatedTest/convar.cpp
@@ -1,3 +1,5 @@
+#include <float.h>
+
 #include "pch.h"
 #include "bits.h"
 #include "cvar.h"

--- a/NorthstarDedicatedTest/dedicatedmaterialsystem.cpp
+++ b/NorthstarDedicatedTest/dedicatedmaterialsystem.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "pch.h"
 #include "dedicated.h"
 #include "dedicatedmaterialsystem.h"

--- a/NorthstarDedicatedTest/dllmain.cpp
+++ b/NorthstarDedicatedTest/dllmain.cpp
@@ -52,9 +52,9 @@
 #include "rapidjson/writer.h"
 #include "rapidjson/error/en.h"
 #include "ExploitFixes.h"
-#include "scriptJson.h"
+#include "scriptjson.h"
 
-typedef void (*initPluginFuncPtr)(void* getPluginObject);
+typedef void (*initPluginFuncPtr)(void* (*getPluginObject)(PluginObject));
 
 bool initialised = false;
 
@@ -129,7 +129,7 @@ bool LoadPlugins()
 			spdlog::info("Failed to load library {}: ", std::system_category().message(GetLastError()));
 			continue;
 		}
-		HRSRC manifestResource = FindResourceW(datafile, MAKEINTRESOURCE(101), MAKEINTRESOURCE(RT_RCDATA));
+		HRSRC manifestResource = FindResourceW(datafile, MAKEINTRESOURCEW(101), MAKEINTRESOURCEW(RT_RCDATA));
 
 		if (manifestResource == NULL)
 		{

--- a/NorthstarDedicatedTest/filesystem.cpp
+++ b/NorthstarDedicatedTest/filesystem.cpp
@@ -41,11 +41,19 @@ void InitialiseFilesystem(HMODULE baseAddress)
 	// create hooks
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x5CBA0, &ReadFileFromVPKHook, reinterpret_cast<LPVOID*>(&readFileFromVPK));
-	ENABLER_CREATEHOOK(hook, (*g_Filesystem)->m_vtable->ReadFromCache, &ReadFromCacheHook, reinterpret_cast<LPVOID*>(&readFromCache));
 	ENABLER_CREATEHOOK(
-		hook, (*g_Filesystem)->m_vtable->AddSearchPath, &AddSearchPathHook, reinterpret_cast<LPVOID*>(&addSearchPathOriginal));
+		hook,
+		reinterpret_cast<void*>((*g_Filesystem)->m_vtable->ReadFromCache),
+		&ReadFromCacheHook,
+		reinterpret_cast<LPVOID*>(&readFromCache));
+	ENABLER_CREATEHOOK(
+		hook,
+		reinterpret_cast<void*>((*g_Filesystem)->m_vtable->AddSearchPath),
+		&AddSearchPathHook,
+		reinterpret_cast<LPVOID*>(&addSearchPathOriginal));
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x15F20, &ReadFileFromFilesystemHook, reinterpret_cast<LPVOID*>(&readFileFromFilesystem));
-	ENABLER_CREATEHOOK(hook, (*g_Filesystem)->m_vtable->MountVPK, &MountVPKHook, reinterpret_cast<LPVOID*>(&mountVPK));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>((*g_Filesystem)->m_vtable->MountVPK), &MountVPKHook, reinterpret_cast<LPVOID*>(&mountVPK));
 }
 
 std::string ReadVPKFile(const char* path)

--- a/NorthstarDedicatedTest/hooks.cpp
+++ b/NorthstarDedicatedTest/hooks.cpp
@@ -10,7 +10,6 @@
 #include <fstream>
 #include <sstream>
 #include <filesystem>
-#include <Psapi.h>
 
 typedef LPSTR (*GetCommandLineAType)();
 LPSTR GetCommandLineAHook();
@@ -39,11 +38,14 @@ void InstallInitialHooks()
 		spdlog::error("MH_Initialize (minhook initialization) failed");
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, &GetCommandLineA, &GetCommandLineAHook, reinterpret_cast<LPVOID*>(&GetCommandLineAOriginal));
-	ENABLER_CREATEHOOK(hook, &LoadLibraryExA, &LoadLibraryExAHook, reinterpret_cast<LPVOID*>(&LoadLibraryExAOriginal));
-	ENABLER_CREATEHOOK(hook, &LoadLibraryA, &LoadLibraryAHook, reinterpret_cast<LPVOID*>(&LoadLibraryAOriginal));
-	ENABLER_CREATEHOOK(hook, &LoadLibraryExW, &LoadLibraryExWHook, reinterpret_cast<LPVOID*>(&LoadLibraryExWOriginal));
-	ENABLER_CREATEHOOK(hook, &LoadLibraryW, &LoadLibraryWHook, reinterpret_cast<LPVOID*>(&LoadLibraryWOriginal));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>(&GetCommandLineA), &GetCommandLineAHook, reinterpret_cast<LPVOID*>(&GetCommandLineAOriginal));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>(&LoadLibraryExA), &LoadLibraryExAHook, reinterpret_cast<LPVOID*>(&LoadLibraryExAOriginal));
+	ENABLER_CREATEHOOK(hook, reinterpret_cast<void*>(&LoadLibraryA), &LoadLibraryAHook, reinterpret_cast<LPVOID*>(&LoadLibraryAOriginal));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>(&LoadLibraryExW), &LoadLibraryExWHook, reinterpret_cast<LPVOID*>(&LoadLibraryExWOriginal));
+	ENABLER_CREATEHOOK(hook, reinterpret_cast<void*>(&LoadLibraryW), &LoadLibraryWHook, reinterpret_cast<LPVOID*>(&LoadLibraryWOriginal));
 }
 
 LPSTR GetCommandLineAHook()

--- a/NorthstarDedicatedTest/hookutils.h
+++ b/NorthstarDedicatedTest/hookutils.h
@@ -19,4 +19,5 @@ class HookEnabler
 };
 
 // macro to call HookEnabler::CreateHook with the hook's name
-#define ENABLER_CREATEHOOK(enabler, ppTarget, ppDetour, ppOriginal) enabler.CreateHook(ppTarget, ppDetour, ppOriginal, #ppDetour)
+#define ENABLER_CREATEHOOK(enabler, ppTarget, ppDetour, ppOriginal)                                                                        \
+	enabler.CreateHook(ppTarget, reinterpret_cast<void*>(ppDetour), ppOriginal, #ppDetour)

--- a/NorthstarDedicatedTest/logging.cpp
+++ b/NorthstarDedicatedTest/logging.cpp
@@ -7,9 +7,8 @@
 #include "convar.h"
 #include <iomanip>
 #include <sstream>
-#include <Psapi.h>
-#include <minidumpapiset.h>
 #include "configurables.h"
+#include <dbghelp.h>
 
 // This needs to be called after hooks are loaded so we can access the command line args
 void CreateLogFiles()

--- a/NorthstarDedicatedTest/masterserver.h
+++ b/NorthstarDedicatedTest/masterserver.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "convar.h"
-#include <WinSock2.h>
+#include <winsock2.h>
 #include <string>
 #include <cstring>
 struct RemoteModInfo

--- a/NorthstarDedicatedTest/maxplayers.cpp
+++ b/NorthstarDedicatedTest/maxplayers.cpp
@@ -212,7 +212,7 @@ void RunUserCmds_Hook(bool a1, float a2)
 
 	v3 = *(unsigned char*)(g_pGlobals + 73);
 	if (*(DWORD*)(qword_1814D9648 + 92) &&
-		((*(unsigned __int8(__fastcall**)(__int64))(*(__int64*)g_pEngineServer + 32i64))(g_pEngineServer) ||
+		((*(unsigned __int8(__fastcall**)(__int64))(*(__int64*)g_pEngineServer + 32))(g_pEngineServer) ||
 		 !*(DWORD*)(qword_1814DA408 + 92)) &&
 		v3)
 	{
@@ -282,7 +282,7 @@ void RunUserCmds_Hook(bool a1, float a2)
 						if (v23)
 							v19 = 1;
 						else
-							*v21 = 0i64;
+							*v21 = 0;
 					}
 					++v20;
 					++v21;

--- a/NorthstarDedicatedTest/memalloc.cpp
+++ b/NorthstarDedicatedTest/memalloc.cpp
@@ -70,7 +70,7 @@ void* operator new(size_t n)
 	return _malloc_base(n);
 }
 
-void operator delete(void* p)
+void operator delete(void* p) noexcept
 {
 	_free_base(p);
 } // /FORCE:MULTIPLE

--- a/NorthstarDedicatedTest/memalloc.h
+++ b/NorthstarDedicatedTest/memalloc.h
@@ -11,7 +11,7 @@ extern "C" void _free_base(void* const block);
 extern "C" char* _strdup_base(const char* src);
 
 void* operator new(size_t n);
-void operator delete(void* p);
+void operator delete(void* p) noexcept;
 
 // void* malloc(size_t n);
 

--- a/NorthstarDedicatedTest/pch.h
+++ b/NorthstarDedicatedTest/pch.h
@@ -13,8 +13,8 @@
 // add headers that you want to pre-compile here
 #include "memalloc.h"
 
-#include <Windows.h>
-#include <Psapi.h>
+#include <windows.h>
+#include <psapi.h>
 #include <set>
 #include <map>
 #include <filesystem>

--- a/NorthstarDedicatedTest/rpakfilesystem.cpp
+++ b/NorthstarDedicatedTest/rpakfilesystem.cpp
@@ -299,9 +299,15 @@ void InitialiseEngineRpakFilesystem(HMODULE baseAddress)
 	pUnknownPakLoadSingleton = (void**)((char*)baseAddress + 0x7C5E20);
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, g_pakLoadApi->LoadPakSync, &LoadPakSyncHook, reinterpret_cast<LPVOID*>(&LoadPakSyncOriginal));
-	ENABLER_CREATEHOOK(hook, g_pakLoadApi->LoadPakAsync, &LoadPakAsyncHook, reinterpret_cast<LPVOID*>(&LoadPakAsyncOriginal));
-	ENABLER_CREATEHOOK(hook, g_pakLoadApi->UnloadPak, &UnloadPakHook, reinterpret_cast<LPVOID*>(&UnloadPakOriginal));
 	ENABLER_CREATEHOOK(
-		hook, g_pakLoadApi->ReadFullFileFromDisk, &ReadFullFileFromDiskHook, reinterpret_cast<LPVOID*>(&ReadFullFileFromDiskOriginal));
+		hook, reinterpret_cast<void*>(g_pakLoadApi->LoadPakSync), &LoadPakSyncHook, reinterpret_cast<LPVOID*>(&LoadPakSyncOriginal));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>(g_pakLoadApi->LoadPakAsync), &LoadPakAsyncHook, reinterpret_cast<LPVOID*>(&LoadPakAsyncOriginal));
+	ENABLER_CREATEHOOK(
+		hook, reinterpret_cast<void*>(g_pakLoadApi->UnloadPak), &UnloadPakHook, reinterpret_cast<LPVOID*>(&UnloadPakOriginal));
+	ENABLER_CREATEHOOK(
+		hook,
+		reinterpret_cast<void*>(g_pakLoadApi->ReadFullFileFromDisk),
+		&ReadFullFileFromDiskHook,
+		reinterpret_cast<LPVOID*>(&ReadFullFileFromDiskOriginal));
 }

--- a/NorthstarDedicatedTest/scriptjson.cpp
+++ b/NorthstarDedicatedTest/scriptjson.cpp
@@ -1,5 +1,5 @@
 #include "pch.h"
-#include "scriptJson.h"
+#include "scriptjson.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"

--- a/NorthstarDedicatedTest/serverchathooks.cpp
+++ b/NorthstarDedicatedTest/serverchathooks.cpp
@@ -194,7 +194,7 @@ void InitialiseServerChatHooks_Server(HMODULE baseAddress)
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook,
-		CServerGameDLL__OnReceivedSayTextMessage,
+		reinterpret_cast<void*>(CServerGameDLL__OnReceivedSayTextMessage),
 		&CServerGameDLL__OnReceivedSayTextMessageHook,
 		reinterpret_cast<LPVOID*>(&CServerGameDLL__OnReceivedSayTextMessageHookBase));
 

--- a/NorthstarDedicatedTest/sourceinterface.cpp
+++ b/NorthstarDedicatedTest/sourceinterface.cpp
@@ -47,7 +47,7 @@ void HookClientCreateInterface(HMODULE baseAddress)
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook,
-		GetProcAddress(baseAddress, "CreateInterface"),
+		reinterpret_cast<void*>(GetProcAddress(baseAddress, "CreateInterface")),
 		&ClientCreateInterfaceHook,
 		reinterpret_cast<LPVOID*>(&clientCreateInterfaceOriginal));
 }
@@ -57,7 +57,7 @@ void HookServerCreateInterface(HMODULE baseAddress)
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook,
-		GetProcAddress(baseAddress, "CreateInterface"),
+		reinterpret_cast<void*>(GetProcAddress(baseAddress, "CreateInterface")),
 		&ServerCreateInterfaceHook,
 		reinterpret_cast<LPVOID*>(&serverCreateInterfaceOriginal));
 }
@@ -67,7 +67,7 @@ void HookEngineCreateInterface(HMODULE baseAddress)
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook,
-		GetProcAddress(baseAddress, "CreateInterface"),
+		reinterpret_cast<void*>(GetProcAddress(baseAddress, "CreateInterface")),
 		&EngineCreateInterfaceHook,
 		reinterpret_cast<LPVOID*>(&engineCreateInterfaceOriginal));
 }

--- a/NorthstarDedicatedTest/squirrel.cpp
+++ b/NorthstarDedicatedTest/squirrel.cpp
@@ -504,7 +504,7 @@ template <ScriptContext context> int64_t RegisterSquirrelFuncHook(void* sqvm, SQ
 
 	if ((funcReg->devLevel == 1) && (!CommandLine()->CheckParm("-allowSquirrelDevFunctions")) &&
 		(!allowedDevFunctions.count(funcReg->squirrelFuncName)))
-		funcReg->funcPtr = SQ_DevFuncStub;
+		funcReg->funcPtr = reinterpret_cast<void*>(SQ_DevFuncStub);
 
 	if (context == ScriptContext::SERVER)
 		return ServerRegisterSquirrelFunc(sqvm, funcReg, unknown);

--- a/NorthstarDedicatedTest/squirrel.h
+++ b/NorthstarDedicatedTest/squirrel.h
@@ -138,7 +138,7 @@ enum SQObjectType : __int32
 };
 
 /* 156 */
-union __declspec(align(8)) SQObjectValue
+union alignas(8) SQObjectValue
 {
 	SQString* asString;
 	SQTable* asTable;
@@ -153,7 +153,7 @@ union __declspec(align(8)) SQObjectValue
 };
 
 /* 128 */
-struct __declspec(align(8)) SQObject
+struct alignas(8) SQObject
 {
 	SQObjectType _Type;
 	__int32 _structOffset;
@@ -168,7 +168,7 @@ struct tableNode
 };
 
 /* 138 */
-struct __declspec(align(8)) SQString
+struct alignas(8) SQString
 {
 	__int64* vftable;
 	__int32 uiRef;
@@ -182,7 +182,7 @@ struct __declspec(align(8)) SQString
 };
 
 /* 137 */
-struct __declspec(align(8)) SQTable
+struct alignas(8) SQTable
 {
 	__int64* vftable;
 	uint8 gap_08[4];
@@ -203,7 +203,7 @@ struct __declspec(align(8)) SQTable
 };
 
 /* 140 */
-struct __declspec(align(8)) SQClosure
+struct alignas(8) SQClosure
 {
 	void* vftable;
 	uint8 gap_08[4];
@@ -221,7 +221,7 @@ struct __declspec(align(8)) SQClosure
 };
 
 /* 139 */
-struct __declspec(align(8)) SQFunctionProto
+struct alignas(8) SQFunctionProto
 {
 	void* vftable;
 	uint8 gap_08[4];
@@ -262,7 +262,7 @@ struct SQStructInstance
 };
 
 /* 157 */
-struct __declspec(align(8)) SQNativeClosure
+struct alignas(8) SQNativeClosure
 {
 	void* vftable;
 	uint8 gap_08[4];
@@ -289,7 +289,7 @@ struct StringTable
 };
 
 /* 129 */
-struct __declspec(align(8)) HSquirrelVM
+struct alignas(8) HSquirrelVM
 {
 	void* vftable;
 	__int32 uiRef;
@@ -331,7 +331,7 @@ struct __declspec(align(8)) HSquirrelVM
 };
 
 /* 136 */
-struct __declspec(align(8)) CallInfo
+struct alignas(8) CallInfo
 {
 	SQInstruction* ip;
 	SQObject* _literals;
@@ -473,7 +473,7 @@ enum SQOpcode : int
 };
 
 /* 141 */
-struct __declspec(align(8)) SQStackInfos
+struct alignas(8) SQStackInfos
 {
 	char* _name;
 	char* _sourceName;
@@ -481,7 +481,7 @@ struct __declspec(align(8)) SQStackInfos
 };
 
 /* 151 */
-struct __declspec(align(4)) SQInstruction
+struct alignas(4) SQInstruction
 {
 	int op;
 	int arg1;
@@ -804,7 +804,7 @@ template <ScriptContext context> class SquirrelManager
 		reg->argTypes = new char[argTypes.size() + 1];
 		strcpy((char*)reg->argTypes, argTypes.c_str());
 
-		reg->funcPtr = func;
+		reg->funcPtr = reinterpret_cast<void*>(func);
 
 		m_funcRegistrations.push_back(reg);
 	}

--- a/loader_launcher_proxy/Memory.cpp
+++ b/loader_launcher_proxy/Memory.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "Memory.h"
 
 extern HMODULE hTier0Module;
 IMemAlloc** g_ppMemAllocSingleton;
@@ -77,6 +78,12 @@ void* realloc(void* old_ptr, size_t size)
 	return nullptr;
 }
 
-void* operator new(size_t n) { return malloc(n); }
+void* operator new(size_t n)
+{
+	return malloc(n);
+}
 
-void operator delete(void* p) { return free(p); }
+void operator delete(void* p) noexcept
+{
+	return free(p);
+}

--- a/loader_launcher_proxy/Memory.h
+++ b/loader_launcher_proxy/Memory.h
@@ -2,23 +2,23 @@
 
 class IMemAlloc
 {
-public:
-    struct VTable
-    {
-        void* unknown[1]; // alloc debug
-        void* (*Alloc) (IMemAlloc* memAlloc, size_t nSize);
-        void* unknown2[1]; // realloc debug
-        void* (*Realloc)(IMemAlloc* memAlloc, void* pMem, size_t nSize);
-        void* unknown3[1]; // free #1
-        void (*Free) (IMemAlloc* memAlloc, void* pMem);
-        void* unknown4[2]; // nullsubs, maybe CrtSetDbgFlag
-        size_t(*GetSize) (IMemAlloc* memAlloc, void* pMem);
-        void* unknown5[9]; // they all do literally nothing
-        void (*DumpStats) (IMemAlloc* memAlloc);
-        void (*DumpStatsFileBase) (IMemAlloc* memAlloc, const char* pchFileBase);
-        void* unknown6[4];
-        int (*heapchk) (IMemAlloc* memAlloc);
-    };
+  public:
+	struct VTable
+	{
+		void* unknown[1]; // alloc debug
+		void* (*Alloc)(IMemAlloc* memAlloc, size_t nSize);
+		void* unknown2[1]; // realloc debug
+		void* (*Realloc)(IMemAlloc* memAlloc, void* pMem, size_t nSize);
+		void* unknown3[1]; // free #1
+		void (*Free)(IMemAlloc* memAlloc, void* pMem);
+		void* unknown4[2]; // nullsubs, maybe CrtSetDbgFlag
+		size_t (*GetSize)(IMemAlloc* memAlloc, void* pMem);
+		void* unknown5[9]; // they all do literally nothing
+		void (*DumpStats)(IMemAlloc* memAlloc);
+		void (*DumpStatsFileBase)(IMemAlloc* memAlloc, const char* pchFileBase);
+		void* unknown6[4];
+		int (*heapchk)(IMemAlloc* memAlloc);
+	};
 
-    VTable* m_vtable;
+	VTable* m_vtable;
 };

--- a/loader_launcher_proxy/dllmain.cpp
+++ b/loader_launcher_proxy/dllmain.cpp
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string>
 #include <system_error>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <sstream>
 #include <fstream>
 #include <filesystem>
@@ -14,61 +14,64 @@ HMODULE hTier0Module;
 using CreateInterfaceFn = void* (*)(const char* pName, int* pReturnCode);
 
 // does not seem to ever be used
-extern "C" _declspec(dllexport) void* __fastcall CreateInterface(const char* pName, int* pReturnCode)
+extern "C" __declspec(dllexport) void* __fastcall CreateInterface(const char* pName, int* pReturnCode)
 {
-    //AppSystemCreateInterfaceFn(pName, pReturnCode);
-    printf("external CreateInterface: name: %s\n", pName);
+	// AppSystemCreateInterfaceFn(pName, pReturnCode);
+	printf("external CreateInterface: name: %s\n", pName);
 
-    static CreateInterfaceFn launcher_CreateInterface = (CreateInterfaceFn)GetProcAddress(hLauncherModule, "CreateInterface");
-    auto res = launcher_CreateInterface(pName, pReturnCode);
+	static CreateInterfaceFn launcher_CreateInterface = (CreateInterfaceFn)GetProcAddress(hLauncherModule, "CreateInterface");
+	auto res = launcher_CreateInterface(pName, pReturnCode);
 
-    printf("external CreateInterface: return code: %p\n", res);
-    return res;
+	printf("external CreateInterface: return code: %p\n", res);
+	return res;
 }
 
 bool GetExePathWide(wchar_t* dest, DWORD destSize)
 {
-    if (!dest) return NULL;
-    if (destSize < MAX_PATH) return NULL;
+	if (!dest)
+		return NULL;
+	if (destSize < MAX_PATH)
+		return NULL;
 
-    DWORD length = GetModuleFileNameW(NULL, dest, destSize);
-    return length && PathRemoveFileSpecW(dest);
+	DWORD length = GetModuleFileNameW(NULL, dest, destSize);
+	return length && PathRemoveFileSpecW(dest);
 }
 
 FARPROC GetLauncherMain()
 {
-    static FARPROC Launcher_LauncherMain;
-    if (!Launcher_LauncherMain)
-        Launcher_LauncherMain = GetProcAddress(hLauncherModule, "LauncherMain");
-    return Launcher_LauncherMain;
+	static FARPROC Launcher_LauncherMain;
+	if (!Launcher_LauncherMain)
+		Launcher_LauncherMain = GetProcAddress(hLauncherModule, "LauncherMain");
+	return Launcher_LauncherMain;
 }
 
 void LibraryLoadError(DWORD dwMessageId, const wchar_t* libName, const wchar_t* location)
 {
-    char text[4096];
-    std::string message = std::system_category().message(dwMessageId);
-    sprintf_s(text, "Failed to load the %ls at \"%ls\" (%lu):\n\n%hs", libName, location, dwMessageId, message.c_str());
-    if (dwMessageId == 126 && std::filesystem::exists(location))
-    {
-        sprintf_s(text, "%s\n\nThe file at the specified location DOES exist, so this error indicates that one of its *dependencies* failed to be found.", text);
-    }
-    MessageBoxA(GetForegroundWindow(), text, "Northstar Launcher Proxy Error", 0);
+	char text[4096];
+	std::string message = std::system_category().message(dwMessageId);
+	sprintf_s(text, "Failed to load the %ls at \"%ls\" (%lu):\n\n%hs", libName, location, dwMessageId, message.c_str());
+	if (dwMessageId == 126 && std::filesystem::exists(location))
+	{
+		sprintf_s(
+			text,
+			"%s\n\nThe file at the specified location DOES exist, so this error indicates that one of its *dependencies* failed to be "
+			"found.",
+			text);
+	}
+	MessageBoxA(GetForegroundWindow(), text, "Northstar Launcher Proxy Error", 0);
 }
 
-BOOL APIENTRY DllMain( HMODULE hModule,
-                       DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
-                     )
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
-    switch (ul_reason_for_call)
-    {
-    case DLL_PROCESS_ATTACH:
-    case DLL_THREAD_ATTACH:
-    case DLL_THREAD_DETACH:
-    case DLL_PROCESS_DETACH:
-        break;
-    }
-    return TRUE;
+	switch (ul_reason_for_call)
+	{
+	case DLL_PROCESS_ATTACH:
+	case DLL_THREAD_ATTACH:
+	case DLL_THREAD_DETACH:
+	case DLL_PROCESS_DETACH:
+		break;
+	}
+	return TRUE;
 }
 
 wchar_t exePath[4096];
@@ -76,86 +79,96 @@ wchar_t dllPath[4096];
 
 bool ShouldLoadNorthstar()
 {
-    bool loadNorthstar = !strstr(GetCommandLineA(), "-vanilla");
+	bool loadNorthstar = !strstr(GetCommandLineA(), "-vanilla");
 
-    if (!loadNorthstar)
-        return loadNorthstar;
+	if (!loadNorthstar)
+		return loadNorthstar;
 
-    auto runNorthstarFile = std::ifstream("run_northstar.txt");
-    if (runNorthstarFile)
-    {
-        std::stringstream runNorthstarFileBuffer;
-        runNorthstarFileBuffer << runNorthstarFile.rdbuf();
-        runNorthstarFile.close();
-        if (runNorthstarFileBuffer.str()._Starts_with("0"))
-            loadNorthstar = false;
-    }
-    return loadNorthstar;
+	auto runNorthstarFile = std::ifstream("run_northstar.txt");
+	if (runNorthstarFile)
+	{
+		std::stringstream runNorthstarFileBuffer;
+		runNorthstarFileBuffer << runNorthstarFile.rdbuf();
+		runNorthstarFile.close();
+		if (runNorthstarFileBuffer.str().starts_with("0"))
+			loadNorthstar = false;
+	}
+	return loadNorthstar;
 }
 
 bool LoadNorthstar()
 {
-    FARPROC Hook_Init = nullptr;
-    {
-        swprintf_s(dllPath, L"%s\\Northstar.dll", exePath);
-        hHookModule = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
-        if (hHookModule) Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
-        if (!hHookModule || Hook_Init == nullptr)
-        {
-            LibraryLoadError(GetLastError(), L"Northstar.dll", dllPath);
-            return false;
-        }
-    }
+	FARPROC Hook_Init = nullptr;
+	{
+		swprintf_s(dllPath, L"%s\\Northstar.dll", exePath);
+		hHookModule = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+		if (hHookModule)
+			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
+		if (!hHookModule || Hook_Init == nullptr)
+		{
+			LibraryLoadError(GetLastError(), L"Northstar.dll", dllPath);
+			return false;
+		}
+	}
 
-    ((bool (*)()) Hook_Init)();
-    return true;
+	((bool (*)())Hook_Init)();
+	return true;
 }
 
 extern "C" __declspec(dllexport) int LauncherMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-    {
-        if (!GetExePathWide(exePath, 4096))
-        {
-            MessageBoxA(GetForegroundWindow(), "Failed getting game directory.\nThe game cannot continue and has to exit.", "Northstar Launcher Proxy Error", 0);
-            return 1;
-        }
+	{
+		if (!GetExePathWide(exePath, 4096))
+		{
+			MessageBoxA(
+				GetForegroundWindow(),
+				"Failed getting game directory.\nThe game cannot continue and has to exit.",
+				"Northstar Launcher Proxy Error",
+				0);
+			return 1;
+		}
 
-        bool loadNorthstar = ShouldLoadNorthstar();
+		bool loadNorthstar = ShouldLoadNorthstar();
 
-        if (loadNorthstar)
-        {
-            swprintf_s(dllPath, L"%s\\bin\\x64_retail\\tier0.dll", exePath);
-            hTier0Module = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
-            if (!hTier0Module)
-            {
-                LibraryLoadError(GetLastError(), L"tier0.dll", dllPath);
-                return 1;
-            }
+		if (loadNorthstar)
+		{
+			swprintf_s(dllPath, L"%s\\bin\\x64_retail\\tier0.dll", exePath);
+			hTier0Module = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+			if (!hTier0Module)
+			{
+				LibraryLoadError(GetLastError(), L"tier0.dll", dllPath);
+				return 1;
+			}
 
-            if (!LoadNorthstar())
-                return 1;
-        }
-        //else printf("\n\n WILL !!!NOT!!! LOAD NORTHSTAR\n\n");
+			if (!LoadNorthstar())
+				return 1;
+		}
+		// else printf("\n\n WILL !!!NOT!!! LOAD NORTHSTAR\n\n");
 
-        swprintf_s(dllPath, L"%s\\bin\\x64_retail\\launcher.org.dll", exePath);
-        hLauncherModule = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
-        if (!hLauncherModule)
-        {
-            LibraryLoadError(GetLastError(), L"launcher.org.dll", dllPath);
-            return 1;
-        }
-    }
+		swprintf_s(dllPath, L"%s\\bin\\x64_retail\\launcher.org.dll", exePath);
+		hLauncherModule = LoadLibraryExW(dllPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+		if (!hLauncherModule)
+		{
+			LibraryLoadError(GetLastError(), L"launcher.org.dll", dllPath);
+			return 1;
+		}
+	}
 
-    auto LauncherMain = GetLauncherMain();
-    if (!LauncherMain)
-        MessageBoxA(GetForegroundWindow(), "Failed loading launcher.org.dll.\nThe game cannot continue and has to exit.", "Northstar Launcher Proxy Error", 0);
-    //auto result = ((__int64(__fastcall*)())LauncherMain)();
-    //auto result = ((signed __int64(__fastcall*)(__int64))LauncherMain)(0i64);
-    return ((int(__fastcall*)(HINSTANCE, HINSTANCE, LPSTR, int))LauncherMain)(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
+	auto LauncherMain = GetLauncherMain();
+	if (!LauncherMain)
+		MessageBoxA(
+			GetForegroundWindow(),
+			"Failed loading launcher.org.dll.\nThe game cannot continue and has to exit.",
+			"Northstar Launcher Proxy Error",
+			0);
+	// auto result = ((__int64(__fastcall*)())LauncherMain)();
+	// auto result = ((signed __int64(__fastcall*)(__int64))LauncherMain)(0i64);
+	return ((int(__fastcall*)(HINSTANCE, HINSTANCE, LPSTR, int))LauncherMain)(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
 }
 
 // doubt that will help us here (in launcher.dll) though
-extern "C" {
-    __declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
-    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+extern "C"
+{
+	__declspec(dllexport) DWORD AmdPowerXpressRequestHighPerformance = 0x00000001;
+	__declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
 }

--- a/loader_launcher_proxy/framework.h
+++ b/loader_launcher_proxy/framework.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from windows.headers
 #define WIN32_EXTRA_LEAN
 #define VC_EXTRALEAN
 // Windows Header Files
-#include <Windows.h>
+#include <windows.h>

--- a/loader_launcher_proxy/loader_launcher_proxy.vcxproj
+++ b/loader_launcher_proxy/loader_launcher_proxy.vcxproj
@@ -59,7 +59,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -78,7 +78,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/loader_launcher_proxy/pch.h
+++ b/loader_launcher_proxy/pch.h
@@ -10,4 +10,4 @@
 // add headers that you want to pre-compile here
 #include "framework.h"
 
-#endif //PCH_H
+#endif // PCH_H

--- a/loader_wsock32_proxy/dllmain.cpp
+++ b/loader_wsock32_proxy/dllmain.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "loader.h"
 
-#include <Shlwapi.h>
+#include <shlwapi.h>
 #include <filesystem>
 
 HINSTANCE hLThis = 0;
@@ -10,8 +10,10 @@ HINSTANCE hL = 0;
 
 bool GetExePathWide(wchar_t* dest, DWORD destSize)
 {
-	if (!dest) return NULL;
-	if (destSize < MAX_PATH) return NULL;
+	if (!dest)
+		return NULL;
+	if (destSize < MAX_PATH)
+		return NULL;
 
 	DWORD length = GetModuleFileNameW(NULL, dest, destSize);
 	return length && PathRemoveFileSpecW(dest);
@@ -29,7 +31,11 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 
 		if (!GetExePathWide(exePath, 4096))
 		{
-			MessageBoxA(GetForegroundWindow(), "Failed getting game directory.\nThe game cannot continue and has to exit.", "Northstar Wsock32 Proxy Error", 0);
+			MessageBoxA(
+				GetForegroundWindow(),
+				"Failed getting game directory.\nThe game cannot continue and has to exit.",
+				"Northstar Wsock32 Proxy Error",
+				0);
 			return true;
 		}
 
@@ -59,7 +65,14 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 				{
 					if (!std::filesystem::exists(temp_dir))
 					{
-						swprintf_s(buffer2, L"Failed copying wsock32.dll from system32 to \"%s\"\n\n%S\n\nFurthermore, we failed copying wsock32.dll into temporary directory at \"%s\"\n\n%S", buffer1, e1.what(), temp_dir.c_str(), e2.what());
+						swprintf_s(
+							buffer2,
+							L"Failed copying wsock32.dll from system32 to \"%s\"\n\n%S\n\nFurthermore, we failed copying wsock32.dll into "
+							L"temporary directory at \"%s\"\n\n%S",
+							buffer1,
+							e1.what(),
+							temp_dir.c_str(),
+							e2.what());
 						MessageBoxW(GetForegroundWindow(), buffer2, L"Northstar Wsock32 Proxy Error", 0);
 						return false;
 					}
@@ -68,7 +81,8 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 			}
 		}
 		hL = LoadLibraryExW(buffer1, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
-		if (!hL) {
+		if (!hL)
+		{
 			LibraryLoadError(GetLastError(), L"wsock32.org.dll", buffer1);
 			return false;
 		}
@@ -104,51 +118,63 @@ extern "C"
 	FARPROC PA = NULL;
 	int RunASM();
 
-	void PROXY_EnumProtocolsA() {
+	void PROXY_EnumProtocolsA()
+	{
 		PA = p[1];
 		RunASM();
 	}
-	void PROXY_EnumProtocolsW() {
+	void PROXY_EnumProtocolsW()
+	{
 		PA = p[2];
 		RunASM();
 	}
-	void PROXY_GetAddressByNameA() {
+	void PROXY_GetAddressByNameA()
+	{
 		PA = p[4];
 		RunASM();
 	}
-	void PROXY_GetAddressByNameW() {
+	void PROXY_GetAddressByNameW()
+	{
 		PA = p[5];
 		RunASM();
 	}
-	void PROXY_WEP() {
+	void PROXY_WEP()
+	{
 		PA = p[17];
 		RunASM();
 	}
-	void PROXY_WSARecvEx() {
+	void PROXY_WSARecvEx()
+	{
 		PA = p[30];
 		RunASM();
 	}
-	void PROXY___WSAFDIsSet() {
+	void PROXY___WSAFDIsSet()
+	{
 		PA = p[36];
 		RunASM();
 	}
-	void PROXY_getnetbyname() {
+	void PROXY_getnetbyname()
+	{
 		PA = p[45];
 		RunASM();
 	}
-	void PROXY_getsockopt() {
+	void PROXY_getsockopt()
+	{
 		PA = p[52];
 		RunASM();
 	}
-	void PROXY_inet_network() {
+	void PROXY_inet_network()
+	{
 		PA = p[56];
 		RunASM();
 	}
-	void PROXY_s_perror() {
+	void PROXY_s_perror()
+	{
 		PA = p[67];
 		RunASM();
 	}
-	void PROXY_setsockopt() {
+	void PROXY_setsockopt()
+	{
 		PA = p[72];
 		RunASM();
 	}

--- a/loader_wsock32_proxy/hookutils.cpp
+++ b/loader_wsock32_proxy/hookutils.cpp
@@ -1,54 +1,61 @@
+#include <cstdio>
+
 #include "pch.h"
 #include "../NorthstarDedicatedTest/hookutils.h"
 
-#define ERROR(...) { char err[2048]; sprintf_s(err, __VA_ARGS__); MessageBoxA(GetForegroundWindow(), err, "Northstar Wsock32 Proxy Error", 0); }
+#define HU_ERROR(...)                                                                                                                      \
+	{                                                                                                                                      \
+		char err[2048];                                                                                                                    \
+		snprintf(err, sizeof(err), __VA_ARGS__);                                                                                           \
+		MessageBoxA(GetForegroundWindow(), err, "Northstar Wsock32 Proxy Error", 0);                                                       \
+	}
 
 void HookEnabler::CreateHook(LPVOID ppTarget, LPVOID ppDetour, LPVOID* ppOriginal, const char* targetName)
 {
-    // the macro for this uses ppTarget's name as targetName, and this typically starts with &
-    // targetname is used for debug stuff and debug output is nicer if we don't have this
-    if (*targetName == '&')
-        targetName++;
+	// the macro for this uses ppTarget's name as targetName, and this typically starts with &
+	// targetname is used for debug stuff and debug output is nicer if we don't have this
+	if (*targetName == '&')
+		targetName++;
 
-    if (MH_CreateHook(ppTarget, ppDetour, ppOriginal) == MH_OK)
-    {
-        HookTarget* target = new HookTarget;
-        target->targetAddress = ppTarget;
-        target->targetName = (char*)targetName;
+	if (MH_CreateHook(ppTarget, ppDetour, ppOriginal) == MH_OK)
+	{
+		HookTarget* target = new HookTarget;
+		target->targetAddress = ppTarget;
+		target->targetName = (char*)targetName;
 
-        m_hookTargets.push_back(target);
-    }
-    else
-    {
-        if (targetName != nullptr)
-        {
-            ERROR("MH_CreateHook failed for function %s", targetName);
-        }
-        else
-        {
-            ERROR("MH_CreateHook failed for unknown function");
-        }
-    }
+		m_hookTargets.push_back(target);
+	}
+	else
+	{
+		if (targetName != nullptr)
+		{
+			HU_ERROR("MH_CreateHook failed for function %s", targetName);
+		}
+		else
+		{
+			HU_ERROR("MH_CreateHook failed for unknown function");
+		}
+	}
 }
 
 HookEnabler::~HookEnabler()
 {
-    for (auto& hook : m_hookTargets)
-    {
-        if (MH_EnableHook(hook->targetAddress) != MH_OK)
-        {
-            if (hook->targetName != nullptr)
-            {
-                ERROR("MH_EnableHook failed for function %s", hook->targetName);
-            }
-            else
-            {
-                ERROR("MH_EnableHook failed for unknown function");
-            }
-        }
-        else
-        {
-            //ERROR("Enabling hook %s", hook->targetName);
-        }
-    }
+	for (auto& hook : m_hookTargets)
+	{
+		if (MH_EnableHook(hook->targetAddress) != MH_OK)
+		{
+			if (hook->targetName != nullptr)
+			{
+				HU_ERROR("MH_EnableHook failed for function %s", hook->targetName);
+			}
+			else
+			{
+				HU_ERROR("MH_EnableHook failed for unknown function");
+			}
+		}
+		else
+		{
+			// HU_ERROR("Enabling hook %s", hook->targetName);
+		}
+	}
 }

--- a/loader_wsock32_proxy/loader.cpp
+++ b/loader_wsock32_proxy/loader.cpp
@@ -14,7 +14,11 @@ void LibraryLoadError(DWORD dwMessageId, const wchar_t* libName, const wchar_t* 
 	sprintf_s(text, "Failed to load the %ls at \"%ls\" (%lu):\n\n%hs", libName, location, dwMessageId, message.c_str());
 	if (dwMessageId == 126 && std::filesystem::exists(location))
 	{
-		sprintf_s(text, "%s\n\nThe file at the specified location DOES exist, so this error indicates that one of its *dependencies* failed to be found.", text);
+		sprintf_s(
+			text,
+			"%s\n\nThe file at the specified location DOES exist, so this error indicates that one of its *dependencies* failed to be "
+			"found.",
+			text);
 	}
 	MessageBoxA(GetForegroundWindow(), text, "Northstar Wsock32 Proxy Error", 0);
 }
@@ -32,7 +36,7 @@ bool ShouldLoadNorthstar()
 		std::stringstream runNorthstarFileBuffer;
 		runNorthstarFileBuffer << runNorthstarFile.rdbuf();
 		runNorthstarFile.close();
-		if (!runNorthstarFileBuffer.str()._Starts_with("0"))
+		if (!runNorthstarFileBuffer.str().starts_with("0"))
 			loadNorthstar = true;
 	}
 	return loadNorthstar;
@@ -44,7 +48,8 @@ bool LoadNorthstar()
 	{
 		swprintf_s(buffer1, L"%s\\Northstar.dll", exePath);
 		auto hHookModule = LoadLibraryExW(buffer1, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
-		if (hHookModule) Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
+		if (hHookModule)
+			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
 		if (!hHookModule || Hook_Init == nullptr)
 		{
 			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer1);
@@ -52,11 +57,11 @@ bool LoadNorthstar()
 		}
 	}
 
-	((bool (*)()) Hook_Init)();
+	((bool (*)())Hook_Init)();
 	return true;
 }
 
-typedef int(*LauncherMainType)(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);
+typedef int (*LauncherMainType)(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow);
 LauncherMainType LauncherMainOriginal;
 
 int LauncherMainHook(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
@@ -73,19 +78,28 @@ bool ProvisionNorthstar()
 
 	if (MH_Initialize() != MH_OK)
 	{
-		MessageBoxA(GetForegroundWindow(), "MH_Initialize failed\nThe game cannot continue and has to exit.", "Northstar Wsock32 Proxy Error", 0);
+		MessageBoxA(
+			GetForegroundWindow(), "MH_Initialize failed\nThe game cannot continue and has to exit.", "Northstar Wsock32 Proxy Error", 0);
 		return false;
 	}
 
 	auto launcherHandle = GetModuleHandleA("launcher.dll");
 	if (!launcherHandle)
 	{
-		MessageBoxA(GetForegroundWindow(), "Launcher isn't loaded yet.\nThe game cannot continue and has to exit.", "Northstar Wsock32 Proxy Error", 0);
+		MessageBoxA(
+			GetForegroundWindow(),
+			"Launcher isn't loaded yet.\nThe game cannot continue and has to exit.",
+			"Northstar Wsock32 Proxy Error",
+			0);
 		return false;
 	}
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(hook, GetProcAddress(launcherHandle, "LauncherMain"), &LauncherMainHook, reinterpret_cast<LPVOID*>(&LauncherMainOriginal));
+	ENABLER_CREATEHOOK(
+		hook,
+		reinterpret_cast<void*>(GetProcAddress(launcherHandle, "LauncherMain")),
+		&LauncherMainHook,
+		reinterpret_cast<LPVOID*>(&LauncherMainOriginal));
 
 	return true;
 }

--- a/loader_wsock32_proxy/loader_wsock32_proxy.vcxproj
+++ b/loader_wsock32_proxy/loader_wsock32_proxy.vcxproj
@@ -60,7 +60,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>..\NorthstarDedicatedTest\</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -82,7 +82,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>..\NorthstarDedicatedTest\</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/loader_wsock32_proxy/pch.h
+++ b/loader_wsock32_proxy/pch.h
@@ -7,10 +7,10 @@
 #ifndef PCH_H
 #define PCH_H
 
-#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 // Windows Header Files
 #include <windows.h>
 
 #include "include/MinHook.h"
 
-#endif //PCH_H
+#endif // PCH_H


### PR DESCRIPTION
- Fix include case.
- Replace MSVC-specific align with standard alignas.
- Type fixes.
- Delete operator noexcept.
- A few other minor issues.
- clang-format everything.
- Use c++20 instead of c++17.
- Rewrite ERROR macro for launcher_wsock32_proxy.
- Use a plain ifstream for the audio.cpp wavStream.

Note: When compiling with clang, you'll need -municode.

Related to #212.