### PR TITLE
Add Named Pipe Client with Squirrle Integration

### DIFF
--- a/NorthstarDLL/NorthstarDLL.vcxproj
+++ b/NorthstarDLL/NorthstarDLL.vcxproj
@@ -118,6 +118,7 @@
     <ClInclude Include="clientruihooks.h" />
     <ClInclude Include="clientvideooverrides.h" />
     <ClInclude Include="localchatwriter.h" />
+    <ClInclude Include="namedpipeclient.h" />
     <ClInclude Include="ns_version.h" />
     <ClInclude Include="plugins.h" />
     <ClInclude Include="plugin_abi.h" />
@@ -580,6 +581,7 @@
     <ClCompile Include="clientruihooks.cpp" />
     <ClCompile Include="clientvideooverrides.cpp" />
     <ClCompile Include="concommand.cpp" />
+    <ClCompile Include="namedpipeclient.cpp" />
     <ClCompile Include="nsprefix.cpp" />
     <ClCompile Include="context.cpp" />
     <ClCompile Include="convar.cpp" />

--- a/NorthstarDLL/NorthstarDLL.vcxproj.filters
+++ b/NorthstarDLL/NorthstarDLL.vcxproj.filters
@@ -1521,6 +1521,9 @@
     <ClInclude Include="scriptjson.h">
       <Filter>Header Files\Shared</Filter>
     </ClInclude>
+    <ClInclude Include="namedpipeclient.h">
+      <Filter>Header Files\Server</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -35,6 +35,7 @@
 #include "nsprefix.h"
 #include "serverchathooks.h"
 #include "clientchathooks.h"
+#include "namedpipeclient.h"
 #include "localchatwriter.h"
 #include "scriptservertoclientstringcommand.h"
 #include "plugin_abi.h"
@@ -287,6 +288,9 @@ bool InitialiseNorthstar()
 	AddDllLoadCallback("engine.dll", InitialiseMaxPlayersOverride_Engine);
 	AddDllLoadCallback("client.dll", InitialiseMaxPlayersOverride_Client);
 	AddDllLoadCallback("server.dll", InitialiseMaxPlayersOverride_Server);
+
+	//Initialise Named Pipe
+	AddDllLoadCallback("server.dll", InitialiseNamedPipeClient);
 
 	// mod manager after everything else
 	AddDllLoadCallback("engine.dll", InitialiseModManager);

--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -289,7 +289,7 @@ bool InitialiseNorthstar()
 	AddDllLoadCallback("client.dll", InitialiseMaxPlayersOverride_Client);
 	AddDllLoadCallback("server.dll", InitialiseMaxPlayersOverride_Server);
 
-	//Initialise Named Pipe
+	// Initialise Named Pipe
 	AddDllLoadCallback("server.dll", InitialiseNamedPipeClient);
 
 	// mod manager after everything else

--- a/NorthstarDLL/namedpipeclient.cpp
+++ b/NorthstarDLL/namedpipeclient.cpp
@@ -27,7 +27,7 @@ HANDLE GetNewPipeInstance()
 	HANDLE thisMatchPipe = INVALID_HANDLE_VALUE;
 	if (isGeneralConnected)
 	{
-		TCHAR chBuf[BUFF_SIZE]; // TODO: Length of general pipe ids + terminating zero
+		TCHAR chBuf[BUFF_SIZE]; // Server message should either be BUFF_SIZE or Length of general pipe ids + terminating zero
 		DWORD cbRead;
 		if (ReadFile(
 				generalPipe, // pipe handle

--- a/NorthstarDLL/namedpipeclient.cpp
+++ b/NorthstarDLL/namedpipeclient.cpp
@@ -48,12 +48,12 @@ HANDLE GetNewPipeInstance()
 
 void SendMessageToPipe(string message)
 {
-	bool success = false;
+	//bool success = false;
 	DWORD read;
-	do
-	{
-		success = WriteFile(hPipe, message.c_str(), message.length(), &read, nullptr);
-	} while (!success);
+	/*do
+	{*/
+		/*success = */WriteFile(hPipe, message.c_str(), message.length(), &read, nullptr);
+	/*} while (!success);*/
 }
 
 SQRESULT SQ_SendToNamedPipe(void* sqvm)

--- a/NorthstarDLL/namedpipeclient.cpp
+++ b/NorthstarDLL/namedpipeclient.cpp
@@ -1,0 +1,142 @@
+#pragma once
+#include "pch.h"
+#include "namedpipeclient.h"
+#include "squirrel.h" // Squirrel
+
+// Named Pipe Stuff
+#include <windows.h>
+#include <conio.h>
+#include <tchar.h>
+#include <string>
+#include <atlstr.h>
+
+using namespace std;
+
+#define GENERAL_PIPE_NAME TEXT("\\\\.\\pipe\\GameDataPipe")
+#define BUFF_SIZE 512
+
+HANDLE hPipe;
+bool isConnected = false;
+
+ConVar* Cvar_ns_enable_named_pipe;
+
+HANDLE GetNewPipeInstance()
+{
+	HANDLE generalPipe = CreateFile(GENERAL_PIPE_NAME, GENERIC_READ, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+	bool isGeneralConnected = generalPipe != INVALID_HANDLE_VALUE;
+	HANDLE thisMatchPipe = INVALID_HANDLE_VALUE;
+	if (isGeneralConnected)
+	{
+		TCHAR chBuf[BUFF_SIZE]; // TODO: Length of general pipe ids + terminating zero
+		DWORD cbRead;
+		if (ReadFile(
+				generalPipe, // pipe handle
+				chBuf, // buffer to receive reply
+				BUFF_SIZE * sizeof(TCHAR), // size of buffer
+				&cbRead, // number of bytes read
+				NULL)) // not overlapped
+		{
+			do
+			{
+				spdlog::info("New Pipe connection");
+				thisMatchPipe = CreateFile(chBuf, GENERIC_WRITE, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+			} while (thisMatchPipe == INVALID_HANDLE_VALUE);
+		}
+	}
+	return thisMatchPipe;
+}
+
+void SendMessageToPipe(string message)
+{
+	bool success = false;
+	DWORD read;
+	do
+	{
+		success = WriteFile(hPipe, message.c_str(), message.length(), &read, nullptr);
+	} while (!success);
+}
+
+SQRESULT SQ_SendToNamedPipe(void* sqvm)
+{
+	try
+	{
+		if(Cvar_ns_enable_named_pipe->GetInt() && isConnected)
+		{
+			SendMessageToPipe(ServerSq_getstring(sqvm, 1));
+		}
+	}
+	catch (exception _e)
+	{
+		spdlog::error("Internal error while sending message through named pipe");
+		spdlog::error(_e.what());
+	}
+
+	return SQRESULT_NULL;
+}
+
+SQRESULT SQ_OpenNamedPipe(void* sqvm)
+{
+	try
+	{
+		if (Cvar_ns_enable_named_pipe->GetInt())
+		{
+			if (!isConnected || hPipe == INVALID_HANDLE_VALUE) 
+			{
+				isConnected = false;
+				hPipe = GetNewPipeInstance();
+			} else
+			{
+				SendMessageToPipe(ServerSq_getstring(sqvm, 2));
+			}
+			
+			isConnected = hPipe != INVALID_HANDLE_VALUE;
+
+			if (isConnected)
+			{
+				SendMessageToPipe(ServerSq_getstring(sqvm, 1));
+			}
+			else
+			{
+				spdlog::error("INVALID_HANDLE_VALUE while opening named pipe");
+				spdlog::error(GetLastError());
+			}
+		}
+	}
+	catch (exception _e)
+	{
+		spdlog::error("Internal error while opening named pipe");
+		spdlog::error(_e.what());
+	}
+
+	return SQRESULT_NULL;
+}
+
+SQRESULT SQ_ClosePipe(void* sqvm)
+{
+	try
+	{
+		if (Cvar_ns_enable_named_pipe->GetInt() && isConnected)
+		{
+			SendMessageToPipe(ServerSq_getstring(sqvm, 1));
+			
+			CloseHandle(hPipe);
+			isConnected = false;
+		}
+	}
+	catch (exception _e)
+	{
+		spdlog::error("Internal error while closing named pipe");
+		spdlog::error(_e.what());
+	}
+
+	return SQRESULT_NULL;
+}
+
+void InitialiseNamedPipeClient(HMODULE baseAddress)
+{
+	Cvar_ns_enable_named_pipe =
+		new ConVar("ns_enable_named_pipe", "0", FCVAR_GAMEDLL, "Whether to start up a named pipe server on request from squirrel");
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSSendToNamedPipe", "string textToSend", "", SQ_SendToNamedPipe);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSOpenNamedPipe", "string openingMessage, string closingMessageIfOpen", "", SQ_OpenNamedPipe);
+	g_ServerSquirrelManager->AddFuncRegistration("void", "NSCloseNamedPipe", "string closingMessage", "", SQ_ClosePipe);
+}

--- a/NorthstarDLL/namedpipeclient.cpp
+++ b/NorthstarDLL/namedpipeclient.cpp
@@ -60,7 +60,7 @@ SQRESULT SQ_SendToNamedPipe(void* sqvm)
 {
 	try
 	{
-		if(Cvar_ns_enable_named_pipe->GetInt() && isConnected)
+		if (Cvar_ns_enable_named_pipe->GetInt() && isConnected)
 		{
 			SendMessageToPipe(ServerSq_getstring(sqvm, 1));
 		}
@@ -80,15 +80,16 @@ SQRESULT SQ_OpenNamedPipe(void* sqvm)
 	{
 		if (Cvar_ns_enable_named_pipe->GetInt())
 		{
-			if (!isConnected || hPipe == INVALID_HANDLE_VALUE) 
+			if (!isConnected || hPipe == INVALID_HANDLE_VALUE)
 			{
 				isConnected = false;
 				hPipe = GetNewPipeInstance();
-			} else
+			}
+			else
 			{
 				SendMessageToPipe(ServerSq_getstring(sqvm, 2));
 			}
-			
+
 			isConnected = hPipe != INVALID_HANDLE_VALUE;
 
 			if (isConnected)
@@ -118,7 +119,7 @@ SQRESULT SQ_ClosePipe(void* sqvm)
 		if (Cvar_ns_enable_named_pipe->GetInt() && isConnected)
 		{
 			SendMessageToPipe(ServerSq_getstring(sqvm, 1));
-			
+
 			CloseHandle(hPipe);
 			isConnected = false;
 		}
@@ -137,6 +138,7 @@ void InitialiseNamedPipeClient(HMODULE baseAddress)
 	Cvar_ns_enable_named_pipe =
 		new ConVar("ns_enable_named_pipe", "0", FCVAR_GAMEDLL, "Whether to start up a named pipe server on request from squirrel");
 	g_ServerSquirrelManager->AddFuncRegistration("void", "NSSendToNamedPipe", "string textToSend", "", SQ_SendToNamedPipe);
-	g_ServerSquirrelManager->AddFuncRegistration("void", "NSOpenNamedPipe", "string openingMessage, string closingMessageIfOpen", "", SQ_OpenNamedPipe);
+	g_ServerSquirrelManager->AddFuncRegistration(
+		"void", "NSOpenNamedPipe", "string openingMessage, string closingMessageIfOpen", "", SQ_OpenNamedPipe);
 	g_ServerSquirrelManager->AddFuncRegistration("void", "NSCloseNamedPipe", "string closingMessage", "", SQ_ClosePipe);
 }

--- a/NorthstarDLL/namedpipeclient.cpp
+++ b/NorthstarDLL/namedpipeclient.cpp
@@ -48,12 +48,8 @@ HANDLE GetNewPipeInstance()
 
 void SendMessageToPipe(string message)
 {
-	//bool success = false;
 	DWORD read;
-	/*do
-	{*/
-		/*success = */WriteFile(hPipe, message.c_str(), message.length(), &read, nullptr);
-	/*} while (!success);*/
+	WriteFile(hPipe, message.c_str(), message.length(), &read, nullptr);
 }
 
 SQRESULT SQ_SendToNamedPipe(void* sqvm)

--- a/NorthstarDLL/namedpipeclient.h
+++ b/NorthstarDLL/namedpipeclient.h
@@ -4,6 +4,6 @@
 
 extern ConVar* Cvar_ns_server_name;
 
-//bool shouldUseNamedPipe = true;
+// bool shouldUseNamedPipe = true;
 void InitialiseNamedPipeClient(HMODULE baseAddress);
-//void InitialiseNamedPipeClient();
+// void InitialiseNamedPipeClient();

--- a/NorthstarDLL/namedpipeclient.h
+++ b/NorthstarDLL/namedpipeclient.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "pch.h"
+#include "convar.h"
+
+extern ConVar* Cvar_ns_server_name;
+
+//bool shouldUseNamedPipe = true;
+void InitialiseNamedPipeClient(HMODULE baseAddress);
+//void InitialiseNamedPipeClient();


### PR DESCRIPTION
This pull request adds a Named Pipe Client into the Northstar Launcher which allows it to connect to a Named Pipe Server.

This feature is currently being used for the [R2Northstar-TelemetrySystem](https://github.com/Neoministein/R2Northstar-TelemetrySystem) project to get a high volume of data out of Northstar to generate heatmaps and live web-based minimaps.

### Current Implementation details

Configuration:
```
The named pipe server is turned off by default but can be enabled with a startup argument:
+ns_enable_named_pipe 1
```

Open Named Pipe Client:
```
1. Squirrel calls NSOpenNamedPipe(string openingMessage, string closingMessageIfOpen)
2. The Launcher tries to connect to a named pipe at "\\\\.\\pipe\\GameDataPipe"
3. On connection the Launcher expects a byte array of 512. If it is smaller it needs to be null-terminated.
4. The byte array contains the name of a designated pipe which will be used for all further communication.

This is done so only one NamedPipeServer is needed for x amount of Northstar instances.
```

Send a message:
```
1. Squirrel calls NSSendToNamedPipe(string textToSend)
2. If connected and enabled it sends the specified string through the named pipe.
3. There is no specified length so the Named Pipe Server would need to look out for null-termination for when the message ends.
```

Close Named Pipe Client:
```
1. Squirrel calls NSCloseNamedPipe(string closingMessage)
2. The connection to the named pipe is terminated.
```

Developed by [@Aragami-delp], [@Neoministein]