### PR TITLE
Fix overriding individual localisation strings being weird

### DIFF
--- a/NorthstarDLL/client/modlocalisation.cpp
+++ b/NorthstarDLL/client/modlocalisation.cpp
@@ -35,7 +35,10 @@ void, __fastcall, (void* pVguiLocalize))
 	CLocalize__ReloadLocalizationFiles(pVguiLocalize);
 }
 
-AUTOHOOK(CEngineVGui__Init, engine.dll + 0x247E10, void, __fastcall, (void* self))
+// clang-format off
+AUTOHOOK(CEngineVGui__Init, engine.dll + 0x247E10,
+void, __fastcall, (void* self))
+// clang-format on
 {
 	CEngineVGui__Init(self); // this loads r1_english, valve_english, dev_english
 

--- a/NorthstarDLL/client/modlocalisation.cpp
+++ b/NorthstarDLL/client/modlocalisation.cpp
@@ -35,10 +35,9 @@ void, __fastcall, (void* pVguiLocalize))
 	CLocalize__ReloadLocalizationFiles(pVguiLocalize);
 }
 
-AUTOHOOK(CEngineVGui__Init, engine.dll + 0x247E10,
-void, __fastcall, (void* self))
+AUTOHOOK(CEngineVGui__Init, engine.dll + 0x247E10, void, __fastcall, (void* self))
 {
-	CEngineVGui__Init(self);
+	CEngineVGui__Init(self); // this loads r1_english, valve_english, dev_english
 
 	// previously we did this in CLocalize::AddFile, but for some reason it won't properly overwrite localization from
 	// files loaded previously if done there, very weird but this works so whatever


### PR DESCRIPTION
Change how we load localisation to fix overriding individual localisation strings being weird.
With the old localisation loading code, our custom value in `Northstar.Custom` for the string `GAMEMODE_FW` wouldn't load, this fixes that by changing where we load our localisation to be more consistent