### PR TITLE
Ignore folder rename in git history

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,6 @@
 
 # Format commit
 75bf194b2fca06de805a7bc025c6dd8379250fa5
+
+# Folder rename
+f9bc3c9d1834cb8bd5f872b749b057c33e8b0102


### PR DESCRIPTION
Ignore folder rename in git history when checking with `git blame`. When checking the author of a specific line we obviously don't want to show the folder rename commit as that didn't actually change the line.