### PR TITLE
Fix DecodeJSON() not returning SQRESULT_NOTNULL.

### DIFF
--- a/NorthstarDLL/scriptjson.cpp
+++ b/NorthstarDLL/scriptjson.cpp
@@ -238,6 +238,7 @@ ADD_SQFUNC(
 	}
 
 	DecodeJsonTable<context>(sqvm, (rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<SourceAllocator>>*)&doc);
+	return SQRESULT_NOTNULL;
 }
 
 ADD_SQFUNC(


### PR DESCRIPTION
This PR simply makes the DecodeJSON() SQ function return `SQRESULT_NOTNULL` as to fix an issue where the Squirrel side would never return the decoded JSON table.