### PR TITLE
Exit instead of abort on server compile error

### DIFF
--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -362,7 +362,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		{
 			// flush the logger before we exit so debug things get saved to log file
 			logger->flush();
-			exit(-1);
+			exit(1);
 		}
 		else
 		{

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -362,7 +362,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		{
 			// flush the logger before we exit so debug things get saved to log file
 			logger->flush();
-			exit(1);
+			exit(EXIT_FAILURE);
 		}
 		else
 		{

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -360,7 +360,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		// kill dedicated server if we hit this
 		if (IsDedicatedServer())
 		{
-			// flush the logger before we abort so debug things get saved to log file
+			// flush the logger before we exit so debug things get saved to log file
 			logger->flush();
 			exit(-1);
 		}

--- a/NorthstarDLL/squirrel.cpp
+++ b/NorthstarDLL/squirrel.cpp
@@ -362,7 +362,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		{
 			// flush the logger before we abort so debug things get saved to log file
 			logger->flush();
-			abort();
+			exit(-1);
 		}
 		else
 		{


### PR DESCRIPTION
Dedicated server should almost never call abort in the event of a crash.