### PR TITLE
Set current directory properly

### DIFF
--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -334,6 +334,8 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 
+	SetCurrentDirectoryW(exePath);
+
 	bool noOriginStartup = false;
 	bool dedicated = false;
 	bool nostubs = false;

--- a/loader_launcher_proxy/dllmain.cpp
+++ b/loader_launcher_proxy/dllmain.cpp
@@ -128,6 +128,8 @@ extern "C" __declspec(dllexport) int LauncherMain(HINSTANCE hInstance, HINSTANCE
 			return 1;
 		}
 
+		SetCurrentDirectoryW(exePath);
+
 		bool loadNorthstar = ShouldLoadNorthstar();
 
 		if (loadNorthstar)

--- a/loader_wsock32_proxy/dllmain.cpp
+++ b/loader_wsock32_proxy/dllmain.cpp
@@ -39,6 +39,8 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 			return true;
 		}
 
+		SetCurrentDirectoryW(exePath);
+
 		if (!ProvisionNorthstar()) // does not call InitialiseNorthstar yet, will do it on LauncherMain hook
 			return true;
 


### PR DESCRIPTION
set current working directory to the exe path -- this is normally expected to be set to that, but under certain circumstances where you create a shortcut to NorthstarLauncher.exe or otherwise use non-direct method of launching it (3rd party game launchers etc), the working directory might have been wrong, causing issues like the log file being attempted to be written in another location, due to use of relative paths

[ separated from #272 ]