### PR TITLE
fix typo in ConVar::SetValue( const char* )

### DIFF
--- a/NorthstarDLL/convar.cpp
+++ b/NorthstarDLL/convar.cpp
@@ -299,9 +299,7 @@ void ConVar::SetValue(float flValue)
 void ConVar::SetValue(const char* pszValue)
 {
 	if (strcmp(this->m_Value.m_pszString, pszValue) == 0)
-	{
 		return;
-	}
 
 	char szTempValue[32] {};
 	const char* pszNewValue {};
@@ -381,13 +379,7 @@ void ConVar::ChangeStringValue(const char* pszTempVal, float flOldValue)
 		if (len > m_Value.m_iStringLength)
 		{
 			if (m_Value.m_pszString)
-			{
-				// !TODO: Causes issues in tier0.dll, but doesn't in apex.
-				// Not a big issue since we are creating a new string below
-				// anyways to prevent buffer overflow if string is longer
-				// then the old string.
-				// delete[] m_Value.m_pszString;
-			}
+				delete[] m_Value.m_pszString;
 
 			m_Value.m_pszString = new char[len];
 			m_Value.m_iStringLength = len;

--- a/NorthstarDLL/convar.cpp
+++ b/NorthstarDLL/convar.cpp
@@ -302,7 +302,6 @@ void ConVar::SetValue(const char* pszValue)
 	{
 		return;
 	}
-	this->m_Value.m_pszString = pszValue;
 
 	char szTempValue[32] {};
 	const char* pszNewValue {};

--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -279,9 +279,9 @@ void FixupCvarFlags()
 		{"_playerSettings_reparse_Server", FCVAR_DEVELOPMENTONLY},
 	};
 
-	const std::vector<std::tuple<const char*, int>> CVAR_FIXUP_DEFAULT_VALUES = {
-		{"sv_stressbots", 0}, // not currently used but this is probably a bad default if we get bots working
-		{"cl_pred_optimize", 0} // fixes issues with animation prediction in thirdperson
+	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {
+		{"sv_stressbots", "0"}, // not currently used but this is probably a bad default if we get bots working
+		{"cl_pred_optimize", "0"} // fixes issues with animation prediction in thirdperson
 	};
 
 	for (auto& fixup : CVAR_FIXUP_ADD_FLAGS)
@@ -304,10 +304,7 @@ void FixupCvarFlags()
 		if (cvar && !strcmp(cvar->GetString(), cvar->m_pszDefaultValue))
 		{
 			cvar->SetValue(std::get<1>(fixup));
-
-			int nLen = strlen(cvar->GetString());
-			cvar->m_pszDefaultValue = new char[nLen];
-			memcpy((void*)cvar->m_pszDefaultValue, cvar->GetString(), nLen + 1);
+			cvar->m_pszDefaultValue = std::get<1>(fixup);
 		}
 	}
 }


### PR DESCRIPTION
idk how this got here tbh, this typo breaks `SetValue( const char* )` because it causes writes to bad memory (usually readonly memory), this fixes that