### PR TITLE
Improve response to UI VM compile errors

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -376,14 +376,14 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		// kill dedicated server if we hit this
 		if (IsDedicatedServer())
 		{
-			logger->error("Exiting dedicated server due to fatal compile error");
+			logger->error("Exiting dedicated server, compile error is fatal");
 			// flush the logger before we exit so debug things get saved to log file
 			logger->flush();
 			exit(EXIT_FAILURE);
 		}
 		else
 		{
-			logger->error("Disconnecting due to fatal compile error");
+			logger->error("Disconnecting, compile error is fatal");
 
 			R2::Cbuf_AddText(
 				R2::Cbuf_GetCurrentPlayer(),
@@ -400,7 +400,13 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 	}
 	else
 	{
-		logger->warn("Ignoring non-fatal compile error");
+		logger->warn("Not disconnecting, compile error is non-fatal");
+
+		// likely temp: show console so user can see any errors, as error message wont display if ui is dead
+		// maybe we could disable all mods other than the coremods and try a reload before doing this?
+		// could also maybe do some vgui bullshit to show something visually rather than console
+		if (realContext == ScriptContext::UI)
+			R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "showconsole", R2::cmd_source_t::kCommandSrcCode);
 	}
 
 	// dont call the original function since it kills game lol

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -376,6 +376,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		// kill dedicated server if we hit this
 		if (IsDedicatedServer())
 		{
+			logger->error("Exiting dedicated server due to fatal compile error");
 			// flush the logger before we exit so debug things get saved to log file
 			logger->flush();
 			exit(EXIT_FAILURE);
@@ -388,12 +389,18 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 					.c_str(),
 				R2::cmd_source_t::kCommandSrcCode);
 
+			logger->error("Disconnecting due to fatal compile error");
+
 			// likely temp: show console so user can see any errors, as error message wont display if ui is dead
 			// maybe we could disable all mods other than the coremods and try a reload before doing this?
 			// could also maybe do some vgui bullshit to show something visually rather than console
 			if (realContext == ScriptContext::UI)
 				R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "showconsole", R2::cmd_source_t::kCommandSrcCode);
 		}
+	}
+	else
+	{
+		logger->warn("Ignoring non-fatal compile error");
 	}
 
 	// dont call the original function since it kills game lol

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -400,12 +400,6 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 	else
 	{
 		logger->warn("Not disconnecting, compile error is non-fatal");
-
-		// likely temp: show console so user can see any errors, as error message wont display if ui is dead
-		// maybe we could disable all mods other than the coremods and try a reload before doing this?
-		// could also maybe do some vgui bullshit to show something visually rather than console
-		if (realContext == ScriptContext::UI)
-			R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "showconsole", R2::cmd_source_t::kCommandSrcCode);
 	}
 
 	// dont call the original function since it kills game lol

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -283,8 +283,7 @@ template <ScriptContext context> void SquirrelManager<context>::AddFuncOverride(
 // hooks
 bool IsUIVM(ScriptContext context, HSquirrelVM* pSqvm)
 {
-	return context != ScriptContext::SERVER && g_pSquirrel<ScriptContext::UI>->m_pSQVM &&
-		   g_pSquirrel<ScriptContext::UI>->m_pSQVM->sqvm == pSqvm;
+	return ScriptContext(pSqvm->sharedState->cSquirrelVM->vmContext) == ScriptContext::UI;
 }
 
 template <ScriptContext context> void* (*__fastcall sq_compiler_create)(HSquirrelVM* sqvm, void* a2, void* a3, SQBool bShouldThrowError);

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -383,13 +383,13 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		}
 		else
 		{
+			logger->error("Disconnecting due to fatal compile error");
+
 			R2::Cbuf_AddText(
 				R2::Cbuf_GetCurrentPlayer(),
 				fmt::format("disconnect \"Encountered {} script compilation error, see console for details.\"", GetContextName(realContext))
 					.c_str(),
 				R2::cmd_source_t::kCommandSrcCode);
-
-			logger->error("Disconnecting due to fatal compile error");
 
 			// likely temp: show console so user can see any errors, as error message wont display if ui is dead
 			// maybe we could disable all mods other than the coremods and try a reload before doing this?

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -382,8 +382,6 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 		}
 		else
 		{
-			logger->error("Disconnecting, compile error is fatal");
-
 			R2::Cbuf_AddText(
 				R2::Cbuf_GetCurrentPlayer(),
 				fmt::format("disconnect \"Encountered {} script compilation error, see console for details.\"", GetContextName(realContext))
@@ -396,10 +394,6 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 			if (realContext == ScriptContext::UI)
 				R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "showconsole", R2::cmd_source_t::kCommandSrcCode);
 		}
-	}
-	else
-	{
-		logger->warn("Not disconnecting, compile error is non-fatal");
 	}
 
 	// dont call the original function since it kills game lol

--- a/NorthstarDLL/squirrel/squirreldatatypes.h
+++ b/NorthstarDLL/squirrel/squirreldatatypes.h
@@ -19,6 +19,7 @@ struct SQNativeClosure;
 struct SQArray;
 struct tableNode;
 struct SQUserData;
+struct CSquirrelVM;
 
 typedef void (*releasehookType)(void* val, int size);
 
@@ -395,7 +396,7 @@ struct SQSharedState
 	SQString* _SpinOffStringValue;
 	SQObjectType _SpinOffDelayedStringType;
 	SQString* _SpinOffDelayedStringValue;
-	unsigned char gap_43E8[8];
+	CSquirrelVM* cSquirrelVM;
 	bool enableDebugInfo; // functionality stripped
 	unsigned char gap_43F1[23];
 };
@@ -470,11 +471,16 @@ struct SQCompiler
 /* 155 */
 struct CSquirrelVM
 {
-	unsigned char gap_0[8];
+	BYTE gap_0[8];
 	HSquirrelVM* sqvm;
-	unsigned char gap_10[44];
-	int loadEnumFromFileMaybe;
-	unsigned char gap_40[200];
+	BYTE gap_10[8];
+	SQObject unknownObject_18;
+	__int64 unknown_28;
+	BYTE gap_30[12];
+	__int32 vmContext;
+	BYTE gap_40[648];
+	char* (*formatString)(__int64 a1, const char* format, ...);
+	BYTE gap_2D0[24];
 };
 
 struct SQUserData


### PR DESCRIPTION
Now should open the console automatically when UI VM hits a compile error, could still use some work I think, but this now works.

Also fixes a bug in `IsUIVM` which was the cause of the above not working properly to begin with, thanks to @RoyalBlue1 

Also improves logging around compile errors a bit, logging the response (or lack thereof) to the compile 

Users should now see something like this when they boot the game with a UI compile error, as opposed to the blank screen
![image](https://user-images.githubusercontent.com/66967891/210640313-a805d4d2-1e53-4759-b49e-7401aa942514.png)
