### PR TITLE
Fix slow keyvalues building

### DIFF
--- a/NorthstarDLL/crashhandler.cpp
+++ b/NorthstarDLL/crashhandler.cpp
@@ -291,7 +291,7 @@ long GenerateExceptionLog(EXCEPTION_POINTERS* exceptionInfo)
 
 long __stdcall ExceptionFilter(EXCEPTION_POINTERS* exceptionInfo)
 {
-	if (true)
+	if (!IsDebuggerPresent())
 	{
 		// Check if we are capable of handling this type of exception
 		if (ExceptionNames.find(exceptionInfo->ExceptionRecord->ExceptionCode) == ExceptionNames.end())

--- a/NorthstarDLL/crashhandler.cpp
+++ b/NorthstarDLL/crashhandler.cpp
@@ -262,6 +262,8 @@ void CreateMiniDump(EXCEPTION_POINTERS* exceptionInfo)
 
 long GenerateExceptionLog(EXCEPTION_POINTERS* exceptionInfo)
 {
+	storedException->exceptionRecord = *exceptionInfo->ExceptionRecord;
+	storedException->contextRecord = *exceptionInfo->ContextRecord;
 	const DWORD exceptionCode = exceptionInfo->ExceptionRecord->ExceptionCode;
 
 	void* exceptionAddress = exceptionInfo->ExceptionRecord->ExceptionAddress;

--- a/NorthstarDLL/crashhandler.h
+++ b/NorthstarDLL/crashhandler.h
@@ -14,8 +14,8 @@ struct ExceptionLog
 {
 	std::string cause;
 	HMODULE crashedModule;
-	PEXCEPTION_RECORD exceptionRecord;
-	PCONTEXT contextRecord;
+	EXCEPTION_RECORD exceptionRecord;
+	CONTEXT contextRecord;
 	std::vector<BacktraceModule> trace;
 	std::vector<std::string> registerDump;
 


### PR DESCRIPTION
Turns out that under windows, if you throw a runtime exception and catch it, it still passes through the exception filter. I was not aware of this, and was generating a dump file whenever the exception filter ran, since i assumed we would always be crashing at one point.