### PR TITLE
remove sv_cheats requirement from r_drawviewmodel

### DIFF
--- a/NorthstarDLL/misccommands.cpp
+++ b/NorthstarDLL/misccommands.cpp
@@ -202,6 +202,7 @@ void FixupCvarFlags()
 		{"cam_collision", FCVAR_DEVELOPMENTONLY},
 		{"cam_idealdelta", FCVAR_DEVELOPMENTONLY},
 		{"cam_ideallag", FCVAR_DEVELOPMENTONLY},
+		{"r_drawviewmodel", FCVAR_CHEAT}, // this is a cheat command, but shouldn't be as you can achieve similar effects through mods
 
 		// graphics/visual settings
 		{"mat_colorcorrection", FCVAR_DEVELOPMENTONLY},


### PR DESCRIPTION
allows r_drawviewmodel to be set without cheats, this is fine, since people already do similar things with mods anyway, just makes it easier