### PR TITLE
Fixed `unban` not overwriting `banlist.txt`

### DIFF
--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -28,7 +28,7 @@ void ServerBanSystem::OpenBanlist()
 	}
 
 	// open write stream for banlist // dont do this to allow for all time access
-	//m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
+	// m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
 }
 
 void ServerBanSystem::ReloadBanlist()

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -27,24 +27,8 @@ void ServerBanSystem::OpenBanlist()
 		enabledModsStream.close();
 	}
 
-	// open write stream for banlist // dont do this to allow for all time access
-	//m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
-}
-
-void ServerBanSystem::ReloadBanlist()
-{
-	std::ifstream fsBanlist(GetNorthstarPrefix() + "/banlist.txt");
-
-	if (!fsBanlist.fail())
-	{
-		std::string line;
-		// since we wanna use this as the reload func we need to clear the list
-		m_vBannedUids.clear();
-		while (std::getline(fsBanlist, line))
-			m_vBannedUids.push_back(strtoull(line.c_str(), nullptr, 10));
-
-		fsBanlist.close();
-	}
+	// open write stream for banlist
+	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
 }
 
 void ServerBanSystem::ClearBanlist()
@@ -54,15 +38,12 @@ void ServerBanSystem::ClearBanlist()
 	// reopen the file, don't provide std::ofstream::app so it clears on open
 	m_sBanlistStream.close();
 	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
-	m_sBanlistStream.close();
 }
 
 void ServerBanSystem::BanUID(uint64_t uid)
 {
 	m_vBannedUids.push_back(uid);
-	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
 	m_sBanlistStream << std::to_string(uid) << std::endl;
-	m_sBanlistStream.close();
 	spdlog::info("{} was banned", uid);
 }
 
@@ -141,13 +122,12 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 
 	for (std::string updatedLine : banlistText)
 		m_sBanlistStream << updatedLine << std::endl;
-	m_sBanlistStream.close();
+
 	spdlog::info("{} was unbanned", uid);
 }
 
 bool ServerBanSystem::IsUIDAllowed(uint64_t uid)
 {
-	ReloadBanlist(); // Reload to have up to date list on join
 	return std::find(m_vBannedUids.begin(), m_vBannedUids.end(), uid) == m_vBannedUids.end();
 }
 

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -27,8 +27,24 @@ void ServerBanSystem::OpenBanlist()
 		enabledModsStream.close();
 	}
 
-	// open write stream for banlist
-	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
+	// open write stream for banlist // dont do this to allow for all time access
+	//m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
+}
+
+void ServerBanSystem::ReloadBanlist()
+{
+	std::ifstream fsBanlist(GetNorthstarPrefix() + "/banlist.txt");
+
+	if (!fsBanlist.fail())
+	{
+		std::string line;
+		// since we wanna use this as the reload func we need to clear the list
+		m_vBannedUids.clear();
+		while (std::getline(fsBanlist, line))
+			m_vBannedUids.push_back(strtoull(line.c_str(), nullptr, 10));
+
+		fsBanlist.close();
+	}
 }
 
 void ServerBanSystem::ClearBanlist()
@@ -38,12 +54,15 @@ void ServerBanSystem::ClearBanlist()
 	// reopen the file, don't provide std::ofstream::app so it clears on open
 	m_sBanlistStream.close();
 	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
+	m_sBanlistStream.close();
 }
 
 void ServerBanSystem::BanUID(uint64_t uid)
 {
 	m_vBannedUids.push_back(uid);
+	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
 	m_sBanlistStream << std::to_string(uid) << std::endl;
+	m_sBanlistStream.close();
 	spdlog::info("{} was banned", uid);
 }
 
@@ -122,12 +141,13 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 
 	for (std::string updatedLine : banlistText)
 		m_sBanlistStream << updatedLine << std::endl;
-
+	m_sBanlistStream.close();
 	spdlog::info("{} was unbanned", uid);
 }
 
 bool ServerBanSystem::IsUIDAllowed(uint64_t uid)
 {
+	ReloadBanlist(); // Reload to have up to date list on join
 	return std::find(m_vBannedUids.begin(), m_vBannedUids.end(), uid) == m_vBannedUids.end();
 }
 

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -28,7 +28,7 @@ void ServerBanSystem::OpenBanlist()
 	}
 
 	// open write stream for banlist // dont do this to allow for all time access
-	// m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
+	//m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary | std::ofstream::app);
 }
 
 void ServerBanSystem::ReloadBanlist()

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -97,8 +97,8 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 
 				//{y}/{m}/{d} {h}:{m}
 				unbanComment << " # unban date: ";
-				unbanComment << now->tm_year + 1900 << "/"; // this lib is so fucking awful
-				unbanComment << std::setw(2) << std::setfill('0') << now->tm_mon + 1 << "/";
+				unbanComment << now->tm_year + 1900 << "-"; // this lib is so fucking awful
+				unbanComment << std::setw(2) << std::setfill('0') << now->tm_mon + 1 << "-";
 				unbanComment << std::setw(2) << std::setfill('0') << now->tm_mday << " ";
 				unbanComment << std::setw(2) << std::setfill('0') << now->tm_hour << ":";
 				unbanComment << std::setw(2) << std::setfill('0') << now->tm_min;
@@ -118,9 +118,7 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
 
 	for (std::string updatedLine : banlistText)
-	{
 		m_sBanlistStream << updatedLine << std::endl;
-	}
 
 	spdlog::info("{} was unbanned", uid);
 }

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -81,6 +81,9 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 
 			// for inline comments like: 123123123 #banned for unfunny
 			std::string lineUid = line.substr(0, line.find(BANLIST_COMMENT_CHAR));
+			// have to erase spaces or else inline comments will fuck up the uid finding
+			lineUid.erase(std::remove(lineUid.begin(), lineUid.end(), '\t'), lineUid.end());
+			lineUid.erase(std::remove(lineUid.begin(), lineUid.end(), ' '), lineUid.end());
 
 			// if the uid in the line is the uid we wanna unban
 			if (std::to_string(uid) == lineUid)

--- a/NorthstarDedicatedTest/bansystem.cpp
+++ b/NorthstarDedicatedTest/bansystem.cpp
@@ -6,8 +6,10 @@
 #include "miscserverscript.h"
 #include <filesystem>
 #include "configurables.h"
+#include <ctime>
 
 const char* BANLIST_PATH_SUFFIX = "/banlist.txt";
+const char BANLIST_COMMENT_CHAR = '#';
 
 ServerBanSystem* g_ServerBanSystem;
 
@@ -52,9 +54,75 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 		return;
 
 	m_vBannedUids.erase(findResult);
+
+	std::vector<std::string> banlistText;
+	std::ifstream fs_readBanlist(GetNorthstarPrefix() + "/banlist.txt");
+
+	if (!fs_readBanlist.fail())
+	{
+		std::string line;
+		while (std::getline(fs_readBanlist, line))
+		{
+			// support for comments and newlines added in https://github.com/R2Northstar/NorthstarLauncher/pull/227
+
+			std::string modLine = line; // copy the line into a free var that we can fuck with, line will be the original
+
+			// remove tabs which shouldnt be there but maybe someone did the funny
+			modLine.erase(std::remove(modLine.begin(), modLine.end(), '\t'), modLine.end());
+			// remove spaces to allow for spaces before uids
+			modLine.erase(std::remove(modLine.begin(), modLine.end(), ' '), modLine.end());
+
+			// ignore line if first char is # or empty line, just add it
+			if (line.front() == BANLIST_COMMENT_CHAR || modLine == "")
+			{
+				banlistText.push_back(line);
+				continue;
+			}
+
+			// for inline comments like: 123123123 #banned for unfunny
+			std::string lineUid = line.substr(0, line.find(BANLIST_COMMENT_CHAR));
+
+			// if the uid in the line is the uid we wanna unban
+			if (std::to_string(uid) == lineUid)
+			{
+				// comment the uid out
+				line.insert(0, "# ");
+
+				// add a comment with unban date
+				// not necessary but i feel like this makes it better
+				std::time_t t = std::time(0);
+				std::tm* now = std::localtime(&t);
+
+				std::ostringstream unbanComment;
+
+				//{y}/{m}/{d} {h}:{m}
+				unbanComment << " # unban date: ";
+				unbanComment << now->tm_year + 1900 << "/"; // this lib is so fucking awful
+				unbanComment << std::setw(2) << std::setfill('0') << now->tm_mon + 1 << "/";
+				unbanComment << std::setw(2) << std::setfill('0') << now->tm_mday << " ";
+				unbanComment << std::setw(2) << std::setfill('0') << now->tm_hour << ":";
+				unbanComment << std::setw(2) << std::setfill('0') << now->tm_min;
+
+				line.append(unbanComment.str());
+			}
+
+			banlistText.push_back(line);
+		}
+
+		fs_readBanlist.close();
+	}
+
+	// open write stream for banlist // without append so we clear the file
+	if (m_sBanlistStream.is_open())
+		m_sBanlistStream.close();
+	m_sBanlistStream.open(GetNorthstarPrefix() + "/banlist.txt", std::ofstream::out | std::ofstream::binary);
+
+	for (std::string updatedLine : banlistText)
+	{
+		m_sBanlistStream << updatedLine << std::endl;
+	}
+
 	spdlog::info("{} was unbanned", uid);
-	// todo: this needs to erase from the banlist file
-	// atm unsure how to do this aside from just clearing and fully rewriting the file
 }
 
 bool ServerBanSystem::IsUIDAllowed(uint64_t uid)

--- a/NorthstarDedicatedTest/bansystem.h
+++ b/NorthstarDedicatedTest/bansystem.h
@@ -9,6 +9,7 @@ class ServerBanSystem
 
   public:
 	void OpenBanlist();
+	void ReloadBanlist();
 	void ClearBanlist();
 	void BanUID(uint64_t uid);
 	void UnbanUID(uint64_t uid);

--- a/NorthstarDedicatedTest/bansystem.h
+++ b/NorthstarDedicatedTest/bansystem.h
@@ -9,7 +9,6 @@ class ServerBanSystem
 
   public:
 	void OpenBanlist();
-	void ReloadBanlist();
 	void ClearBanlist();
 	void BanUID(uint64_t uid);
 	void UnbanUID(uint64_t uid);


### PR DESCRIPTION
This closes #165. 
In the current state it only works with #227!

When unbanning it comments out the uid and adds a comment with the local time when the person was unbanned. Gives a nice overview i think, but it only works with #227 since that adds the comment functionality.
![image](https://user-images.githubusercontent.com/47725553/180656279-82d9d373-5b79-475a-876c-80c1c6b3da0f.png)

--- 

<img src="https://user-images.githubusercontent.com/47725553/180656338-aa024f64-00ec-4148-baba-bb611a094398.png" width="400" height="400" />