### PR TITLE
Add clang-format ignores for AUTOHOOK

### DIFF
--- a/NorthstarDLL/audio.cpp
+++ b/NorthstarDLL/audio.cpp
@@ -372,8 +372,10 @@ bool __declspec(noinline) __fastcall LoadSampleMetadata_Internal(
 
 // DO NOT TOUCH THIS FUNCTION
 // The actual logic of it in a separate function (forcefully not inlined) to preserve the r12 register, which holds the event pointer.
+// clang-format off
 AUTOHOOK(LoadSampleMetadata, mileswin64.dll + 0xF110, 
 bool, __fastcall, (void* sample, void* audioBuffer, unsigned int audioBufferLength, int audioType))
+// clang-format on
 {
 	uintptr_t parentEvent = (uintptr_t)Audio_GetParentEvent();
 
@@ -488,8 +490,10 @@ bool __declspec(noinline) __fastcall LoadSampleMetadata_Internal(
 	return res;
 }
 
+// clang-format off
 AUTOHOOK(MilesLog, client.dll + 0x57DAD0, 
 void, __fastcall, (int level, const char* string))
+// clang-format on
 {
 	spdlog::info("[MSS] {} - {}", level, string);
 }

--- a/NorthstarDLL/buildainfile.cpp
+++ b/NorthstarDLL/buildainfile.cpp
@@ -361,16 +361,20 @@ void DumpAINInfo(CAI_Network* aiNetwork)
 	writeStream.close();
 }
 
+// clang-format off
 AUTOHOOK(CAI_NetworkBuilder__Build, server.dll + 0x385E20,
 void,, (void* builder, CAI_Network* aiNetwork, void* unknown))
+// clang-format on
 {
 	CAI_NetworkBuilder__Build(builder, aiNetwork, unknown);
 
 	DumpAINInfo(aiNetwork);
 }
 
+// clang-format off
 AUTOHOOK(LoadAINFile, server.dll + 0x3933A0,
 void,, (void* aimanager, void* buf, const char* filename))
+// clang-format on
 {
 	LoadAINFile(aimanager, buf, filename);
 

--- a/NorthstarDLL/clientauthhooks.cpp
+++ b/NorthstarDLL/clientauthhooks.cpp
@@ -12,8 +12,10 @@ const int NOT_DECIDED_TO_SEND_TOKEN = 0;
 const int AGREED_TO_SEND_TOKEN = 1;
 const int DISAGREED_TO_SEND_TOKEN = 2;
 
+// clang-format off
 AUTOHOOK(AuthWithStryder, engine.dll + 0x1843A0,
 void,, (void* a1))
+// clang-format on
 {
 	// game will call this forever, until it gets a valid auth key
 	// so, we need to manually invalidate our key until we're authed with northstar, then we'll allow game to auth with stryder

--- a/NorthstarDLL/clientchathooks.cpp
+++ b/NorthstarDLL/clientchathooks.cpp
@@ -7,8 +7,10 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK(CHudChat__AddGameLine, client.dll + 0x22E580, 
 void,, (void* self, const char* message, int inboxId, bool isTeam, bool isDead))
+// clang-format on
 {
 	// This hook is called for each HUD, but we only want our logic to run once.
 	if (self != *CHudChat::allHuds)

--- a/NorthstarDLL/clientruihooks.cpp
+++ b/NorthstarDLL/clientruihooks.cpp
@@ -5,8 +5,10 @@ AUTOHOOK_INIT()
 
 ConVar* Cvar_rui_drawEnable;
 
+// clang-format off
 AUTOHOOK(DrawRUIFunc, engine.dll + 0xFC500,
 bool,, (void* a1, float* a2))
+// clang-format on
 {
 	if (!Cvar_rui_drawEnable->GetBool())
 		return 0;

--- a/NorthstarDLL/clientvideooverrides.cpp
+++ b/NorthstarDLL/clientvideooverrides.cpp
@@ -3,8 +3,10 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK_PROCADDRESS(BinkOpen, bink2w64.dll, BinkOpen, 
 void*,, (const char* path, uint32_t flags))
+// clang-format on
 {
 	std::string filename(fs::path(path).filename().string());
 	spdlog::info("BinkOpen {}", filename);

--- a/NorthstarDLL/debugoverlay.cpp
+++ b/NorthstarDLL/debugoverlay.cpp
@@ -76,8 +76,10 @@ typedef void (*RenderBoxType)(Vector3 vOrigin, QAngle angles, Vector3 vMins, Vec
 static RenderBoxType RenderBox;
 static RenderBoxType RenderWireframeBox;
 
+// clang-format off
 AUTOHOOK(DrawOverlay, engine.dll + 0xABCB0, 
 void, __fastcall, (OverlayBase_t * pOverlay))
+// clang-format on
 {
 	EnterCriticalSection((LPCRITICAL_SECTION)((char*)sEngineModule + 0x10DB0A38)); // s_OverlayMutex
 

--- a/NorthstarDLL/dedicated.cpp
+++ b/NorthstarDLL/dedicated.cpp
@@ -114,7 +114,10 @@ DWORD WINAPI ConsoleInputThread(PVOID pThreadParameter)
 	return 0;
 }
 
-AUTOHOOK(IsGameActiveWindow, engine.dll + 0x1CDC80, bool, , ())
+// clang-format off
+AUTOHOOK(IsGameActiveWindow, engine.dll + 0x1CDC80,
+bool, , ())
+// clang-format on
 {
 	return true;
 }
@@ -262,8 +265,10 @@ ON_DLL_LOAD_DEDI("tier0.dll", DedicatedServerOrigin, (CModule module))
 	module.GetExport("Tier0_InitOrigin").Patch("C3");
 }
 
+// clang-format off
 AUTOHOOK(PrintSquirrelError, server.dll + 0x794D0, 
 void, , (void* sqvm))
+// clang-format on
 {
 	PrintSquirrelError(sqvm);
 

--- a/NorthstarDLL/dedicatedmaterialsystem.cpp
+++ b/NorthstarDLL/dedicatedmaterialsystem.cpp
@@ -4,6 +4,7 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK(D3D11CreateDevice, materialsystem_dx11.dll + 0xD9A0E,
 HRESULT, __stdcall, (
 	void* pAdapter,
@@ -16,6 +17,7 @@ HRESULT, __stdcall, (
 	void** ppDevice,
 	int* pFeatureLevel,
 	void** ppImmediateContext))
+// clang-format on
 {
 	// note: this is super duper temp pretty much just messing around with it
 	// does run surprisingly well on dedi for a software driver tho if you ignore the +1gb ram usage at times, seems like dedi doesn't

--- a/NorthstarDLL/exploitfixes.cpp
+++ b/NorthstarDLL/exploitfixes.cpp
@@ -29,27 +29,35 @@ ConVar* Cvar_sv_cheats;
 
 // block bad netmessages
 // Servers can literally request a screenshot from any client, yeah no
+// clang-format off
 AUTOHOOK(CLC_Screenshot_WriteToBuffer, engine.dll + 0x22AF20, 
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 57 48 83 EC 20 8B 42 10
+// clang-format on
 {
 	return false;
 }
 
+// clang-format off
 AUTOHOOK(CLC_Screenshot_ReadFromBuffer, engine.dll + 0x221F00, 
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B DA 48 8B 52 38
+// clang-format on
 {
 	return false;
 }
 
 // This is unused ingame and a big client=>server=>client exploit vector
+// clang-format off
 AUTOHOOK(Base_CmdKeyValues_ReadFromBuffer, engine.dll + 0x220040,
 bool, __fastcall, (void* thisptr, void* buffer)) // 40 55 48 81 EC ? ? ? ? 48 8D 6C 24 ? 48 89 5D 70
+// clang-format on
 {
 	return false;
 }
 
+// clang-format off
 AUTOHOOK(CClient_ProcessSetConVar, engine.dll + 0x75CF0,
 bool, __fastcall, (void* pMsg)) // 48 8B D1 48 8B 49 18 48 8B 01 48 FF 60 10
+// clang-format on
 {
 
 	constexpr int ENTRY_STR_LEN = 260;
@@ -147,8 +155,10 @@ bool, __fastcall, (void* pMsg)) // 48 8B D1 48 8B 49 18 48 8B 01 48 FF 60 10
 }
 
 // prevent invalid user CMDs
+// clang-format off
 AUTOHOOK(CClient_ProcessUsercmds, engine.dll + 0x1040F0,
 bool, __fastcall, (void* thisptr, void* pMsg)) // 40 55 56 48 83 EC 58
+// clang-format on
 {
 	struct CLC_Move
 	{
@@ -181,8 +191,10 @@ bool, __fastcall, (void* thisptr, void* pMsg)) // 40 55 56 48 83 EC 58
 	return CClient_ProcessUsercmds(thisptr, pMsg);
 }
 
+// clang-format off
 AUTOHOOK(ReadUsercmd, server.dll + 0x2603F0,
 void, __fastcall, (void* buf, void* pCmd_move, void* pCmd_from)) // 4C 89 44 24 ? 53 55 56 57
+// clang-format on
 {
 	// Let normal usercmd read happen first, it's safe
 	ReadUsercmd(buf, pCmd_move, pCmd_from);
@@ -256,8 +268,10 @@ INVALID_CMD:
 
 // ensure that GetLocalBaseClient().m_bRestrictServerCommands is set correctly, which the return value of this function controls
 // this is IsValveMod in source, but we're making it IsRespawnMod now since valve didn't make this one
+// clang-format off
 AUTOHOOK(IsRespawnMod, engine.dll + 0x1C6360,
 bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 15 ? ? ? ? E8 ? ? ? ? 85 C0 74 63
+// clang-format on
 {
 	// somewhat temp, store the modname here, since we don't have a proper ptr in engine to it rn
 	int iSize = strlen(pModName);
@@ -270,8 +284,10 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 
 // ratelimit stringcmds, and prevent remote clients from calling commands that they shouldn't
 bool (*CCommand__Tokenize)(CCommand& self, const char* pCommandString, R2::cmd_source_t commandSource);
+// clang-format off
 AUTOHOOK(CGameClient__ExecuteStringCommand, 
 engine.dll + 0x1022E0, bool, , (R2::CBaseClient* self, uint32_t unknown, const char* pCommandString))
+// clang-format on
 {
 	if (Cvar_ns_should_log_all_clientcommands->GetBool())
 		spdlog::info("player {} (UID: {}) sent command: \"{}\"", self->m_Name, self->m_UID, pCommandString);
@@ -341,8 +357,10 @@ engine.dll + 0x1022E0, bool, , (R2::CBaseClient* self, uint32_t unknown, const c
 
 // prevent clients from crashing servers through overflowing CNetworkStringTableContainer::WriteBaselines
 bool bWasWritingStringTableSuccessful;
+// clang-format off
 AUTOHOOK(CBaseClient__SendServerInfo, 
 engine.dll + 0x104FB0, void, , (void* self))
+// clang-format on
 {
 	bWasWritingStringTableSuccessful = true;
 	CBaseClient__SendServerInfo(self);
@@ -353,8 +371,10 @@ engine.dll + 0x104FB0, void, , (void* self))
 
 // return null when GetEntByIndex is passed an index >= 0x4000
 // this is called from exactly 1 script clientcommand that can be given an arbitrary index, and going above 0x4000 crashes
+// clang-format off
 AUTOHOOK(GetEntByIndex, engine.dll + 0x2A8A50,
 void*,, (int i))
+// clang-format on
 {
 	const int MAX_ENT_IDX = 0x4000;
 

--- a/NorthstarDLL/exploitfixes_lzss.cpp
+++ b/NorthstarDLL/exploitfixes_lzss.cpp
@@ -12,8 +12,10 @@ struct lzss_header_t
 
 // Rewrite of CLZSS::SafeUncompress to fix a vulnerability where malicious compressed payloads could cause the decompressor to try to read
 // out of the bounds of the output buffer.
+// clang-format off
 AUTOHOOK(CLZSS__SafeDecompress, engine.dll + 0x432A10,
 unsigned int,, (void* self, const unsigned char* pInput, unsigned char* pOutput, unsigned int unBufSize))
+// clang-format on
 {
 	unsigned int totalBytes = 0;
 	int getCmdByte = 0;

--- a/NorthstarDLL/exploitfixes_utf8parser.cpp
+++ b/NorthstarDLL/exploitfixes_utf8parser.cpp
@@ -170,8 +170,10 @@ LABEL_48:
 }
 
 // prevent utf8 parser from crashing when provided bad data, which can be sent through user-controlled openinvites 
+// clang-format off
 AUTOHOOK(Rson_ParseUTF8, engine.dll + 0xEF670, 
 bool, __fastcall, (INT64* a1, DWORD* a2, char* strData)) // 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 41 54 41 55 41 56 41 57 48 83 EC 20 8B 1A
+// clang-format on
 {
 	static void* targetRetAddr = CModule("engine.dll").FindPattern("84 C0 75 2C 49 8B 16");
 

--- a/NorthstarDLL/filesystem.cpp
+++ b/NorthstarDLL/filesystem.cpp
@@ -114,8 +114,10 @@ bool,, (IFileSystem* filesystem, char* pPath, void* result))
 }
 
 // force modded files to be read from mods, not vpk
+// clang-format off
 AUTOHOOK(ReadFileFromVPK, filesystem_stdio.dll + 0x5CBA0,
 FileHandle_t,, (VPKData* vpkInfo, uint64_t* b, char* filename))
+// clang-format on
 {
 	// don't compile here because this is only ever called from OpenEx, which already compiles
 	if (TryReplaceFile(filename, false))
@@ -127,8 +129,10 @@ FileHandle_t,, (VPKData* vpkInfo, uint64_t* b, char* filename))
 	return ReadFileFromVPK(vpkInfo, b, filename);
 }
 
+// clang-format off
 AUTOHOOK(CBaseFileSystem__OpenEx, filesystem_stdio.dll + 0x15F50,
 FileHandle_t,, (IFileSystem* filesystem, const char* pPath, const char* pOptions, uint32_t flags, const char* pPathID, char **ppszResolvedFilename))
+// clang-format on
 {
 	TryReplaceFile(pPath, true);
 	return CBaseFileSystem__OpenEx(filesystem, pPath, pOptions, flags, pPathID, ppszResolvedFilename);

--- a/NorthstarDLL/hooks.cpp
+++ b/NorthstarDLL/hooks.cpp
@@ -182,8 +182,10 @@ void MakeHook(LPVOID pTarget, LPVOID pDetour, void* ppOriginal, const char* pFun
 		spdlog::error("MH_CreateHook failed for function {}", pStrippedFuncName);
 }
 
+// clang-format off
 AUTOHOOK_ABSOLUTEADDR(_GetCommandLineA, GetCommandLineA,
 LPSTR, WINAPI, ())
+// clang-format on
 {
 	static char* cmdlineModified;
 	static char* cmdlineOrg;
@@ -352,8 +354,10 @@ void CallAllPendingDLLLoadCallbacks()
 	}
 }
 
+// clang-format off
 AUTOHOOK_ABSOLUTEADDR(_LoadLibraryExA, LoadLibraryExA, 
 HMODULE, WINAPI, (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
+// clang-format on
 	{
 	HMODULE moduleAddress = _LoadLibraryExA(lpLibFileName, hFile, dwFlags);
 
@@ -364,8 +368,10 @@ HMODULE, WINAPI, (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
 }
 
 
+// clang-format off
 AUTOHOOK_ABSOLUTEADDR(_LoadLibraryA, LoadLibraryA, 
 HMODULE, WINAPI, (LPCSTR lpLibFileName))
+// clang-format on
 {
 	HMODULE moduleAddress = _LoadLibraryA(lpLibFileName);
 
@@ -375,8 +381,10 @@ HMODULE, WINAPI, (LPCSTR lpLibFileName))
 	return moduleAddress;
 }
 
+// clang-format off
 AUTOHOOK_ABSOLUTEADDR(_LoadLibraryExW, LoadLibraryExW, 
 HMODULE, WINAPI, (LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
+// clang-format on
 {
 	HMODULE moduleAddress = _LoadLibraryExW(lpLibFileName, hFile, dwFlags);
 
@@ -386,8 +394,10 @@ HMODULE, WINAPI, (LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
 	return moduleAddress;
 }
 
+// clang-format off
 AUTOHOOK_ABSOLUTEADDR(_LoadLibraryW, LoadLibraryW, 
 HMODULE, WINAPI, (LPCWSTR lpLibFileName))
+// clang-format on
 {
 	HMODULE moduleAddress = _LoadLibraryW(lpLibFileName);
 

--- a/NorthstarDLL/host.cpp
+++ b/NorthstarDLL/host.cpp
@@ -7,8 +7,10 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK(Host_Init, engine.dll + 0x155EA0,
 void,, (bool bDedicated))
+// clang-format on
 {
 	spdlog::info("Host_Init()");
 	Host_Init(bDedicated);

--- a/NorthstarDLL/hoststate.cpp
+++ b/NorthstarDLL/hoststate.cpp
@@ -27,8 +27,10 @@ void ServerStartingOrChangingMap()
 		g_pCVar->FindVar("net_data_block_enabled")->SetValue(true);
 }
 
+// clang-format off
 AUTOHOOK(CHostState__State_NewGame, engine.dll + 0x16E7D0,
 void,, (CHostState* self))
+// clang-format on
 {
 	spdlog::info("HostState: NewGame");
 
@@ -58,8 +60,10 @@ void,, (CHostState* self))
 	g_pServerAuthentication->m_bNeedLocalAuthForNewgame = false;
 }
 
+// clang-format off
 AUTOHOOK(CHostState__State_ChangeLevelMP, engine.dll + 0x16E520,
 void,, (CHostState* self))
+// clang-format on
 {
 	spdlog::info("HostState: ChangeLevelMP");
 
@@ -72,8 +76,10 @@ void,, (CHostState* self))
 	g_pServerPresence->SetMap(g_pHostState->m_levelName);
 }
 
+// clang-format off
 AUTOHOOK(CHostState__State_GameShutdown, engine.dll + 0x16E640,
 void,, (CHostState* self))
+// clang-format on
 {
 	spdlog::info("HostState: GameShutdown");
 
@@ -83,8 +89,10 @@ void,, (CHostState* self))
 	CHostState__State_GameShutdown(self);
 }
 
+// clang-format off
 AUTOHOOK(CHostState__FrameUpdate, engine.dll + 0x16DB00,
 void, __fastcall, (CHostState* self, double flCurrentTime, float flFrameTime))
+// clang-format on
 {
 	CHostState__FrameUpdate(self, flCurrentTime, flFrameTime);
 

--- a/NorthstarDLL/keyvalues.cpp
+++ b/NorthstarDLL/keyvalues.cpp
@@ -106,8 +106,10 @@ void ModManager::TryBuildKeyValues(const char* filename)
 		m_ModFiles[normalisedPath] = overrideFile;
 }
 
+// clang-format off
 AUTOHOOK(KeyValues__LoadFromBuffer, engine.dll + 0x426C30,
 char,, (void* self, const char* resourceName, const char* pBuffer, void* pFileSystem, void* a5, void* a6, int a7))
+// clang-format on
 {
 	static void* pSavedFilesystemPtr = nullptr;
 

--- a/NorthstarDLL/languagehooks.cpp
+++ b/NorthstarDLL/languagehooks.cpp
@@ -47,8 +47,10 @@ std::string GetAnyInstalledAudioLanguage()
 	return "NO LANGUAGE DETECTED";
 }
 
+// clang-format off
 AUTOHOOK(GetGameLanguage, tier0.dll + 0xF560,
 char*,, ())
+// clang-format on
 {
 	auto tier0Handle = GetModuleHandleA("tier0.dll");
 	auto Tier0_DetectDefaultLanguageType = GetProcAddress(tier0Handle, "Tier0_DetectDefaultLanguage");

--- a/NorthstarDLL/latencyflex.cpp
+++ b/NorthstarDLL/latencyflex.cpp
@@ -7,8 +7,10 @@ ConVar* Cvar_r_latencyflex;
 
 void (*m_winelfx_WaitAndBeginFrame)();
 
+// clang-format off
 AUTOHOOK(OnRenderStart, client.dll + 0x1952C0, 
 void,, ())
+// clang-format on
 {
 	if (Cvar_r_latencyflex->GetBool() && m_winelfx_WaitAndBeginFrame)
 		m_winelfx_WaitAndBeginFrame();

--- a/NorthstarDLL/limits.cpp
+++ b/NorthstarDLL/limits.cpp
@@ -57,8 +57,10 @@ bool ServerLimitsManager::CheckChatLimits(R2::CBaseClient* player)
 	return true;
 }
 
+// clang-format off
 AUTOHOOK(CNetChan__ProcessMessages, engine.dll + 0x2140A0, 
 char, __fastcall, (void* self, void* buf))
+// clang-format on
 {
 	enum eNetChanLimitMode
 	{
@@ -112,8 +114,10 @@ char, __fastcall, (void* self, void* buf))
 	return ret;
 }
 
+// clang-format off
 AUTOHOOK(ProcessConnectionlessPacket, engine.dll + 0x117800, 
 bool, , (void* a1, R2::netpacket_t* packet))
+// clang-format on
 {
 	if (packet->adr.type == R2::NA_IP &&
 		(!(packet->data[4] == 'N' && Cvar_net_datablock_enabled->GetBool()) || !Cvar_net_datablock_enabled->GetBool()))

--- a/NorthstarDLL/logging.cpp
+++ b/NorthstarDLL/logging.cpp
@@ -34,8 +34,10 @@ const std::unordered_map<SpewType_t, const char*> PrintSpewTypes = {
 	{SpewType_t::SPEW_LOG, "SPEW_LOG"}
 };
 
+// clang-format off
 AUTOHOOK(EngineSpewFunc, engine.dll + 0x11CA80,
 void,, (void* pEngineServer, SpewType_t type, const char* format, va_list args))
+// clang-format on
 {
 	if (!Cvar_spewlog_enable->GetBool())
 		return;
@@ -109,8 +111,10 @@ void,, (void* pEngineServer, SpewType_t type, const char* format, va_list args))
 }
 
 // used for printing the output of status
+// clang-format off
 AUTOHOOK(Status_ConMsg, engine.dll + 0x15ABD0,
 void,, (const char* text, ...))
+// clang-format on
 {
 	char formatted[2048];
 	va_list list;
@@ -126,8 +130,10 @@ void,, (const char* text, ...))
 	spdlog::info(formatted);
 }
 
+// clang-format off
 AUTOHOOK(CClientState_ProcessPrint, engine.dll + 0x1A1530, 
 bool,, (void* thisptr, uintptr_t msg))
+// clang-format on
 {
 	char* text = *(char**)(msg + 0x20);
 
@@ -163,8 +169,10 @@ enum class TextMsgPrintType_t
 	HUD_PRINTCENTER
 };
 
+// clang-format off
 AUTOHOOK(TextMsg, client.dll + 0x198710,
 void,, (BFRead* msg))
+// clang-format on
 {
 	TextMsgPrintType_t msg_dest = (TextMsgPrintType_t)msg->ReadByte();
 
@@ -194,8 +202,10 @@ void,, (BFRead* msg))
 	}
 }
 
+// clang-format off
 AUTOHOOK(ConCommand_echo, engine.dll + 0x123680,
 void,, (const CCommand& arg))
+// clang-format on
 {
 	if (arg.ArgC() >= 2)
 		spdlog::info("[echo] {}", arg.ArgS());

--- a/NorthstarDLL/maxplayers.cpp
+++ b/NorthstarDLL/maxplayers.cpp
@@ -70,8 +70,10 @@ template <class T> void ChangeOffset(MemoryAddress addr, unsigned int offset)
 	addr.Patch((BYTE*)&offset, sizeof(T));
 }
 
+// clang-format off
 AUTOHOOK(StringTables_CreateStringTable, engine.dll + 0x22E220,
 void*,, (void* thisptr, const char* name, int maxentries, int userdatafixedsize, int userdatanetworkbits, int flags))
+// clang-format on
 {
 	// Change the amount of entries to account for a bigger player amount
 	if (!strcmp(name, "userinfo"))
@@ -135,8 +137,10 @@ HMODULE serverBase = 0;
 auto RandomIntZeroMax = (__int64(__fastcall*)())0;
 
 // lazy rebuild
+// clang-format off
 AUTOHOOK(RunUserCmds, server.dll + 0x483D10,
 void,, (bool a1, float a2))
+// clang-format on
 {
 	unsigned char v3; // bl
 	int v5; // er14
@@ -277,8 +281,10 @@ void,, (bool a1, float a2))
 	}
 }
 
+// clang-format off
 AUTOHOOK(SendPropArray2, server.dll + 0x12B130,
 __int64, __fastcall, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn, unsigned char unk1))
+// clang-format on
 {
 	// Change the amount of elements to account for a bigger player amount
 	if (!strcmp(name, "\"player_array\""))
@@ -446,8 +452,10 @@ ON_DLL_LOAD("server.dll", MaxPlayersOverride_Server, (CModule module))
 	DT_Team_Construct();
 }
 
+// clang-format off
 AUTOHOOK(RecvPropArray2, client.dll + 0x1CEDA0,
 __int64, __fastcall, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn))
+// clang-format on
 {
 	// Change the amount of elements to account for a bigger player amount
 	if (!strcmp(name, "\"player_array\""))

--- a/NorthstarDLL/modlocalisation.cpp
+++ b/NorthstarDLL/modlocalisation.cpp
@@ -3,8 +3,10 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK(AddLocalisationFile, localize.dll + 0x6D80,
 bool,, (void* pVguiLocalize, const char* path, const char* pathId, char unknown))
+// clang-format on
 {
 	static bool bLoadModLocalisationFiles = true;
 	bool ret = AddLocalisationFile(pVguiLocalize, path, pathId, unknown);

--- a/NorthstarDLL/playlist.cpp
+++ b/NorthstarDLL/playlist.cpp
@@ -19,8 +19,10 @@ namespace R2
 
 ConVar* Cvar_ns_use_clc_SetPlaylistVarOverride;
 
+// clang-format off
 AUTOHOOK(clc_SetPlaylistVarOverride__Process, engine.dll + 0x222180,
 char,, (void* a1, void* a2))
+// clang-format on
 {
 	// the private_match playlist on mp_lobby is the only situation where there should be any legitimate sending of this netmessage
 	if (!Cvar_ns_use_clc_SetPlaylistVarOverride->GetBool() || strcmp(R2::GetCurrentPlaylistName(), "private_match") || strcmp(R2::g_pHostState->m_levelName, "mp_lobby"))
@@ -29,8 +31,10 @@ char,, (void* a1, void* a2))
 	return clc_SetPlaylistVarOverride__Process(a1, a2);
 }
 
+// clang-format off
 AUTOHOOK(SetCurrentPlaylist, engine.dll + 0x18EB20,
 bool, __fastcall, (const char* pPlaylistName))
+// clang-format on
 {
 	bool bSuccess = SetCurrentPlaylist(pPlaylistName);
 
@@ -43,8 +47,10 @@ bool, __fastcall, (const char* pPlaylistName))
 	return bSuccess;
 }
 
+// clang-format off
 AUTOHOOK(SetPlaylistVarOverride, engine.dll + 0x18ED00,
 void,, (const char* pVarName, const char* pValue))
+// clang-format on
 {
 	if (strlen(pValue) >= 64)
 		return;
@@ -52,8 +58,10 @@ void,, (const char* pVarName, const char* pValue))
 	SetPlaylistVarOverride(pVarName, pValue);
 }
 
+// clang-format off
 AUTOHOOK(GetCurrentPlaylistVar, engine.dll + 0x18C680,
 const char*,, (const char* pVarName, bool bUseOverrides))
+// clang-format on
 {
 	if (!bUseOverrides && !strcmp(pVarName, "max_players"))
 		bUseOverrides = true;
@@ -61,8 +69,10 @@ const char*,, (const char* pVarName, bool bUseOverrides))
 	return GetCurrentPlaylistVar(pVarName, bUseOverrides);
 }
 
+// clang-format off
 AUTOHOOK(GetCurrentGamemodeMaxPlayers, engine.dll + 0x18C430,
 int,, ())
+// clang-format on
 {
 	const char* pMaxPlayers = R2::GetCurrentPlaylistVar("max_players", 0);
 	if (!pMaxPlayers)

--- a/NorthstarDLL/printmaps.cpp
+++ b/NorthstarDLL/printmaps.cpp
@@ -110,8 +110,10 @@ void RefreshMapList()
 	}
 }
 
+// clang-format off
 AUTOHOOK(_Host_Map_f_CompletionFunc, engine.dll + 0x161AE0,
 int, __fastcall, (const char const* cmdname, const char const* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]))
+// clang-format on
 {
 	// don't update our map list often from this func, only refresh every 10 seconds so we avoid constantly reading fs
 	static double flLastAutocompleteRefresh = -999;

--- a/NorthstarDLL/runframe.cpp
+++ b/NorthstarDLL/runframe.cpp
@@ -6,8 +6,10 @@
 
 AUTOHOOK_INIT()
 
+// clang-format off
 AUTOHOOK(CEngine__Frame, engine.dll + 0x1C8650,
 void, __fastcall, (R2::CEngine* self))
+// clang-format on
 {
 	CEngine__Frame(self);
 }

--- a/NorthstarDLL/scriptbrowserhooks.cpp
+++ b/NorthstarDLL/scriptbrowserhooks.cpp
@@ -4,8 +4,10 @@ AUTOHOOK_INIT()
 
 bool* bIsOriginOverlayEnabled;
 
+// clang-format off
 AUTOHOOK(OpenExternalWebBrowser, engine.dll + 0x184E40, 
 void,, (char* pUrl, char flags))
+// clang-format on
 {
 	bool bIsOriginOverlayEnabledOriginal = *bIsOriginOverlayEnabled;
 		if (flags & 2 && !strncmp(pUrl, "http", 4)) // custom force external browser flag

--- a/NorthstarDLL/serverauthentication.cpp
+++ b/NorthstarDLL/serverauthentication.cpp
@@ -237,8 +237,10 @@ void ServerAuthenticationManager::WritePersistentData(R2::CBaseClient* player)
 char* pNextPlayerToken;
 uint64_t iNextPlayerUid;
 
+// clang-format off
 AUTOHOOK(CBaseServer__ConnectClient, engine.dll + 0x114430,
 void*,, (
+// clang-format on
 	void* server,
 	void* a2,
 	void* a3,
@@ -264,8 +266,10 @@ void*,, (
 	return CBaseServer__ConnectClient(server, a2, a3, a4, a5, a6, a7, a8, serverFilter, a10, a11, a12, a13, a14, uid, a16, a17);
 }
 
+// clang-format off
 AUTOHOOK(CBaseClient__Connect, engine.dll + 0x101740,
 bool,, (R2::CBaseClient* self, char* name, void* netchan_ptr_arg, char b_fake_player_arg, void* a5, char* Buffer, void* a7))
+// clang-format on
 {
 	// try changing name before all else
 	g_pServerAuthentication->VerifyPlayerName(self, pNextPlayerToken, name);
@@ -294,8 +298,10 @@ bool,, (R2::CBaseClient* self, char* name, void* netchan_ptr_arg, char b_fake_pl
 	return ret;
 }
 
+// clang-format off
 AUTOHOOK(CBaseClient__ActivatePlayer, engine.dll + 0x100F80,
 void,, (R2::CBaseClient* self))
+// clang-format on
 {
 	// if we're authed, write our persistent data
 	// RemovePlayerAuthData returns true if it removed successfully, i.e. on first call only, and we only want to write on >= second call
@@ -310,8 +316,10 @@ void,, (R2::CBaseClient* self))
 	CBaseClient__ActivatePlayer(self);
 }
 
+// clang-format off
 AUTOHOOK(_CBaseClient__Disconnect, engine.dll + 0x1012C0,
 void,, (R2::CBaseClient* self, uint32_t unknownButAlways1, const char* pReason, ...))
+// clang-format on
 {
 	// have to manually format message because can't pass varargs to original func
 	char buf[1024];

--- a/NorthstarDLL/serverchathooks.cpp
+++ b/NorthstarDLL/serverchathooks.cpp
@@ -36,8 +36,10 @@ void(__fastcall* MessageWriteBool)(bool bValue);
 
 bool bShouldCallSayTextHook = false;
 
+// clang-format off
 AUTOHOOK(_CServerGameDLL__OnReceivedSayTextMessage, server.dll + 0x1595C0,
 void,, (CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam))
+// clang-format on
 {
 	// MiniHook doesn't allow calling the base function outside of anywhere but the hook function.
 	// To allow bypassing the hook, isSkippingHook can be set.

--- a/NorthstarDLL/sourceinterface.cpp
+++ b/NorthstarDLL/sourceinterface.cpp
@@ -6,8 +6,10 @@ AUTOHOOK_INIT()
 
 // really wanted to do a modular callback system here but honestly couldn't be bothered so hardcoding stuff for now: todo later
 
+// clang-format off
 AUTOHOOK_PROCADDRESS(ClientCreateInterface, client.dll, CreateInterface, 
 void*,, (const char* pName, const int* pReturnCode))
+// clang-format on
 {
 	void* ret = ClientCreateInterface(pName, pReturnCode);
 	spdlog::info("CreateInterface CLIENT {}", pName);
@@ -18,8 +20,10 @@ void*,, (const char* pName, const int* pReturnCode))
 	return ret;
 }
 
+// clang-format off
 AUTOHOOK_PROCADDRESS(ServerCreateInterface, server.dll, CreateInterface, 
 void*,, (const char* pName, const int* pReturnCode))
+// clang-format on
 {
 	void* ret = ServerCreateInterface(pName, pReturnCode);
 		spdlog::info("CreateInterface SERVER {}", pName);
@@ -27,8 +31,10 @@ void*,, (const char* pName, const int* pReturnCode))
 	return ret;
 }
 
+// clang-format off
 AUTOHOOK_PROCADDRESS(EngineCreateInterface, engine.dll, CreateInterface, 
 void*,, (const char* pName, const int* pReturnCode))
+// clang-format on
 {
 	void* ret = EngineCreateInterface(pName, pReturnCode);
 		spdlog::info("CreateInterface ENGINE {}", pName);


### PR DESCRIPTION
The proper solution would be to have some way in clang-format config file that specifies that our `AUTOHOOK` formatting should be considered correct but that takes more investigation and simply ignoring formatting in AUTOHOOK macros is the lower hanging fruit.
