### PR TITLE
Add NSDisconnectPlayer() function.

### DIFF
--- a/NorthstarDLL/scripts/server/miscserverscript.cpp
+++ b/NorthstarDLL/scripts/server/miscserverscript.cpp
@@ -59,7 +59,12 @@ ADD_SQFUNC("bool", NSIsDedicated, "", "", ScriptContext::SERVER)
 	return SQRESULT_NOTNULL;
 }
 
-ADD_SQFUNC("bool", NSDisconnectPlayer, "entity player, string reason", "Disconnects the player from the server with the given reason", ScriptContext::SERVER)
+ADD_SQFUNC(
+	"bool",
+	NSDisconnectPlayer,
+	"entity player, string reason",
+	"Disconnects the player from the server with the given reason",
+	ScriptContext::SERVER)
 {
 	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->getentity<R2::CBasePlayer>(sqvm, 1);
 	const char* reason = g_pSquirrel<context>->getstring(sqvm, 2);

--- a/NorthstarDLL/scripts/server/miscserverscript.cpp
+++ b/NorthstarDLL/scripts/server/miscserverscript.cpp
@@ -58,3 +58,39 @@ ADD_SQFUNC("bool", NSIsDedicated, "", "", ScriptContext::SERVER)
 	g_pSquirrel<context>->pushbool(sqvm, IsDedicatedServer());
 	return SQRESULT_NOTNULL;
 }
+
+ADD_SQFUNC("bool", NSDisconnectPlayer, "entity player, string reason", "Disconnects the player from the server with the given reason", ScriptContext::SERVER)
+{
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const char* reason = g_pSquirrel<context>->getstring(sqvm, 2);
+
+	if (!pPlayer)
+	{
+		spdlog::warn("Attempted to call NSDisconnectPlayer() with null player.");
+
+		g_pSquirrel<context>->pushbool(sqvm, false);
+		return SQRESULT_NOTNULL;
+	}
+
+	// Shouldn't happen but I like sanity checks.
+	R2::CBaseClient* pClient = &R2::g_pClientArray[pPlayer->m_nPlayerIndex - 1];
+	if (!pClient)
+	{
+		spdlog::warn("NSDisconnectPlayer(): player entity has null CBaseClient!");
+
+		g_pSquirrel<context>->pushbool(sqvm, false);
+		return SQRESULT_NOTNULL;
+	}
+
+	if (reason)
+	{
+		R2::CBaseClient__Disconnect(pClient, 1, reason);
+	}
+	else
+	{
+		R2::CBaseClient__Disconnect(pClient, 1, "Disconnected by the server.");
+	}
+
+	g_pSquirrel<context>->pushbool(sqvm, true);
+	return SQRESULT_NOTNULL;
+}


### PR DESCRIPTION
This PR adds the following function:

```lua
bool function NSDisconnectPlayer(entity player, string reason);
```

This uses the native `CBaseClient__Disconnect()` function to ensure the player is booted from the server, while still giving them a disconnect reason much like the `disconnect` command.

Available on server VM.