### PR TITLE
Add missing breaks to AsyncCall_External()

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -164,10 +164,13 @@ void AsyncCall_External(ScriptContext context, const char* func_name, SquirrelMe
 	{
 	case ScriptContext::CLIENT:
 		g_pSquirrel<ScriptContext::CLIENT>->messageBuffer->push(message);
+		break;
 	case ScriptContext::SERVER:
 		g_pSquirrel<ScriptContext::SERVER>->messageBuffer->push(message);
+		break;
 	case ScriptContext::UI:
 		g_pSquirrel<ScriptContext::UI>->messageBuffer->push(message);
+		break;
 	}
 }
 


### PR DESCRIPTION
Simply fixes a few missing `break`s in `AsyncCall_External()` leading to weird behaviour.