### PR TITLE
Add Destroy callback for squirrel scripts.

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -198,6 +198,9 @@ Mod::Mod(fs::path modDir, char* jsonBuf)
 				if (scriptObj["ServerCallback"].HasMember("After") && scriptObj["ServerCallback"]["After"].IsString())
 					callback.AfterCallback = scriptObj["ServerCallback"]["After"].GetString();
 
+				if (scriptObj["ServerCallback"].HasMember("Destroy") && scriptObj["ServerCallback"]["Destroy"].IsString())
+					callback.DestroyCallback = scriptObj["ServerCallback"]["Destroy"].GetString();
+
 				script.Callbacks.push_back(callback);
 			}
 
@@ -212,6 +215,9 @@ Mod::Mod(fs::path modDir, char* jsonBuf)
 				if (scriptObj["ClientCallback"].HasMember("After") && scriptObj["ClientCallback"]["After"].IsString())
 					callback.AfterCallback = scriptObj["ClientCallback"]["After"].GetString();
 
+				if (scriptObj["ClientCallback"].HasMember("Destroy") && scriptObj["ClientCallback"]["Destroy"].IsString())
+					callback.DestroyCallback = scriptObj["ClientCallback"]["Destroy"].GetString();
+
 				script.Callbacks.push_back(callback);
 			}
 
@@ -225,6 +231,9 @@ Mod::Mod(fs::path modDir, char* jsonBuf)
 
 				if (scriptObj["UICallback"].HasMember("After") && scriptObj["UICallback"]["After"].IsString())
 					callback.AfterCallback = scriptObj["UICallback"]["After"].GetString();
+
+				if (scriptObj["UICallback"].HasMember("Destroy") && scriptObj["UICallback"]["Destroy"].IsString())
+					callback.DestroyCallback = scriptObj["UICallback"]["Destroy"].GetString();
 
 				script.Callbacks.push_back(callback);
 			}

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -41,6 +41,8 @@ struct ModScriptCallback
 	std::string BeforeCallback;
 	// called after the codecallback has finished executing
 	std::string AfterCallback;
+	// called right before the vm is destroyed.
+	std::string DestroyCallback;
 };
 
 struct ModScript

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -229,20 +229,7 @@ template <ScriptContext context> void SquirrelManager<context>::VMDestroyed()
 						continue;
 					}
 
-					SQObject functionobj {};
-					int result = sq_getfunction(m_pSQVM->sqvm, callback.DestroyCallback.c_str(), &functionobj, 0);
-					if (result != 0) // This func returns 0 on success for some reason
-					{
-						NS::log::squirrel_logger<context>()->error(
-							"VMDestroyed() was unable to find function with name '{}'. Is it global?", callback.DestroyCallback);
-						continue;
-					}
-
-					pushobject(m_pSQVM->sqvm, &functionobj);
-					pushroottable(m_pSQVM->sqvm);
-
-					_call(m_pSQVM->sqvm, 0);
-
+					Call(callback.DestroyCallback.c_str());
 					NS::log::squirrel_logger<context>()->info("Executed Destroy callback {}.", callback.DestroyCallback);
 				}
 			}


### PR DESCRIPTION
This PR adds a new callback to configure in a mod's `mod.json` file. The `Destroy` callback will be executed right before the VM of the given context is destroyed:

```json
{
    "Path": "spyglass/client_globals.nut",
    "RunOn": "CLIENT && MP",
    "ClientCallback":
    {
        "After": "Spyglass_ClientGlobalsInit",
        "Destroy": "Spyglass_ClientGlobalsDestroy"
    }
}
```
```lua
void function Spyglass_ClientGlobalsDestroy()
{
    printt("hello i get destroyed oh no")
}
```

The above example would give the following result:

![image](https://user-images.githubusercontent.com/25248023/209485042-c889b307-d204-4444-937c-abaffec9a857.png)
