### PR TITLE
Validate serverlist response using a JSON schema

### DIFF
--- a/NorthstarDLL/masterserver.cpp
+++ b/NorthstarDLL/masterserver.cpp
@@ -261,7 +261,6 @@ void MasterServerManager::RequestServerList()
 			"lastHeartbeat",
 			"id",
 			"name",
-			"region",
 			"description",
 			"playerCount",
 			"maxPlayers",

--- a/NorthstarDLL/masterserver.cpp
+++ b/NorthstarDLL/masterserver.cpp
@@ -214,7 +214,7 @@ void MasterServerManager::RequestServerList()
 				rapidjson::Document schemaDoc;
 				// this schema validates each entry in the array of servers
 				schemaDoc.Parse(
-R"({
+					R"({
 	"type": "object",
 		"properties": {
 			"lastHeartbeat": {

--- a/NorthstarDLL/masterserver.cpp
+++ b/NorthstarDLL/masterserver.cpp
@@ -213,8 +213,8 @@ void MasterServerManager::RequestServerList()
 				// rapidjson conforms to JSON Schema draft 4
 				rapidjson::Document schemaDoc;
 				// this schema validates each entry in the array of servers
-				schemaDoc.Parse(
-					R"({
+				schemaDoc.Parse(R"(
+{
 	"type": "object",
 		"properties": {
 			"lastHeartbeat": {


### PR DESCRIPTION
Currently this works, but I do not like that I am using a raw string literal for the schema, is there some way to have a json file or something separate that gets packed or whatever at compile time?

Also the schema itself could maybe use some work, namely for regions. Currently they are set to be required, but this might be bad?