### PR TITLE
remove dev-only flag from save_enable

### DIFF
--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -265,6 +265,8 @@ void FixupCvarFlags()
 
 		{"ai_ainRebuildOnMapStart", FCVAR_DEVELOPMENTONLY},
 
+		{"save_enable", FCVAR_DEVELOPMENTONLY},
+
 		// cheat commands
 		{"switchclass", FCVAR_DEVELOPMENTONLY},
 		{"set", FCVAR_DEVELOPMENTONLY},
@@ -278,7 +280,6 @@ void FixupCvarFlags()
 		{"playerSettings_reparse", FCVAR_DEVELOPMENTONLY},
 		{"_playerSettings_reparse_Server", FCVAR_DEVELOPMENTONLY},
 
-		{"save_enable", FCVAR_DEVELOPMENTONLY},
 	};
 
 	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {

--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -277,6 +277,8 @@ void FixupCvarFlags()
 		{"damagedefs_reparse_client", FCVAR_DEVELOPMENTONLY},
 		{"playerSettings_reparse", FCVAR_DEVELOPMENTONLY},
 		{"_playerSettings_reparse_Server", FCVAR_DEVELOPMENTONLY},
+
+		{"save_enable", FCVAR_DEVELOPMENTONLY},
 	};
 
 	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {


### PR DESCRIPTION
Unsure if this is the proper fix for this but it seems as if the client tries to set this to 0 while in a server and cannot due to it being dev-only. 
We previously had it without the dev-only flag and I don't believe there should be any negative effects due to this. 

Should fix R2Northstar/Northstar#359