### PR TITLE
Refactor: Use in-file macros rather than global funcs for registering dll load callbacks/

### DIFF
--- a/NorthstarDLL/audio.cpp
+++ b/NorthstarDLL/audio.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "audio.h"
 #include "dedicated.h"
 
@@ -493,7 +494,7 @@ void __fastcall MilesLog_Hook(int level, const char* string)
 	spdlog::info("[MSS] {} - {}", level, string);
 }
 
-void InitialiseMilesAudioHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", AudioHooks, ConVar, (HMODULE baseAddress)
 {
 	Cvar_ns_print_played_sounds = new ConVar("ns_print_played_sounds", "0", FCVAR_NONE, "");
 
@@ -512,4 +513,4 @@ void InitialiseMilesAudioHooks(HMODULE baseAddress)
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x57DAD0, &MilesLog_Hook, reinterpret_cast<LPVOID*>(&MilesLog_Original));
 
 	MilesStopAll = (MilesStopAll_Type)((char*)baseAddress + 0x580850);
-}
+})

--- a/NorthstarDLL/audio.h
+++ b/NorthstarDLL/audio.h
@@ -46,5 +46,3 @@ class CustomAudioManager
 };
 
 extern CustomAudioManager g_CustomAudioManager;
-
-void InitialiseMilesAudioHooks(HMODULE baseAddress);

--- a/NorthstarDLL/bansystem.cpp
+++ b/NorthstarDLL/bansystem.cpp
@@ -1,5 +1,7 @@
+#pragma once
 #include "pch.h"
 #include "bansystem.h"
+#include "hooks.h"
 #include "serverauthentication.h"
 #include "concommand.h"
 #include "miscserverscript.h"
@@ -210,7 +212,7 @@ void ClearBanlistCommand(const CCommand& args)
 	g_ServerBanSystem->ClearBanlist();
 }
 
-void InitialiseBanSystem(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("engine.dll", BanSystem, ConCommand, (HMODULE baseAddress)
 {
 	g_ServerBanSystem = new ServerBanSystem;
 	g_ServerBanSystem->OpenBanlist();
@@ -218,4 +220,4 @@ void InitialiseBanSystem(HMODULE baseAddress)
 	RegisterConCommand("ban", BanPlayerCommand, "bans a given player by uid or name", FCVAR_GAMEDLL);
 	RegisterConCommand("unban", UnbanPlayerCommand, "unbans a given player by uid", FCVAR_NONE);
 	RegisterConCommand("clearbanlist", ClearBanlistCommand, "clears all uids on the banlist", FCVAR_NONE);
-}
+})

--- a/NorthstarDLL/buildainfile.cpp
+++ b/NorthstarDLL/buildainfile.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "buildainfile.h"
 #include "convar.h"
+#include "hooks.h"
 #include "hookutils.h"
 #include <fstream>
 #include <filesystem>
@@ -373,7 +374,7 @@ void LoadAINFileHook(void* aimanager, void* buf, const char* filename)
 	}
 }
 
-void InitialiseBuildAINFileHooks(HMODULE baseAddress)
+ON_DLL_LOAD("server.dll", BuildAINFile, (HMODULE baseAddress)
 {
 	Cvar_ns_ai_dumpAINfileFromLoad = new ConVar(
 		"ns_ai_dumpAINfileFromLoad", "0", FCVAR_NONE, "For debugging: whether we should dump ain data for ains loaded from disk");
@@ -397,4 +398,4 @@ void InitialiseBuildAINFileHooks(HMODULE baseAddress)
 	// due to the sheer amount of logging this is a massive perf hit to generation, but spewlog_enable 0 exists so whatever
 	NSMem::NOP(base + 0x3889B6, 6);
 	NSMem::NOP(base + 0x3889BF, 6);
-}
+});

--- a/NorthstarDLL/buildainfile.h
+++ b/NorthstarDLL/buildainfile.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseBuildAINFileHooks(HMODULE baseAddress);

--- a/NorthstarDLL/chatcommand.cpp
+++ b/NorthstarDLL/chatcommand.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "convar.h"
 #include "concommand.h"
 #include "chatcommand.h"
@@ -29,10 +30,10 @@ void ConCommand_log(const CCommand& args)
 	}
 }
 
-void InitialiseChatCommands(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", ClientChatCommand, ConCommand, (HMODULE baseAddress)
 {
 	ClientSayText = (ClientSayTextType)((char*)baseAddress + 0x54780);
 	RegisterConCommand("say", ConCommand_say, "Enters a message in public chat", FCVAR_CLIENTDLL);
 	RegisterConCommand("say_team", ConCommand_say_team, "Enters a message in team chat", FCVAR_CLIENTDLL);
 	RegisterConCommand("log", ConCommand_log, "Log a message to the local chat window", FCVAR_CLIENTDLL);
-}
+})

--- a/NorthstarDLL/chatcommand.h
+++ b/NorthstarDLL/chatcommand.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseChatCommands(HMODULE baseAddress);

--- a/NorthstarDLL/clientauthhooks.cpp
+++ b/NorthstarDLL/clientauthhooks.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "clientauthhooks.h"
 #include "hookutils.h"
 #include "gameutils.h"
@@ -33,7 +34,7 @@ void AuthWithStryderHook(void* a1)
 	AuthWithStryder(a1);
 }
 
-void InitialiseClientAuthHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", ClientAuthHooks, ConVar, (HMODULE baseAddress)
 {
 	// this cvar will save to cfg once initially agreed with
 	Cvar_ns_has_agreed_to_send_token = new ConVar(
@@ -44,4 +45,4 @@ void InitialiseClientAuthHooks(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1843A0, &AuthWithStryderHook, reinterpret_cast<LPVOID*>(&AuthWithStryder));
-}
+})

--- a/NorthstarDLL/clientauthhooks.h
+++ b/NorthstarDLL/clientauthhooks.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialiseClientAuthHooks(HMODULE baseAddress);

--- a/NorthstarDLL/clientchathooks.cpp
+++ b/NorthstarDLL/clientchathooks.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "clientchathooks.h"
 #include <rapidjson/document.h>
 #include "squirrel.h"
@@ -84,7 +85,7 @@ static SQRESULT SQ_ChatWriteLine(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-void InitialiseClientChatHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ClientChatHooks, ClientSquirrel, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x22E580, &CHudChat__AddGameLineHook, reinterpret_cast<LPVOID*>(&CHudChat__AddGameLine));
@@ -92,4 +93,4 @@ void InitialiseClientChatHooks(HMODULE baseAddress)
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWrite", "int context, string text", "", SQ_ChatWrite);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWriteRaw", "int context, string text", "", SQ_ChatWriteRaw);
 	g_ClientSquirrelManager->AddFuncRegistration("void", "NSChatWriteLine", "int context, string text", "", SQ_ChatWriteLine);
-}
+})

--- a/NorthstarDLL/clientchathooks.h
+++ b/NorthstarDLL/clientchathooks.h
@@ -1,5 +1,2 @@
 #pragma once
 #include "pch.h"
-#include "serverchathooks.h"
-
-void InitialiseClientChatHooks(HMODULE baseAddress);

--- a/NorthstarDLL/clientruihooks.cpp
+++ b/NorthstarDLL/clientruihooks.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "clientruihooks.h"
 #include "convar.h"
 
@@ -15,10 +16,10 @@ char DrawRUIFuncHook(void* a1, float* a2)
 	return DrawRUIFunc(a1, a2);
 }
 
-void InitialiseEngineClientRUIHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", RUI, ConVar, (HMODULE baseAddress)
 {
 	Cvar_rui_drawEnable = new ConVar("rui_drawEnable", "1", FCVAR_CLIENTDLL, "Controls whether RUI should be drawn");
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xFC500, &DrawRUIFuncHook, reinterpret_cast<LPVOID*>(&DrawRUIFunc));
-}
+})

--- a/NorthstarDLL/clientruihooks.h
+++ b/NorthstarDLL/clientruihooks.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialiseEngineClientRUIHooks(HMODULE baseAddress);

--- a/NorthstarDLL/clientvideooverrides.cpp
+++ b/NorthstarDLL/clientvideooverrides.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "clientvideooverrides.h"
 #include "modmanager.h"
 #include "nsmem.h"
@@ -32,7 +33,7 @@ void* BinkOpenHook(const char* path, uint32_t flags)
 		return BinkOpen(path, flags);
 }
 
-void InitialiseEngineClientVideoOverrides(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT("client.dll", BinkVideo, (HMODULE baseAddress)
 {
 	// remove engine check for whether the bik we're trying to load exists in r2/media, as this will fail for biks in mods
 	// note: the check in engine is actually unnecessary, so it's just useless in practice and we lose nothing by removing it
@@ -44,4 +45,4 @@ void InitialiseEngineClientVideoOverrides(HMODULE baseAddress)
 		reinterpret_cast<void*>(GetProcAddress(GetModuleHandleA("bink2w64.dll"), "BinkOpen")),
 		&BinkOpenHook,
 		reinterpret_cast<LPVOID*>(&BinkOpen));
-}
+})

--- a/NorthstarDLL/clientvideooverrides.h
+++ b/NorthstarDLL/clientvideooverrides.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialiseEngineClientVideoOverrides(HMODULE baseAddress);

--- a/NorthstarDLL/concommand.cpp
+++ b/NorthstarDLL/concommand.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "concommand.h"
 #include "gameutils.h"
 #include "misccommands.h"
@@ -17,11 +18,11 @@ void RegisterConCommand(const char* name, void (*callback)(const CCommand&), con
 	conCommandConstructor(newCommand, name, callback, helpString, flags, nullptr);
 }
 
-void InitialiseConCommands(HMODULE baseAddress)
+ON_DLL_LOAD("engine.dll", ConCommand, (HMODULE baseAddress)
 {
 	conCommandConstructor = (ConCommandConstructorType)((char*)baseAddress + 0x415F60);
 	AddMiscConCommands();
-}
+})
 
 //-----------------------------------------------------------------------------
 // Purpose: Returns true if this is a command

--- a/NorthstarDLL/concommand.h
+++ b/NorthstarDLL/concommand.h
@@ -122,6 +122,5 @@ class ConCommand : public ConCommandBase
 }; // Size: 0x0060
 
 void RegisterConCommand(const char* name, void (*callback)(const CCommand&), const char* helpString, int flags);
-void InitialiseConCommands(HMODULE baseAddress);
 
 #define MAKE_CONCMD(name, helpStr, flags, fn) RegisterConCommand(name, fn, helpStr, flags);

--- a/NorthstarDLL/convar.cpp
+++ b/NorthstarDLL/convar.cpp
@@ -1,6 +1,7 @@
 #include <float.h>
 
 #include "pch.h"
+#include "hooks.h"
 #include "bits.h"
 #include "cvar.h"
 #include "convar.h"
@@ -33,7 +34,7 @@ CvarIsFlagSetType CvarIsFlagSet;
 //-----------------------------------------------------------------------------
 // Purpose: ConVar interface initialization
 //-----------------------------------------------------------------------------
-void InitialiseConVars(HMODULE baseAddress)
+ON_DLL_LOAD("engine.dll", ConVar, (HMODULE baseAddress)
 {
 	conVarMalloc = (ConVarMallocType)((char*)baseAddress + 0x415C20);
 	conVarRegister = (ConVarRegisterType)((char*)baseAddress + 0x417230);
@@ -46,7 +47,7 @@ void InitialiseConVars(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x417FA0, &ConVar::IsFlagSet, reinterpret_cast<LPVOID*>(&CvarIsFlagSet));
-}
+})
 
 //-----------------------------------------------------------------------------
 // Purpose: constructor

--- a/NorthstarDLL/convar.h
+++ b/NorthstarDLL/convar.h
@@ -145,5 +145,3 @@ class ConVar
 	void* m_pMalloc {}; // 0x0070
 	char m_pPad80[10] {}; // 0x0080
 }; // Size: 0x0080
-
-void InitialiseConVars(HMODULE baseAddress);

--- a/NorthstarDLL/debugoverlay.cpp
+++ b/NorthstarDLL/debugoverlay.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "debugoverlay.h"
 #include "dedicated.h"
 #include "cvar.h"
@@ -151,7 +152,7 @@ void __fastcall DrawOverlayHook(OverlayBase_t* pOverlay)
 	LeaveCriticalSection((LPCRITICAL_SECTION)((char*)sEngineModule + 0x10DB0A38));
 }
 
-void InitialiseDebugOverlay(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", DebugOverlay, ConVar, (HMODULE baseAddress)
 {
 	if (IsDedicatedServer())
 		return;
@@ -172,4 +173,4 @@ void InitialiseDebugOverlay(HMODULE baseAddress)
 	Cvar_enable_debug_overlays->SetValue(false);
 	Cvar_enable_debug_overlays->m_pszDefaultValue = (char*)"0";
 	Cvar_enable_debug_overlays->AddFlags(FCVAR_CHEAT);
-}
+})

--- a/NorthstarDLL/debugoverlay.h
+++ b/NorthstarDLL/debugoverlay.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseDebugOverlay(HMODULE baseAddress);

--- a/NorthstarDLL/dedicated.cpp
+++ b/NorthstarDLL/dedicated.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "dedicated.h"
 #include "hookutils.h"
 #include "gameutils.h"
@@ -128,7 +129,7 @@ DWORD WINAPI ConsoleInputThread(PVOID pThreadParameter)
 }
 
 #include "nsmem.h"
-void InitialiseDedicated(HMODULE engineAddress)
+ON_DLL_LOAD_DEDI("engine.dll", DedicatedServer, (HMODULE engineAddress)
 {
 	spdlog::info("InitialiseDedicated");
 
@@ -299,9 +300,9 @@ void InitialiseDedicated(HMODULE engineAddress)
 		consoleInputThreadHandle = CreateThread(0, 0, ConsoleInputThread, 0, 0, NULL);
 	else
 		spdlog::info("Console input disabled by user request");
-}
+})
 
-void InitialiseDedicatedOrigin(HMODULE baseAddress)
+ON_DLL_LOAD_DEDI("tier0.dll", DedicatedServerOrigin, (HMODULE baseAddress)
 {
 	// disable origin on dedicated
 	// for any big ea lawyers, this can't be used to play the game without origin, game will throw a fit if you try to do anything without
@@ -312,7 +313,7 @@ void InitialiseDedicatedOrigin(HMODULE baseAddress)
 		{
 			0xC3 // ret
 		});
-}
+})
 
 typedef void (*PrintFatalSquirrelErrorType)(void* sqvm);
 PrintFatalSquirrelErrorType PrintFatalSquirrelError;
@@ -322,8 +323,8 @@ void PrintFatalSquirrelErrorHook(void* sqvm)
 	g_pEngine->m_nQuitting = EngineQuitState::QUIT_TODESKTOP;
 }
 
-void InitialiseDedicatedServerGameDLL(HMODULE baseAddress)
+ON_DLL_LOAD_DEDI("server.dll", DedicatedServerGameDLL, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, baseAddress + 0x794D0, &PrintFatalSquirrelErrorHook, reinterpret_cast<LPVOID*>(&PrintFatalSquirrelError));
-}
+})

--- a/NorthstarDLL/dedicated.h
+++ b/NorthstarDLL/dedicated.h
@@ -1,7 +1,3 @@
 #pragma once
 
 bool IsDedicatedServer();
-
-void InitialiseDedicated(HMODULE moduleAddress);
-void InitialiseDedicatedOrigin(HMODULE baseAddress);
-void InitialiseDedicatedServerGameDLL(HMODULE baseAddress);

--- a/NorthstarDLL/dedicatedmaterialsystem.cpp
+++ b/NorthstarDLL/dedicatedmaterialsystem.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "dedicated.h"
 #include "dedicatedmaterialsystem.h"
 #include "hookutils.h"
@@ -44,7 +45,7 @@ HRESULT __stdcall D3D11CreateDeviceHook(
 		pAdapter, DriverType, Software, Flags, pFeatureLevels, FeatureLevels, SDKVersion, ppDevice, pFeatureLevel, ppImmediateContext);
 }
 
-void InitialiseDedicatedMaterialSystem(HMODULE baseAddress)
+ON_DLL_LOAD_DEDI("materialsystem_dx11.dll", DedicatedServerMaterialSystem, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xD9A0E, &D3D11CreateDeviceHook, reinterpret_cast<LPVOID*>(&D3D11CreateDevice));
@@ -81,7 +82,7 @@ void InitialiseDedicatedMaterialSystem(HMODULE baseAddress)
 
 	// previously had DisableDedicatedWindowCreation stuff here, removing for now since shit and unstable
 	// check commit history if needed
-}
+})
 
 typedef void* (*PakLoadAPI__LoadRpakType)(char* filename, void* unknown, int flags);
 PakLoadAPI__LoadRpakType PakLoadAPI__LoadRpak;

--- a/NorthstarDLL/dedicatedmaterialsystem.h
+++ b/NorthstarDLL/dedicatedmaterialsystem.h
@@ -1,3 +1,1 @@
 #pragma once
-void InitialiseDedicatedMaterialSystem(HMODULE baseAddress);
-void InitialiseDedicatedRtechGame(HMODULE baseAddress);

--- a/NorthstarDLL/filesystem.cpp
+++ b/NorthstarDLL/filesystem.cpp
@@ -34,7 +34,7 @@ bool readingOriginalFile;
 std::string currentModPath;
 SourceInterface<IFileSystem>* g_Filesystem;
 
-void InitialiseFilesystem(HMODULE baseAddress)
+ON_DLL_LOAD("filesystem_stdio.dll", Filesystem, (HMODULE baseAddress)
 {
 	g_Filesystem = new SourceInterface<IFileSystem>("filesystem_stdio.dll", "VFileSystem017");
 
@@ -54,7 +54,7 @@ void InitialiseFilesystem(HMODULE baseAddress)
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x15F20, &ReadFileFromFilesystemHook, reinterpret_cast<LPVOID*>(&readFileFromFilesystem));
 	ENABLER_CREATEHOOK(
 		hook, reinterpret_cast<void*>((*g_Filesystem)->m_vtable->MountVPK), &MountVPKHook, reinterpret_cast<LPVOID*>(&mountVPK));
-}
+})
 
 std::string ReadVPKFile(const char* path)
 {

--- a/NorthstarDLL/filesystem.h
+++ b/NorthstarDLL/filesystem.h
@@ -70,5 +70,4 @@ class IFileSystem
 std::string ReadVPKFile(const char* path);
 std::string ReadVPKOriginalFile(const char* path);
 
-void InitialiseFilesystem(HMODULE baseAddress);
 extern SourceInterface<IFileSystem>* g_Filesystem;

--- a/NorthstarDLL/hooks.cpp
+++ b/NorthstarDLL/hooks.cpp
@@ -4,12 +4,16 @@
 #include "sigscanning.h"
 #include "dedicated.h"
 
+#include <iostream>
 #include <wchar.h>
 #include <iostream>
 #include <vector>
 #include <fstream>
 #include <sstream>
 #include <filesystem>
+#include <psapi.h>
+
+namespace fs = std::filesystem;
 
 typedef LPSTR (*GetCommandLineAType)();
 LPSTR GetCommandLineAHook();
@@ -38,14 +42,39 @@ void InstallInitialHooks()
 		spdlog::error("MH_Initialize (minhook initialization) failed");
 
 	HookEnabler hook;
-	ENABLER_CREATEHOOK(
-		hook, reinterpret_cast<void*>(&GetCommandLineA), &GetCommandLineAHook, reinterpret_cast<LPVOID*>(&GetCommandLineAOriginal));
-	ENABLER_CREATEHOOK(
-		hook, reinterpret_cast<void*>(&LoadLibraryExA), &LoadLibraryExAHook, reinterpret_cast<LPVOID*>(&LoadLibraryExAOriginal));
-	ENABLER_CREATEHOOK(hook, reinterpret_cast<void*>(&LoadLibraryA), &LoadLibraryAHook, reinterpret_cast<LPVOID*>(&LoadLibraryAOriginal));
-	ENABLER_CREATEHOOK(
-		hook, reinterpret_cast<void*>(&LoadLibraryExW), &LoadLibraryExWHook, reinterpret_cast<LPVOID*>(&LoadLibraryExWOriginal));
-	ENABLER_CREATEHOOK(hook, reinterpret_cast<void*>(&LoadLibraryW), &LoadLibraryWHook, reinterpret_cast<LPVOID*>(&LoadLibraryWOriginal));
+	ENABLER_CREATEHOOK(hook, &GetCommandLineA, &GetCommandLineAHook, reinterpret_cast<LPVOID*>(&GetCommandLineAOriginal));
+	ENABLER_CREATEHOOK(hook, &LoadLibraryExA, &LoadLibraryExAHook, reinterpret_cast<LPVOID*>(&LoadLibraryExAOriginal));
+	ENABLER_CREATEHOOK(hook, &LoadLibraryA, &LoadLibraryAHook, reinterpret_cast<LPVOID*>(&LoadLibraryAOriginal));
+	ENABLER_CREATEHOOK(hook, &LoadLibraryExW, &LoadLibraryExWHook, reinterpret_cast<LPVOID*>(&LoadLibraryExWOriginal));
+	ENABLER_CREATEHOOK(hook, &LoadLibraryW, &LoadLibraryWHook, reinterpret_cast<LPVOID*>(&LoadLibraryWOriginal));
+}
+
+// called from the ON_DLL_LOAD macros
+__dllLoadCallback::__dllLoadCallback(
+	eDllLoadCallbackSide side, const std::string dllName, DllLoadCallbackFuncType callback, std::string uniqueStr, std::string reliesOn)
+{
+	spdlog::info("calling loadcallback {} for dll {}", uniqueStr, dllName);
+
+	switch (side)
+	{
+		case eDllLoadCallbackSide::UNSIDED:
+		{
+			AddDllLoadCallback(dllName, callback, uniqueStr, reliesOn);
+			break;
+		}
+
+		case eDllLoadCallbackSide::CLIENT:
+		{
+			AddDllLoadCallbackForClient(dllName, callback, uniqueStr, reliesOn);
+			break;
+		}
+
+		case eDllLoadCallbackSide::DEDICATED_SERVER:
+		{
+			AddDllLoadCallbackForDedicatedServer(dllName, callback, uniqueStr, reliesOn);
+			break;
+		}
+	}
 }
 
 LPSTR GetCommandLineAHook()
@@ -117,71 +146,117 @@ struct DllLoadCallback
 {
 	std::string dll;
 	DllLoadCallbackFuncType callback;
+	std::string tag;
+	std::string reliesOn;
 	bool called;
 };
 
-std::vector<DllLoadCallback*> dllLoadCallbacks;
+bool how = false;
+std::vector<DllLoadCallback> dllLoadCallbacks = std::vector<DllLoadCallback>();
 
-void AddDllLoadCallback(std::string dll, DllLoadCallbackFuncType callback)
+void AddDllLoadCallback(std::string dll, DllLoadCallbackFuncType callback, std::string tag, std::string reliesOn)
 {
-	DllLoadCallback* callbackStruct = new DllLoadCallback;
-	callbackStruct->dll = dll;
-	callbackStruct->callback = callback;
-	callbackStruct->called = false;
+	if (!how) // WHY IS THIS A THING WE NEED ON DEBUG?????
+	{
+		dllLoadCallbacks = std::vector<DllLoadCallback>();
+		how = true;
+	}
 
-	dllLoadCallbacks.push_back(callbackStruct);
+	DllLoadCallback& callbackStruct = dllLoadCallbacks.emplace_back();
+
+	callbackStruct.dll = dll;
+	callbackStruct.callback = callback;
+	callbackStruct.tag = tag;
+	callbackStruct.reliesOn = reliesOn;
+	callbackStruct.called = false;
 }
 
-void AddDllLoadCallbackForDedicatedServer(std::string dll, DllLoadCallbackFuncType callback)
+void AddDllLoadCallbackForDedicatedServer(
+	std::string dll, DllLoadCallbackFuncType callback, std::string tag, std::string reliesOn)
 {
 	if (!IsDedicatedServer())
 		return;
 
-	DllLoadCallback* callbackStruct = new DllLoadCallback;
-	callbackStruct->dll = dll;
-	callbackStruct->callback = callback;
-	callbackStruct->called = false;
-
-	dllLoadCallbacks.push_back(callbackStruct);
+	AddDllLoadCallback(dll, callback, tag, reliesOn);
 }
 
-void AddDllLoadCallbackForClient(std::string dll, DllLoadCallbackFuncType callback)
+void AddDllLoadCallbackForClient(std::string dll, DllLoadCallbackFuncType callback, std::string tag, std::string reliesOn)
 {
 	if (IsDedicatedServer())
 		return;
 
-	DllLoadCallback* callbackStruct = new DllLoadCallback;
-	callbackStruct->dll = dll;
-	callbackStruct->callback = callback;
-	callbackStruct->called = false;
-
-	dllLoadCallbacks.push_back(callbackStruct);
+	AddDllLoadCallback(dll, callback, tag, reliesOn);
 }
+
+std::vector<std::string> calledTags;
 
 void CallLoadLibraryACallbacks(LPCSTR lpLibFileName, HMODULE moduleAddress)
 {
-	for (auto& callbackStruct : dllLoadCallbacks)
+	spdlog::info((char*)lpLibFileName);
+
+	while (true)
 	{
-		if (!callbackStruct->called &&
-			strstr(lpLibFileName + (strlen(lpLibFileName) - callbackStruct->dll.length()), callbackStruct->dll.c_str()) != nullptr)
+		bool doneCalling = true;
+
+		for (auto& callbackStruct : dllLoadCallbacks)
 		{
-			callbackStruct->callback(moduleAddress);
-			callbackStruct->called = true;
+			spdlog::info("{} {}", callbackStruct.tag, callbackStruct.reliesOn);
+
+			if (!callbackStruct.called && fs::path(lpLibFileName).filename() == fs::path(callbackStruct.dll).filename())
+			{
+				//spdlog::info(callbackStruct.tag);
+				//spdlog::info(callbackStruct.reliesOn);
+
+				if (callbackStruct.reliesOn != "" &&
+					std::find(calledTags.begin(), calledTags.end(), callbackStruct.reliesOn) == calledTags.end())
+				{
+					doneCalling = false;
+					continue;
+				}
+
+				callbackStruct.callback(moduleAddress);
+				calledTags.push_back(callbackStruct.tag);
+				callbackStruct.called = true;
+			}
 		}
+
+		if (doneCalling)
+			break;
 	}
 }
 
 void CallLoadLibraryWCallbacks(LPCWSTR lpLibFileName, HMODULE moduleAddress)
 {
-	for (auto& callbackStruct : dllLoadCallbacks)
+	spdlog::info((char*)lpLibFileName);
+
+	while (true)
 	{
-		std::wstring wcharStrDll = std::wstring(callbackStruct->dll.begin(), callbackStruct->dll.end());
-		const wchar_t* callbackDll = wcharStrDll.c_str();
-		if (!callbackStruct->called && wcsstr(lpLibFileName + (wcslen(lpLibFileName) - wcharStrDll.length()), callbackDll) != nullptr)
+		bool doneCalling = true;
+
+		for (auto& callbackStruct : dllLoadCallbacks)
 		{
-			callbackStruct->callback(moduleAddress);
-			callbackStruct->called = true;
+			spdlog::info("{} {}", callbackStruct.tag, callbackStruct.reliesOn);
+
+			if (!callbackStruct.called && fs::path(lpLibFileName).filename() == fs::path(callbackStruct.dll).filename())
+			{
+				//spdlog::info(callbackStruct.tag);
+				//spdlog::info(callbackStruct.reliesOn);
+
+				if (callbackStruct.reliesOn != "" &&
+					std::find(calledTags.begin(), calledTags.end(), callbackStruct.reliesOn) == calledTags.end())
+				{
+					doneCalling = false;
+					continue;
+				}
+
+				callbackStruct.callback(moduleAddress);
+				calledTags.push_back(callbackStruct.tag);
+				callbackStruct.called = true;
+			}
 		}
+
+		if (doneCalling)
+			break;
 	}
 }
 

--- a/NorthstarDLL/hooks.h
+++ b/NorthstarDLL/hooks.h
@@ -1,11 +1,48 @@
 #pragma once
 #include <string>
+#include <iostream>
 
 void InstallInitialHooks();
 
 typedef void (*DllLoadCallbackFuncType)(HMODULE moduleAddress);
-void AddDllLoadCallback(std::string dll, DllLoadCallbackFuncType callback);
-void AddDllLoadCallbackForDedicatedServer(std::string dll, DllLoadCallbackFuncType callback);
-void AddDllLoadCallbackForClient(std::string dll, DllLoadCallbackFuncType callback);
+void AddDllLoadCallback(std::string dll, DllLoadCallbackFuncType callback, std::string tag = "", std::string reliesOn = "");
+void AddDllLoadCallbackForDedicatedServer(
+	std::string dll, DllLoadCallbackFuncType callback, std::string tag = "", std::string reliesOn = "");
+void AddDllLoadCallbackForClient(std::string dll, DllLoadCallbackFuncType callback, std::string tag = "", std::string reliesOn = "");
 
 void CallAllPendingDLLLoadCallbacks();
+
+// new dll load callback stuff
+enum class eDllLoadCallbackSide
+{
+	UNSIDED,
+	CLIENT,
+	DEDICATED_SERVER
+};
+
+class __dllLoadCallback
+{
+  public:
+	__dllLoadCallback() = delete;
+	__dllLoadCallback(
+		eDllLoadCallbackSide side,
+		const std::string dllName,
+		DllLoadCallbackFuncType callback,
+		std::string uniqueStr,
+		std::string reliesOn);
+};
+
+#define CONCAT_(x, y, z) x##y##z
+#define CONCAT(x, y, z) CONCAT_(x, y, z)
+#define __STR(s) #s
+
+#define __ON_DLL_LOAD(dllName, func, side, counter, uniquestr, reliesOn) \
+void CONCAT(__callbackFunc, uniquestr, counter) func \
+__dllLoadCallback CONCAT(__dllLoadCallbackInstance, uniquestr, counter)(side, dllName, CONCAT(__callbackFunc, uniquestr, counter), __STR(uniquestr), reliesOn); 
+
+#define ON_DLL_LOAD(dllName, uniquestr, func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::UNSIDED, __LINE__, uniquestr, "")
+#define ON_DLL_LOAD_RELIESON(dllName, uniquestr, reliesOn, func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::UNSIDED, __LINE__, uniquestr, __STR(reliesOn))
+#define ON_DLL_LOAD_CLIENT(dllName, uniquestr, func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::CLIENT, __LINE__, uniquestr, "")
+#define ON_DLL_LOAD_CLIENT_RELIESON(dllName, uniquestr, reliesOn,  func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::CLIENT, __LINE__, uniquestr, __STR(reliesOn))
+#define ON_DLL_LOAD_DEDI(dllName, uniquestr, func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::DEDICATED_SERVER, __LINE__, uniquestr, "")
+#define ON_DLL_LOAD_DEDI_RELIESON(dllName, uniquestr, reliesOn, func) __ON_DLL_LOAD(dllName, func, eDllLoadCallbackSide::DEDICATED_SERVER, __LINE__, uniquestr, __STR(reliesOn))

--- a/NorthstarDLL/keyvalues.cpp
+++ b/NorthstarDLL/keyvalues.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "keyvalues.h"
 #include "modmanager.h"
+#include "hooks.h"
 #include "filesystem.h"
 #include "hookutils.h"
 
@@ -13,12 +14,12 @@ KeyValues__LoadFromBufferType KeyValues__LoadFromBuffer;
 char KeyValues__LoadFromBufferHook(
 	void* self, const char* resourceName, const char* pBuffer, void* pFileSystem, void* a5, void* a6, int a7);
 
-void InitialiseKeyValues(HMODULE baseAddress)
+ON_DLL_LOAD("engine.dll", KeyValues, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x426C30, &KeyValues__LoadFromBufferHook, reinterpret_cast<LPVOID*>(&KeyValues__LoadFromBuffer));
-}
+})
 
 void* savedFilesystemPtr;
 

--- a/NorthstarDLL/languagehooks.cpp
+++ b/NorthstarDLL/languagehooks.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "languagehooks.h"
 #include "gameutils.h"
 #include <filesystem>
@@ -112,8 +113,8 @@ char* GetGameLanguageHook()
 	return lang;
 }
 
-void InitialiseTier0LanguageHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT("tier0.dll", LanguageHooks, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0xF560, &GetGameLanguageHook, reinterpret_cast<LPVOID*>(&GetGameLanguageOriginal));
-}
+})

--- a/NorthstarDLL/languagehooks.h
+++ b/NorthstarDLL/languagehooks.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseTier0LanguageHooks(HMODULE baseAddress);

--- a/NorthstarDLL/latencyflex.cpp
+++ b/NorthstarDLL/latencyflex.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "latencyflex.h"
 #include "hookutils.h"
 #include "convar.h"
@@ -26,7 +27,7 @@ void OnRenderStartHook()
 	OnRenderStart();
 }
 
-void InitialiseLatencyFleX(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", LatencyFlex, ConVar, (HMODULE baseAddress)
 {
 	// Connect to the LatencyFleX service
 	// LatencyFleX is an open source vendor agnostic replacement for Nvidia Reflex input latency reduction technology.
@@ -73,4 +74,4 @@ void InitialiseLatencyFleX(HMODULE baseAddress)
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x1952C0, &OnRenderStartHook, reinterpret_cast<LPVOID*>(&OnRenderStart));
-}
+})

--- a/NorthstarDLL/latencyflex.h
+++ b/NorthstarDLL/latencyflex.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialiseLatencyFleX(HMODULE baseAddress);

--- a/NorthstarDLL/localchatwriter.cpp
+++ b/NorthstarDLL/localchatwriter.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "localchatwriter.h"
 
 class vgui_BaseRichText_vtable;
@@ -436,7 +437,7 @@ void LocalChatWriter::InsertDefaultFade()
 	}
 }
 
-void InitialiseLocalChatWriter(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT("client.dll", LocalChatWriter, (HMODULE baseAddress)
 {
 	gGameSettings = (CGameSettings**)((char*)baseAddress + 0x11BAA48);
 	gChatFadeLength = (CGameFloatVar**)((char*)baseAddress + 0x11BAB78);
@@ -444,4 +445,4 @@ void InitialiseLocalChatWriter(HMODULE baseAddress)
 	CHudChat::allHuds = (CHudChat**)((char*)baseAddress + 0x11BA9E8);
 
 	ConvertANSIToUnicode = (ConvertANSIToUnicodeType)((char*)baseAddress + 0x7339A0);
-}
+})

--- a/NorthstarDLL/localchatwriter.h
+++ b/NorthstarDLL/localchatwriter.h
@@ -70,5 +70,3 @@ class LocalChatWriter
 	const char* ApplyAnsiEscape(const char* escape);
 	void InsertDefaultFade();
 };
-
-void InitialiseLocalChatWriter(HMODULE baseAddress);

--- a/NorthstarDLL/logging.cpp
+++ b/NorthstarDLL/logging.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "logging.h"
+#include "hooks.h"
 #include "sourceconsole.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "hookutils.h"
@@ -409,7 +410,7 @@ bool CClientState_ProcessPrint_Hook(__int64 thisptr, __int64 msg)
 	return true;
 }
 
-void InitialiseEngineSpewFuncHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", EngineSpewFuncHooks, ConVar, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 
@@ -426,7 +427,7 @@ void InitialiseEngineSpewFuncHooks(HMODULE baseAddress)
 		reinterpret_cast<LPVOID*>(&CClientState_ProcessPrint_Original));
 
 	Cvar_spewlog_enable = new ConVar("spewlog_enable", "1", FCVAR_NONE, "Enables/disables whether the engine spewfunc should be logged");
-}
+})
 
 #include "bitbuf.h"
 
@@ -476,7 +477,7 @@ void TextMsgHook(BFRead* msg)
 	}
 }
 
-void InitialiseClientPrintHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ClientPrintHooks, ConVar, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 
@@ -486,4 +487,4 @@ void InitialiseClientPrintHooks(HMODULE baseAddress)
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x198710, TextMsgHook, reinterpret_cast<LPVOID*>(&TextMsg_Original));
 
 	Cvar_cl_showtextmsg = new ConVar("cl_showtextmsg", "1", FCVAR_NONE, "Enable/disable text messages printing on the screen.");
-}
+})

--- a/NorthstarDLL/logging.h
+++ b/NorthstarDLL/logging.h
@@ -3,5 +3,3 @@
 
 void CreateLogFiles();
 void InitialiseLogging();
-void InitialiseEngineSpewFuncHooks(HMODULE baseAddress);
-void InitialiseClientPrintHooks(HMODULE baseAddress);

--- a/NorthstarDLL/masterserver.cpp
+++ b/NorthstarDLL/masterserver.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "masterserver.h"
+#include "hooks.h"
 #include "concommand.h"
 #include "gameutils.h"
 #include "hookutils.h"
@@ -1367,7 +1368,7 @@ void CHostState__State_GameShutdownHook(CHostState* hostState)
 
 MasterServerManager::MasterServerManager() : m_pendingConnectionInfo {}, m_ownServerId {""}, m_ownClientAuthToken {""} {}
 
-void InitialiseSharedMasterServer(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("engine.dll", MasterServer, ConCommand, (HMODULE baseAddress)
 {
 	Cvar_ns_masterserver_hostname = new ConVar("ns_masterserver_hostname", "127.0.0.1", FCVAR_NONE, "");
 	// unfortunately lib doesn't let us specify a port and still have https work
@@ -1405,4 +1406,4 @@ void InitialiseSharedMasterServer(HMODULE baseAddress)
 		(char*)baseAddress + 0x16E640,
 		CHostState__State_GameShutdownHook,
 		reinterpret_cast<LPVOID*>(&CHostState__State_GameShutdown));
-}
+})

--- a/NorthstarDLL/masterserver.h
+++ b/NorthstarDLL/masterserver.h
@@ -128,7 +128,6 @@ class MasterServerManager
 };
 std::string unescape_unicode(const std::string& str);
 void UpdateServerInfoFromUnicodeToUTF8();
-void InitialiseSharedMasterServer(HMODULE baseAddress);
 
 extern MasterServerManager* g_MasterServerManager;
 extern ConVar* Cvar_ns_masterserver_hostname;

--- a/NorthstarDLL/miscclientfixes.cpp
+++ b/NorthstarDLL/miscclientfixes.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "miscclientfixes.h"
 #include "hookutils.h"
 #include "dedicated.h"
@@ -25,7 +26,7 @@ void* CrashingWeaponActivityFunc1Hook(void* a1)
 	return CrashingWeaponActivityFunc1(a1);
 }
 
-void InitialiseMiscClientFixes(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", MiscClientFixes, ConVar, (HMODULE baseAddress)
 {
 	if (IsDedicatedServer())
 		return;
@@ -46,4 +47,4 @@ void InitialiseMiscClientFixes(HMODULE baseAddress)
 		void* ptr = (char*)baseAddress + 0x275F9D9;
 		*((char*)ptr) = (char)0;
 	}
-}
+})

--- a/NorthstarDLL/miscclientfixes.h
+++ b/NorthstarDLL/miscclientfixes.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialiseMiscClientFixes(HMODULE baseAddress);

--- a/NorthstarDLL/miscserverfixes.cpp
+++ b/NorthstarDLL/miscserverfixes.cpp
@@ -1,10 +1,11 @@
 #include "pch.h"
+#include "hooks.h"
 #include "miscserverfixes.h"
 #include "hookutils.h"
 
 #include "nsmem.h"
 
-void InitialiseMiscServerFixes(HMODULE baseAddress)
+ON_DLL_LOAD("server.dll", MiscServerFixes, (HMODULE baseAddress)
 {
 	uintptr_t ba = (uintptr_t)baseAddress;
 
@@ -23,4 +24,4 @@ void InitialiseMiscServerFixes(HMODULE baseAddress)
 	{
 		NSMem::BytePatch(ba + 0x153920, "C3");
 	}
-}
+})

--- a/NorthstarDLL/miscserverfixes.h
+++ b/NorthstarDLL/miscserverfixes.h
@@ -1,1 +1,0 @@
-void InitialiseMiscServerFixes(HMODULE baseAddress);

--- a/NorthstarDLL/miscserverscript.cpp
+++ b/NorthstarDLL/miscserverscript.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "miscserverscript.h"
+#include "hooks.h"
 #include "squirrel.h"
 #include "masterserver.h"
 #include "serverauthentication.h"
@@ -66,11 +67,11 @@ SQRESULT SQ_IsDedicated(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-void InitialiseMiscServerScriptCommand(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("server.dll", MiscServerScriptCommands, ServerSquirrel, (HMODULE baseAddress)
 {
 	g_ServerSquirrelManager->AddFuncRegistration(
 		"void", "NSEarlyWritePlayerIndexPersistenceForLeave", "int playerIndex", "", SQ_EarlyWritePlayerIndexPersistenceForLeave);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsWritingPlayerPersistence", "", "", SQ_IsWritingPlayerPersistence);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsPlayerIndexLocalPlayer", "int playerIndex", "", SQ_IsPlayerIndexLocalPlayer);
 	g_ServerSquirrelManager->AddFuncRegistration("bool", "NSIsDedicated", "", "", SQ_IsDedicated);
-}
+})

--- a/NorthstarDLL/miscserverscript.h
+++ b/NorthstarDLL/miscserverscript.h
@@ -1,2 +1,1 @@
-void InitialiseMiscServerScriptCommand(HMODULE baseAddress);
 void* GetPlayerByIndex(int playerIndex);

--- a/NorthstarDLL/modlocalisation.cpp
+++ b/NorthstarDLL/modlocalisation.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "modlocalisation.h"
 #include "hookutils.h"
 #include "modmanager.h"
@@ -30,8 +31,8 @@ bool AddLocalisationFileHook(void* g_pVguiLocalize, const char* path, const char
 	return ret;
 }
 
-void InitialiseModLocalisation(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT("localize.dll", Localize, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(hook, (char*)baseAddress + 0x6D80, AddLocalisationFileHook, reinterpret_cast<LPVOID*>(&AddLocalisationFile));
-}
+})

--- a/NorthstarDLL/modlocalisation.h
+++ b/NorthstarDLL/modlocalisation.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseModLocalisation(HMODULE baseAddress);

--- a/NorthstarDLL/modmanager.cpp
+++ b/NorthstarDLL/modmanager.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "modmanager.h"
+#include "hooks.h"
 #include "convar.h"
 #include "concommand.h"
 #include "audio.h"
@@ -611,12 +612,12 @@ void ReloadModsCommand(const CCommand& args)
 	g_ModManager->LoadMods();
 }
 
-void InitialiseModManager(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("engine.dll", ModManager, ConCommand, (HMODULE baseAddress)
 {
 	g_ModManager = new ModManager;
 
 	RegisterConCommand("reload_mods", ReloadModsCommand, "idk", FCVAR_NONE);
-}
+})
 
 fs::path GetModFolderPath()
 {

--- a/NorthstarDLL/modmanager.h
+++ b/NorthstarDLL/modmanager.h
@@ -149,7 +149,6 @@ class ModManager
 	void BuildPdef();
 };
 
-void InitialiseModManager(HMODULE baseAddress);
 fs::path GetModFolderPath();
 fs::path GetCompiledAssetsPath();
 

--- a/NorthstarDLL/playlist.cpp
+++ b/NorthstarDLL/playlist.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "playlist.h"
+#include "hooks.h"
 #include "concommand.h"
 #include "convar.h"
 #include "gameutils.h"
@@ -72,7 +73,7 @@ int GetCurrentGamemodeMaxPlayersHook()
 }
 
 #include "nsmem.h"
-void InitialisePlaylistHooks(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("engine.dll", PlaylistHooks, ConCommand, (HMODULE baseAddress)
 {
 	RegisterConCommand("setplaylist", SetPlaylistCommand, "Sets the current playlist", FCVAR_NONE);
 	RegisterConCommand("setplaylistvaroverrides", SetPlaylistVarOverrideCommand, "sets a playlist var override", FCVAR_NONE);
@@ -103,4 +104,4 @@ void InitialisePlaylistHooks(HMODULE baseAddress)
 
 	// patch to allow setplaylistvaroverride to be called before map init on dedicated and private match launched through the game
 	NSMem::NOP(ba + 0x18ED17, 6);
-}
+})

--- a/NorthstarDLL/playlist.h
+++ b/NorthstarDLL/playlist.h
@@ -1,2 +1,1 @@
 #pragma once
-void InitialisePlaylistHooks(HMODULE baseAddress);

--- a/NorthstarDLL/rpakfilesystem.cpp
+++ b/NorthstarDLL/rpakfilesystem.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "rpakfilesystem.h"
+#include "hooks.h"
 #include "hookutils.h"
 #include "modmanager.h"
 #include "dedicated.h"
@@ -291,7 +292,7 @@ void* ReadFullFileFromDiskHook(const char* requestedPath, void* a2)
 	return ret;
 }
 
-void InitialiseEngineRpakFilesystem(HMODULE baseAddress)
+ON_DLL_LOAD("engine.dll", RpakFilesystem, (HMODULE baseAddress)
 {
 	g_PakLoadManager = new PakLoadManager;
 
@@ -310,4 +311,4 @@ void InitialiseEngineRpakFilesystem(HMODULE baseAddress)
 		reinterpret_cast<void*>(g_pakLoadApi->ReadFullFileFromDisk),
 		&ReadFullFileFromDiskHook,
 		reinterpret_cast<LPVOID*>(&ReadFullFileFromDiskOriginal));
-}
+})

--- a/NorthstarDLL/rpakfilesystem.h
+++ b/NorthstarDLL/rpakfilesystem.h
@@ -1,7 +1,5 @@
 #pragma once
 
-void InitialiseEngineRpakFilesystem(HMODULE baseAddress);
-
 class PakLoadManager
 {
   public:

--- a/NorthstarDLL/scriptbrowserhooks.cpp
+++ b/NorthstarDLL/scriptbrowserhooks.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "scriptbrowserhooks.h"
 #include "hookutils.h"
 
@@ -17,11 +18,11 @@ void OpenExternalWebBrowserHook(char* url, char flags)
 	*bIsOriginOverlayEnabled = bIsOriginOverlayEnabledOriginal;
 }
 
-void InitialiseScriptExternalBrowserHooks(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT("engine.dll", ScriptExternalBrowserHooks, (HMODULE baseAddress)
 {
 	bIsOriginOverlayEnabled = (bool*)baseAddress + 0x13978255;
 
 	HookEnabler hook;
 	ENABLER_CREATEHOOK(
 		hook, (char*)baseAddress + 0x184E40, &OpenExternalWebBrowserHook, reinterpret_cast<LPVOID*>(&OpenExternalWebBrowser));
-}
+})

--- a/NorthstarDLL/scriptbrowserhooks.h
+++ b/NorthstarDLL/scriptbrowserhooks.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseScriptExternalBrowserHooks(HMODULE baseAddress);

--- a/NorthstarDLL/scriptmainmenupromos.cpp
+++ b/NorthstarDLL/scriptmainmenupromos.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "scriptmainmenupromos.h"
 #include "squirrel.h"
 #include "masterserver.h"
@@ -128,9 +129,9 @@ SQRESULT SQ_GetCustomMainMenuPromoData(void* sqvm)
 	return SQRESULT_NOTNULL;
 }
 
-void InitialiseScriptMainMenuPromos(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ScriptMainMenuPrograms, ClientSquirrel, (HMODULE baseAddress)
 {
 	g_UISquirrelManager->AddFuncRegistration("void", "NSRequestCustomMainMenuPromos", "", "", SQ_RequestCustomMainMenuPromos);
 	g_UISquirrelManager->AddFuncRegistration("bool", "NSHasCustomMainMenuPromoData", "", "", SQ_HasCustomMainMenuPromoData);
 	g_UISquirrelManager->AddFuncRegistration("var", "NSGetCustomMainMenuPromoData", "int promoDataKey", "", SQ_GetCustomMainMenuPromoData);
-}
+})

--- a/NorthstarDLL/scriptmainmenupromos.h
+++ b/NorthstarDLL/scriptmainmenupromos.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseScriptMainMenuPromos(HMODULE baseAddress);

--- a/NorthstarDLL/scriptmodmenu.cpp
+++ b/NorthstarDLL/scriptmodmenu.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "scriptmodmenu.h"
 #include "modmanager.h"
 #include "squirrel.h"
@@ -175,7 +176,7 @@ SQRESULT SQ_ReloadMods(void* sqvm)
 	return SQRESULT_NULL;
 }
 
-void InitialiseScriptModMenu(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ScriptModMenu, ClientSquirrel, (HMODULE baseAddress)
 {
 	g_UISquirrelManager->AddFuncRegistration("array<string>", "NSGetModNames", "", "Returns the names of all loaded mods", SQ_GetModNames);
 	g_UISquirrelManager->AddFuncRegistration(
@@ -200,4 +201,4 @@ void InitialiseScriptModMenu(HMODULE baseAddress)
 		"array<string>", "NSGetModConvarsByModName", "string modName", "Returns the names of all a given mod's cvars", SQ_GetModConvars);
 
 	g_UISquirrelManager->AddFuncRegistration("void", "NSReloadMods", "", "Reloads mods", SQ_ReloadMods);
-}
+})

--- a/NorthstarDLL/scriptmodmenu.h
+++ b/NorthstarDLL/scriptmodmenu.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseScriptModMenu(HMODULE baseAddress);

--- a/NorthstarDLL/scriptserverbrowser.cpp
+++ b/NorthstarDLL/scriptserverbrowser.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "scriptserverbrowser.h"
 #include "squirrel.h"
 #include "masterserver.h"
@@ -414,7 +415,7 @@ SQRESULT SQ_CompleteAuthWithLocalServer(void* sqvm)
 	return SQRESULT_NULL;
 }
 
-void InitialiseScriptServerBrowser(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ScriptServerBrowser, ClientSquirrel, (HMODULE baseAddress)
 {
 	g_UISquirrelManager->AddFuncRegistration("bool", "NSIsMasterServerAuthenticated", "", "", SQ_IsMasterServerAuthenticated);
 	g_UISquirrelManager->AddFuncRegistration("void", "NSRequestServerList", "", "", SQ_RequestServerList);
@@ -445,6 +446,4 @@ void InitialiseScriptServerBrowser(HMODULE baseAddress)
 
 	g_UISquirrelManager->AddFuncRegistration("void", "NSTryAuthWithLocalServer", "", "", SQ_TryAuthWithLocalServer);
 	g_UISquirrelManager->AddFuncRegistration("void", "NSCompleteAuthWithLocalServer", "", "", SQ_CompleteAuthWithLocalServer);
-
-	g_UISquirrelManager->AddFuncRegistration("string", "NSGetAuthFailReason", "", "", SQ_GetAuthFailReason);
-}
+})

--- a/NorthstarDLL/scriptserverbrowser.h
+++ b/NorthstarDLL/scriptserverbrowser.h
@@ -1,4 +1,1 @@
 #pragma once
-#include <minwindef.h>
-
-void InitialiseScriptServerBrowser(HMODULE baseAddress);

--- a/NorthstarDLL/scriptservertoclientstringcommand.cpp
+++ b/NorthstarDLL/scriptservertoclientstringcommand.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "scriptservertoclientstringcommand.h"
 #include "squirrel.h"
 #include "convar.h"
@@ -14,11 +15,11 @@ void ConCommand_ns_script_servertoclientstringcommand(const CCommand& arg)
 	}
 }
 
-void InitialiseScriptServerToClientStringCommands(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ScriptServerToClientStringCommand, ClientSquirrel, (HMODULE baseAddress)
 {
 	RegisterConCommand(
 		"ns_script_servertoclientstringcommand",
 		ConCommand_ns_script_servertoclientstringcommand,
 		"",
 		FCVAR_CLIENTDLL | FCVAR_SERVER_CAN_EXECUTE);
-}
+})

--- a/NorthstarDLL/scriptservertoclientstringcommand.h
+++ b/NorthstarDLL/scriptservertoclientstringcommand.h
@@ -1,3 +1,1 @@
 #pragma once
-
-void InitialiseScriptServerToClientStringCommands(HMODULE baseAddress);

--- a/NorthstarDLL/serverauthentication.cpp
+++ b/NorthstarDLL/serverauthentication.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "serverauthentication.h"
+#include "hooks.h"
 #include "cvar.h"
 #include "convar.h"
 #include "hookutils.h"
@@ -654,7 +655,7 @@ void ResetPdataCommand(const CCommand& args)
 	g_ServerAuthenticationManager->m_bForceReadLocalPlayerPersistenceFromDisk = true;
 }
 
-void InitialiseServerAuthentication(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("engine.dll", ServerAuthentication, ConCommand, (HMODULE baseAddress)
 {
 	g_ServerAuthenticationManager = new ServerAuthenticationManager;
 
@@ -752,4 +753,4 @@ void InitialiseServerAuthentication(HMODULE baseAddress)
 
 		NSMem::NOP(addr + 10, 5);
 	}
-}
+})

--- a/NorthstarDLL/serverauthentication.h
+++ b/NorthstarDLL/serverauthentication.h
@@ -106,7 +106,5 @@ class ServerAuthenticationManager
 typedef void (*CBaseClient__DisconnectType)(void* self, uint32_t unknownButAlways1, const char* reason, ...);
 extern CBaseClient__DisconnectType CBaseClient__Disconnect;
 
-void InitialiseServerAuthentication(HMODULE baseAddress);
-
 extern ServerAuthenticationManager* g_ServerAuthenticationManager;
 extern ConVar* Cvar_ns_player_auth_port;

--- a/NorthstarDLL/serverchathooks.cpp
+++ b/NorthstarDLL/serverchathooks.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "serverchathooks.h"
+#include "hooks.h"
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
@@ -170,12 +171,12 @@ SQRESULT SQ_BroadcastMessage(void* sqvm)
 	return SQRESULT_NULL;
 }
 
-void InitialiseServerChatHooks_Engine(HMODULE baseAddress)
+ON_DLL_LOAD("engine.dll", EngineServerChatHooks, (HMODULE baseAddress)
 {
 	g_pServerGameDLL = (CServerGameDLL*)((char*)baseAddress + 0x13F0AA98);
-}
+})
 
-void InitialiseServerChatHooks_Server(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("server.dll", ServerChatHooks, ServerSquirrel, (HMODULE baseAddress)
 {
 	CServerGameDLL__OnReceivedSayTextMessage = (CServerGameDLL__OnReceivedSayTextMessageType)((char*)baseAddress + 0x1595C0);
 	UTIL_PlayerByIndex = (UTIL_PlayerByIndexType)((char*)baseAddress + 0x26AA10);
@@ -206,4 +207,4 @@ void InitialiseServerChatHooks_Server(HMODULE baseAddress)
 		"int fromPlayerIndex, int toPlayerIndex, string text, bool isTeam, bool isDead, int messageType",
 		"",
 		SQ_BroadcastMessage);
-}
+})

--- a/NorthstarDLL/serverchathooks.h
+++ b/NorthstarDLL/serverchathooks.h
@@ -23,7 +23,3 @@ void ChatSendMessage(unsigned int playerIndex, const char* text, bool isteam);
 //   messageType: send a specific message type
 void ChatBroadcastMessage(
 	int fromPlayerIndex, int toPlayerIndex, const char* text, bool isTeam, bool isDead, CustomMessageType messageType);
-
-void InitialiseServerChatHooks_Engine(HMODULE baseAddress);
-
-void InitialiseServerChatHooks_Server(HMODULE baseAddress);

--- a/NorthstarDLL/sourceconsole.cpp
+++ b/NorthstarDLL/sourceconsole.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "hooks.h"
 #include "convar.h"
 #include "sourceconsole.h"
 #include "sourceinterface.h"
@@ -47,11 +48,11 @@ void InitialiseConsoleOnInterfaceCreation()
 		reinterpret_cast<LPVOID*>(&onCommandSubmittedOriginal));
 }
 
-void InitialiseSourceConsole(HMODULE baseAddress)
+ON_DLL_LOAD_CLIENT_RELIESON("client.dll", SourceConsole, ConCommand, (HMODULE baseAddress)
 {
 	g_SourceGameConsole = new SourceInterface<CGameConsole>("client.dll", "GameConsole004");
 	RegisterConCommand("toggleconsole", ConCommand_toggleconsole, "toggles the console", FCVAR_DONTRECORD);
-}
+})
 
 // logging stuff
 

--- a/NorthstarDLL/sourceconsole.h
+++ b/NorthstarDLL/sourceconsole.h
@@ -102,5 +102,4 @@ class SourceConsoleSink : public spdlog::sinks::base_sink<std::mutex>
 	void flush_() override;
 };
 
-void InitialiseSourceConsole(HMODULE baseAddress);
 void InitialiseConsoleOnInterfaceCreation();

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -112,7 +112,7 @@ SQInteger NSTestFunc(void* sqvm)
 	return 1;
 }
 
-void InitialiseClientSquirrel(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("client.dll", ClientSquirrel, ConCommand, (HMODULE baseAddress)
 {
 	HookEnabler hook;
 
@@ -188,9 +188,9 @@ void InitialiseClientSquirrel(HMODULE baseAddress)
 		(char*)baseAddress + 0x108E0,
 		&RegisterSquirrelFuncHook<ScriptContext::CLIENT>,
 		reinterpret_cast<LPVOID*>(&ClientRegisterSquirrelFunc)); // client registersquirrelfunc function
-}
+})
 
-void InitialiseServerSquirrel(HMODULE baseAddress)
+ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, (HMODULE baseAddress)
 {
 	g_ServerSquirrelManager = new SquirrelManager<ScriptContext::SERVER>();
 
@@ -262,7 +262,7 @@ void InitialiseServerSquirrel(HMODULE baseAddress)
 		ExecuteCodeCommand<ScriptContext::SERVER>,
 		"Executes script code on the server vm",
 		FCVAR_GAMEDLL | FCVAR_CLIENTCMD_CAN_EXECUTE | FCVAR_CHEAT);
-}
+})
 
 // hooks
 template <ScriptContext context> SQInteger SQPrintHook(void* sqvm, char* fmt, ...)

--- a/NorthstarDLL/squirrel.h
+++ b/NorthstarDLL/squirrel.h
@@ -1,9 +1,6 @@
 #include <../modmanager.h>
 #pragma once
 
-void InitialiseClientSquirrel(HMODULE baseAddress);
-void InitialiseServerSquirrel(HMODULE baseAddress);
-
 // stolen from ttf2sdk: sqvm types
 typedef float SQFloat;
 typedef long SQInteger;


### PR DESCRIPTION
This adds the refactor of dll load callbacks from the big refactor PR.

I'm putting it as draft for now cause it only works to some degree atm.

In particular it seems to still use the old load system in some places and me having very little launcher experience, I'm struggling to figure out the exact cause of the issue.

In a nutshell, I wanna get the refactored dll load callbacks working and merged as it makes up a decent chunk of file change and if merged makes the diff between refactor and main a lot more readable ^^

So any help in getting DLL load callbacks added properly would be appreciated <3