### PR TITLE
Don't set initial dedicated server title to the profile name

### DIFF
--- a/NorthstarDLL/nsprefix.cpp
+++ b/NorthstarDLL/nsprefix.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "nsprefix.h"
+#include "dedicated.h"
 #include <string>
 
 std::string GetNorthstarPrefix()
@@ -37,5 +38,7 @@ void InitialiseNorthstarPrefix()
 	}
 
 	// set the console title to show the current profile
-	SetConsoleTitleA((std::string("NorthstarLauncher | ") + NORTHSTAR_FOLDER_PREFIX).c_str());
+	// dont do this on dedi as title contains useful information on dedi and setting title breaks it as well
+	if (!IsDedicatedServer())
+		SetConsoleTitleA((std::string("NorthstarLauncher | ") + NORTHSTAR_FOLDER_PREFIX).c_str());
 }


### PR DESCRIPTION
Should help with #347 apparently?
Could use testing with docker, but it doesn't set the title for normal dedis anymore.
![image](https://user-images.githubusercontent.com/66967891/205103644-6ae7d9b3-f053-4b0c-82a3-39b27cfabff4.png)
