### PR TITLE
Process all squirrel messages in the buffer instead of one per frame.

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -537,10 +537,12 @@ template <ScriptContext context> void SquirrelManager<context>::ProcessMessageBu
 		{
 			NS::log::squirrel_logger<context>()->error(
 				"ProcessMessageBuffer was unable to find function with name '{}'. Is it global?", message.functionName);
-			return;
+			continue;
 		}
+
 		pushobject(m_pSQVM->sqvm, &functionobj); // Push the function object
 		pushroottable(m_pSQVM->sqvm);
+
 		if (message.isExternal)
 		{
 			message.externalFunc(m_pSQVM->sqvm);


### PR DESCRIPTION
This PR simply makes the squirrel manager process all queued messages from native to Squirrel scripts every frame, instead of the previous behaviour which only processed one.

This is going to be needed for my next PR which adds a callback to Squirrel scripts for when the VM is about to be destroyed.