### PR TITLE
Fixup more cvars

### DIFF
--- a/NorthstarDLL/dedicated.cpp
+++ b/NorthstarDLL/dedicated.cpp
@@ -224,6 +224,7 @@ ON_DLL_LOAD_DEDI_RELIESON("engine.dll", DedicatedServer, ServerPresence, (CModul
 	Tier0::CommandLine()->AppendParm("-nomessagebox", 0);
 	Tier0::CommandLine()->AppendParm("+host_preload_shaders", "0");
 	Tier0::CommandLine()->AppendParm("+net_usesocketsforloopback", "1");
+	Tier0::CommandLine()->AppendParm("+community_frame_run", "0");
 
 	// use presence reporter for console title
 	DedicatedConsoleServerPresence* presenceReporter = new DedicatedConsoleServerPresence;
@@ -274,6 +275,7 @@ void, __fastcall, (void* sqvm))
 	PrintSquirrelError(sqvm);
 
 	// close dedicated server if a fatal error is hit
+	// atm, this will crash if not aborted, so this just closes more gracefully
 	static ConVar* Cvar_fatal_script_errors = g_pCVar->FindVar("fatal_script_errors");
 	if (Cvar_fatal_script_errors->GetBool())
 		abort();

--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -197,7 +197,7 @@ void FixupCvarFlags()
 		{"rodeo_enable", FCVAR_DEVELOPMENTONLY},
 		{"sv_forceRodeoToFail", FCVAR_DEVELOPMENTONLY},
 		{"player_find_rodeo_target_per_cmd", FCVAR_DEVELOPMENTONLY}, // todo test before merge
-		{"hud_takesshots",FCVAR_DEVELOPMENTONLY}, // very likely does not work but would be cool if it did
+		{"hud_takesshots", FCVAR_DEVELOPMENTONLY}, // very likely does not work but would be cool if it did
 
 		{"cam_collision", FCVAR_DEVELOPMENTONLY},
 		{"cam_idealdelta", FCVAR_DEVELOPMENTONLY},
@@ -212,7 +212,7 @@ void FixupCvarFlags()
 		{"r_hbaoDistanceLerp", FCVAR_DEVELOPMENTONLY},
 		{"r_hbaoBlurRadius", FCVAR_DEVELOPMENTONLY},
 		{"r_hbaoExponent", FCVAR_DEVELOPMENTONLY},
-		{"r_hbaoDepthFadePctDefault",FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoDepthFadePctDefault", FCVAR_DEVELOPMENTONLY},
 		{"r_drawscreenspaceparticles", FCVAR_DEVELOPMENTONLY},
 		{"ui_loadingscreen_fadeout_time", FCVAR_DEVELOPMENTONLY},
 		{"ui_loadingscreen_fadein_time", FCVAR_DEVELOPMENTONLY},
@@ -266,16 +266,16 @@ void FixupCvarFlags()
 		{"ai_ainRebuildOnMapStart", FCVAR_DEVELOPMENTONLY},
 
 		// cheat commands
-		{"switchclass",FCVAR_DEVELOPMENTONLY},
+		{"switchclass", FCVAR_DEVELOPMENTONLY},
 		{"set", FCVAR_DEVELOPMENTONLY},
 		{"_setClassVarServer", FCVAR_DEVELOPMENTONLY},
 
 		// reparse commands
 		{"aisettings_reparse", FCVAR_DEVELOPMENTONLY},
 		{"aisettings_reparse_client", FCVAR_DEVELOPMENTONLY},
-		{"damagedefs_reparse",FCVAR_DEVELOPMENTONLY},
+		{"damagedefs_reparse", FCVAR_DEVELOPMENTONLY},
 		{"damagedefs_reparse_client", FCVAR_DEVELOPMENTONLY},
-		{"playerSettings_reparse",FCVAR_DEVELOPMENTONLY},
+		{"playerSettings_reparse", FCVAR_DEVELOPMENTONLY},
 		{"_playerSettings_reparse_Server", FCVAR_DEVELOPMENTONLY},
 	};
 

--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -134,7 +134,16 @@ void FixupCvarFlags()
 		{"particle_kill", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS},
 
 		{"test_setteam", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS},
-		{"melee_lunge_ent", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS}};
+		{"melee_lunge_ent", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS},
+
+		// fcvars that should be cheats
+		{"net_ignoreAllSnapshots", FCVAR_CHEAT},
+		{"highlight_draw", FCVAR_CHEAT},
+		// these should potentially be replicated rather than cheat, like sv_footsteps is
+		// however they're defined on client, so can't make replicated atm sadly
+		{"cl_footstep_event_max_dist", FCVAR_CHEAT},
+		{"cl_footstep_event_max_dist_titan", FCVAR_CHEAT},
+	};
 
 	// array of cvars and the flags we want to remove from them
 	const std::vector<std::tuple<const char*, uint32_t>> CVAR_FIXUP_REMOVE_FLAGS = {
@@ -144,7 +153,136 @@ void FixupCvarFlags()
 
 		// unsure how these work exactly (rpt system likely somewhat stripped?), removing anyway since they won't be used
 		{"rpt_client_enable", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS},
-		{"rpt_password", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS}};
+		{"rpt_password", FCVAR_GAMEDLL_FOR_REMOTE_CLIENTS},
+
+		// these are devonly by default but should be modifyable
+		// NOTE: not all of these may actually do anything or work properly in practice
+		// network settings
+		{"cl_updaterate_mp", FCVAR_DEVELOPMENTONLY},
+		{"cl_updaterate_sp", FCVAR_DEVELOPMENTONLY},
+		{"clock_bias_sp", FCVAR_DEVELOPMENTONLY},
+		{"clock_bias_mp", FCVAR_DEVELOPMENTONLY},
+		{"cl_interpolate", FCVAR_DEVELOPMENTONLY}, // super duper ultra fucks anims if changed
+		{"cl_interpolateSoAllAnimsLoop", FCVAR_DEVELOPMENTONLY},
+		{"cl_cmdrate", FCVAR_DEVELOPMENTONLY},
+		{"cl_cmdbackup", FCVAR_DEVELOPMENTONLY},
+		{"rate", FCVAR_DEVELOPMENTONLY},
+		{"net_minroutable", FCVAR_DEVELOPMENTONLY},
+		{"net_maxroutable", FCVAR_DEVELOPMENTONLY},
+		{"net_lerpFields", FCVAR_DEVELOPMENTONLY},
+		{"net_ignoreAllSnapshots", FCVAR_DEVELOPMENTONLY},
+		{"net_chokeloop", FCVAR_DEVELOPMENTONLY},
+		{"sv_unlag", FCVAR_DEVELOPMENTONLY},
+		{"sv_maxunlag", FCVAR_DEVELOPMENTONLY},
+		{"sv_lagpushticks", FCVAR_DEVELOPMENTONLY},
+		{"sv_instancebaselines", FCVAR_DEVELOPMENTONLY},
+		{"sv_voiceEcho", FCVAR_DEVELOPMENTONLY},
+		{"net_compresspackets", FCVAR_DEVELOPMENTONLY},
+		{"net_compresspackets_minsize", FCVAR_DEVELOPMENTONLY},
+		{"net_verifyEncryption", FCVAR_DEVELOPMENTONLY}, // unsure if functional in retail
+
+		// gameplay settings
+		{"vel_samples", FCVAR_DEVELOPMENTONLY},
+		{"vel_sampleFrequency", FCVAR_DEVELOPMENTONLY},
+		{"sv_friction", FCVAR_DEVELOPMENTONLY},
+		{"sv_stopspeed", FCVAR_DEVELOPMENTONLY},
+		{"sv_airaccelerate", FCVAR_DEVELOPMENTONLY},
+		{"sv_forceGrapplesToFail", FCVAR_DEVELOPMENTONLY},
+		{"sv_maxvelocity", FCVAR_DEVELOPMENTONLY},
+		{"sv_footsteps", FCVAR_DEVELOPMENTONLY},
+		// these 2 are flagged as CHEAT above, could be made REPLICATED later potentially
+		{"cl_footstep_event_max_dist", FCVAR_DEVELOPMENTONLY},
+		{"cl_footstep_event_max_dist_titan", FCVAR_DEVELOPMENTONLY},
+		{"sv_balanceTeams", FCVAR_DEVELOPMENTONLY},
+		{"rodeo_enable", FCVAR_DEVELOPMENTONLY},
+		{"sv_forceRodeoToFail", FCVAR_DEVELOPMENTONLY},
+		{"player_find_rodeo_target_per_cmd", FCVAR_DEVELOPMENTONLY}, // todo test before merge
+		{"hud_takesshots",FCVAR_DEVELOPMENTONLY}, // very likely does not work but would be cool if it did
+
+		{"cam_collision", FCVAR_DEVELOPMENTONLY},
+		{"cam_idealdelta", FCVAR_DEVELOPMENTONLY},
+		{"cam_ideallag", FCVAR_DEVELOPMENTONLY},
+
+		// graphics/visual settings
+		{"r_hbaoRadius", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoDepthMax", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoBlurSharpness", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoIntensity", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoBias", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoDistanceLerp", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoBlurRadius", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoExponent", FCVAR_DEVELOPMENTONLY},
+		{"r_hbaoDepthFadePctDefault",FCVAR_DEVELOPMENTONLY},
+		{"r_drawscreenspaceparticles", FCVAR_DEVELOPMENTONLY},
+		{"ui_loadingscreen_fadeout_time", FCVAR_DEVELOPMENTONLY},
+		{"ui_loadingscreen_fadein_time", FCVAR_DEVELOPMENTONLY},
+		{"ui_loadingscreen_transition_time", FCVAR_DEVELOPMENTONLY},
+		{"ui_loadingscreen_mintransition_time", FCVAR_DEVELOPMENTONLY},
+		// these 2 could be FCVAR_CHEAT, i guess?
+		{"cl_draw_player_model", FCVAR_DEVELOPMENTONLY},
+		{"cl_always_draw_3p_player", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_neutral", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_ally", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_ally_cb1", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_ally_cb2", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_ally_cb3", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_enemy", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_enemy_cb1", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_enemy_cb2", FCVAR_DEVELOPMENTONLY},
+		{"idcolor_enemy_cb3", FCVAR_DEVELOPMENTONLY},
+		{"playerListPartyColorR", FCVAR_DEVELOPMENTONLY},
+		{"playerListPartyColorG", FCVAR_DEVELOPMENTONLY},
+		{"playerListPartyColorB", FCVAR_DEVELOPMENTONLY},
+		{"playerListUseFriendColor", FCVAR_DEVELOPMENTONLY},
+		{"fx_impact_neutral", FCVAR_DEVELOPMENTONLY},
+		{"fx_impact_ally", FCVAR_DEVELOPMENTONLY},
+		{"fx_impact_enemy", FCVAR_DEVELOPMENTONLY},
+		{"hitch_alert_color", FCVAR_DEVELOPMENTONLY},
+		{"particles_cull_all", FCVAR_DEVELOPMENTONLY},
+		{"particles_cull_dlights", FCVAR_DEVELOPMENTONLY},
+		{"map_settings_override", FCVAR_DEVELOPMENTONLY},
+		{"highlight_draw", FCVAR_DEVELOPMENTONLY},
+
+		// sys/engine settings
+		{"sleep_when_meeting_framerate", FCVAR_DEVELOPMENTONLY},
+		{"sleep_when_meeting_framerate_headroom_ms", FCVAR_DEVELOPMENTONLY},
+		{"not_focus_sleep", FCVAR_DEVELOPMENTONLY},
+		{"sp_not_focus_pause", FCVAR_DEVELOPMENTONLY},
+		{"joy_requireFocus", FCVAR_DEVELOPMENTONLY},
+
+		{"host_thread_mode", FCVAR_DEVELOPMENTONLY},
+		{"phys_enable_simd_optimizations", FCVAR_DEVELOPMENTONLY},
+		{"phys_enable_experimental_optimizations", FCVAR_DEVELOPMENTONLY},
+
+		{"community_frame_run", FCVAR_DEVELOPMENTONLY},
+		{"sv_single_core_dedi", FCVAR_DEVELOPMENTONLY},
+		{"sv_stressbots", FCVAR_DEVELOPMENTONLY},
+
+		{"fatal_script_errors", FCVAR_DEVELOPMENTONLY},
+		{"fatal_script_errors_client", FCVAR_DEVELOPMENTONLY},
+		{"fatal_script_errors_server", FCVAR_DEVELOPMENTONLY},
+		{"script_error_on_midgame_load", FCVAR_DEVELOPMENTONLY}, // idk what this is
+
+		{"ai_ainRebuildOnMapStart", FCVAR_DEVELOPMENTONLY},
+
+		// cheat commands
+		{"switchclass",FCVAR_DEVELOPMENTONLY},
+		{"set", FCVAR_DEVELOPMENTONLY},
+		{"_setClassVarServer", FCVAR_DEVELOPMENTONLY},
+
+		// reparse commands
+		{"aisettings_reparse", FCVAR_DEVELOPMENTONLY},
+		{"aisettings_reparse_client", FCVAR_DEVELOPMENTONLY},
+		{"damagedefs_reparse",FCVAR_DEVELOPMENTONLY},
+		{"damagedefs_reparse_client", FCVAR_DEVELOPMENTONLY},
+		{"playerSettings_reparse",FCVAR_DEVELOPMENTONLY},
+		{"_playerSettings_reparse_Server", FCVAR_DEVELOPMENTONLY},
+	};
+
+	const std::vector<std::tuple<const char*, int>> CVAR_FIXUP_DEFAULT_VALUES = {
+		{"sv_stressbots", 0}, // not currently used but this is probably a bad default if we get bots working
+		{"cl_pred_optimize", 0} // fixes issues with animation prediction in thirdperson
+	};
 
 	for (auto& fixup : CVAR_FIXUP_ADD_FLAGS)
 	{
@@ -158,5 +296,18 @@ void FixupCvarFlags()
 		ConCommandBase* command = R2::g_pCVar->FindCommandBase(std::get<0>(fixup));
 		if (command)
 			command->m_nFlags &= ~std::get<1>(fixup);
+	}
+
+	for (auto& fixup : CVAR_FIXUP_DEFAULT_VALUES)
+	{
+		ConVar* cvar = R2::g_pCVar->FindVar(std::get<0>(fixup));
+		if (cvar && !strcmp(cvar->GetString(), cvar->m_pszDefaultValue))
+		{
+			cvar->SetValue(std::get<1>(fixup));
+
+			int nLen = strlen(cvar->GetString());
+			cvar->m_pszDefaultValue = new char[nLen];
+			memcpy((void*)cvar->m_pszDefaultValue, cvar->GetString(), nLen + 1);
+		}
 	}
 }


### PR DESCRIPTION
removes unnecessary devonly flags from a bunch of cvars and a few commands
this was initially made to add re-remove `cl_updaterate_mp`'s devonly flag, the code for which was removed in refactor (oops), but i decided to go through all the devonly cvars and remove devonly from everything unnecessary
you can still fully strip devonly and hidden from cvars/commands with a commandline flag, but this is mainly for normal use

POSSIBLE CHANGES: 
`cl_footstep_event_max_dist` and `cl_footstep_event_max_dist_titan` control the distance at which footsteps from pilots and titans can be heard, I've made these `FCVAR_CHEAT` (i.e. require `sv_cheats 1`), but maybe they should be made `FCVAR_REPLICATED` instead? (i.e. server controls value, which is then sent to client)
only issue with this is that they don't exist on dedicated server atm since they're client vars, so they'd have to be redefined there

`cl_draw_player_model` and `cl_always_draw_3p_player` could maybe be made to require `sv_cheats`? but they don't really offer much in the way of cheaty-ness so idk probably not worth (one toggles whether player should be visible in 3p, other one draws 3p model ontop of 1p model in 1p)