### PR TITLE
Fix token clearing hook

### DIFF
--- a/NorthstarDLL/clientauthhooks.cpp
+++ b/NorthstarDLL/clientauthhooks.cpp
@@ -36,7 +36,7 @@ void, __fastcall, (void* a1))
 char* p3PToken;
 
 // clang-format off
-AUTOHOOK(Auth3PToken, engine.dll + 183760,
+AUTOHOOK(Auth3PToken, engine.dll + 0x183760,
 char*, __fastcall, ())
 // clang-format on
 {


### PR DESCRIPTION
A certain someone forgot to put an `0x` in front of their hex number, meaning the offset is wrong. This would cause token to be leaked again.