### PR TITLE
Fix LSX error for good

### DIFF
--- a/NorthstarDLL/logging.cpp
+++ b/NorthstarDLL/logging.cpp
@@ -19,14 +19,23 @@ void CreateLogFiles()
 	}
 	else
 	{
-		// todo: might be good to delete logs that are too old
-		time_t time = std::time(nullptr);
-		tm currentTime = *std::localtime(&time);
-		std::stringstream stream;
+		try
+		{
+			// todo: might be good to delete logs that are too old
+			time_t time = std::time(nullptr);
+			tm currentTime = *std::localtime(&time);
+			std::stringstream stream;
 
-		stream << std::put_time(&currentTime, (GetNorthstarPrefix() + "/logs/nslog%Y-%m-%d %H-%M-%S.txt").c_str());
-		spdlog::default_logger()->sinks().push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(stream.str(), false));
-		spdlog::flush_on(spdlog::level::info);
+			stream << std::put_time(&currentTime, (GetNorthstarPrefix() + "/logs/nslog%Y-%m-%d %H-%M-%S.txt").c_str());
+			spdlog::default_logger()->sinks().push_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(stream.str(), false));
+			spdlog::flush_on(spdlog::level::info);
+		}
+		catch (...)
+		{
+			spdlog::error("Failed creating log file");
+			MessageBoxA(
+				0, "Failed creating log file! Make sure the profile directory is writable.", "Northstar Warning", MB_ICONWARNING | MB_OK);
+		}
 	}
 }
 

--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -334,6 +334,8 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 
+	SetCurrentDirectoryW(exePath);
+
 	bool noOriginStartup = false;
 	bool dedicated = false;
 	bool nostubs = false;
@@ -352,6 +354,11 @@ int main(int argc, char* argv[])
 	{
 		EnsureOriginStarted();
 	}
+
+	// ensure no LSX error
+	GetEnvironmentVariableA("EAConnectionId", nullptr, 0);
+	if (GetLastError() == ERROR_ENVVAR_NOT_FOUND)
+		(void)_putenv("EAConnectionId=Origin.OFR.50.0001452");
 
 	if (dedicated && !nostubs)
 	{

--- a/loader_launcher_proxy/dllmain.cpp
+++ b/loader_launcher_proxy/dllmain.cpp
@@ -128,6 +128,8 @@ extern "C" __declspec(dllexport) int LauncherMain(HINSTANCE hInstance, HINSTANCE
 			return 1;
 		}
 
+		SetCurrentDirectoryW(exePath);
+
 		bool loadNorthstar = ShouldLoadNorthstar();
 
 		if (loadNorthstar)

--- a/loader_wsock32_proxy/dllmain.cpp
+++ b/loader_wsock32_proxy/dllmain.cpp
@@ -39,6 +39,8 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 			return true;
 		}
 
+		SetCurrentDirectoryW(exePath);
+
 		if (!ProvisionNorthstar()) // does not call InitialiseNorthstar yet, will do it on LauncherMain hook
 			return true;
 


### PR DESCRIPTION
* fixes LSX error for good by adding `EAConnectionId` environment variable if it's missing, I confirmed this alone is enough to mitigate the LSX error, as I was lucky enough to have it occur 100% of the time when using NorthstarLauncher.exe :)
  * this method of checking environment variable existence is attested by Microsoft Docs, arguments to GetEnvironmentVariableA are nullptr and 0 as we aren't interested in the old value, these arguments are optional and thus can be set to these values
  * I didn't use `getenv` as the compiler would mutilate me for using "unsafe" function, and `getenv_s` requires taking output, so the method above is better
  * `(void)` cast is used on `_putenv` to explicitly discard the return value and avoid compiler warning
  * wsock and launcher proxy don't set this, as they're expected to be used with executable that's ran from within Origin and has always the environment variable pre-set, this only applies to NorthstarLauncher.exe
  * the actual value of `EAConnectionId` interestingly seems irrelevant, I could enter some random text in it and it would still mitigate the LSX error, it appears it just needs to exist and not be empty
* ~~set current working directory to the exe path -- this is normally expected to be set to that, but under certain circumstances where you create a shortcut to NorthstarLauncher.exe or otherwise use non-direct method of launching it (3rd party game launchers etc), the working directory might have been wrong, causing issues like the log file being attempted to be written in another location, due to use of relative paths~~ --> moved to #275 
* ~~catch an error when log file cannot be created instead of silently crashing, which can happen if the path isn't writable and confuse the user (after the MessageBox is shown, the game will continue launching, as non-writable log file isn't a fatal issue)~~  --> moved to #274

After merging can consider https://github.com/R2Northstar/Northstar/issues/220 obsolete. Of course I tested all these changes and they behave as expected.