### PR TITLE
Execute cfgs before server startup for gamemode being run

### DIFF
--- a/NorthstarDLL/core/convar/concommand.cpp
+++ b/NorthstarDLL/core/convar/concommand.cpp
@@ -1,8 +1,11 @@
 #include "pch.h"
 #include "concommand.h"
 #include "shared/misccommands.h"
+#include "engine/r2engine.h"
 
 #include <iostream>
+
+bool (*CCommand__Tokenize)(CCommand& self, const char* pCommandString, R2::cmd_source_t commandSource);
 
 //-----------------------------------------------------------------------------
 // Purpose: Returns true if this is a command

--- a/NorthstarDLL/engine/hoststate.cpp
+++ b/NorthstarDLL/engine/hoststate.cpp
@@ -26,12 +26,17 @@ void ServerStartingOrChangingMap()
 {
 	ConVar* Cvar_mp_gamemode = g_pCVar->FindVar("mp_gamemode");
 
+	// ensure there's no ; chars in mp_gamemode that might allow someone to append any commands after the exec
+	char* pMode = const_cast<char*>(Cvar_mp_gamemode->GetString());
+	for (int i = 0; pMode[i]; i++)
+		if (pMode[i] == ';')
+			pMode[i] = ' ';
+
 	if (sLastMode.length())
 		Cbuf_AddText(Cbuf_GetCurrentPlayer(), fmt::format("exec cleanup_gamemode_{}", sLastMode).c_str(), cmd_source_t::kCommandSrcCode);
 
 	Cbuf_AddText(
-		Cbuf_GetCurrentPlayer(),
-		fmt::format("exec setup_gamemode_{}", sLastMode = Cvar_mp_gamemode->GetString()).c_str(),
+		Cbuf_GetCurrentPlayer(), fmt::format("exec setup_gamemode_{}", sLastMode = pMode).c_str(),
 		cmd_source_t::kCommandSrcCode);
 	Cbuf_Execute();
 

--- a/NorthstarDLL/engine/hoststate.cpp
+++ b/NorthstarDLL/engine/hoststate.cpp
@@ -34,13 +34,13 @@ void ServerStartingOrChangingMap()
 	memset(commandBuf, 0, sizeof(commandBuf));
 	CCommand tempCommand = *(CCommand*)&commandBuf;
 	if (sLastMode.length() &&
-		CCommand__Tokenize(tempCommand, fmt::format("exec cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
+		CCommand__Tokenize(tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
 		_Cmd_Exec_f(tempCommand, false, false);
 
 	memset(commandBuf, 0, sizeof(commandBuf));
 	if (CCommand__Tokenize(
 			tempCommand,
-			fmt::format("exec setup_gamemode_{}", sLastMode = Cvar_mp_gamemode->GetString()).c_str(),
+			fmt::format("exec server/setup_gamemode_{}", sLastMode = Cvar_mp_gamemode->GetString()).c_str(),
 			R2::cmd_source_t::kCommandSrcCode))
 	{
 		_Cmd_Exec_f(tempCommand, false, false);
@@ -151,7 +151,7 @@ void, __fastcall, (CHostState* self))
 		char* commandBuf[1040]; // assumedly this is the size of CCommand since we don't have an actual constructor
 		memset(commandBuf, 0, sizeof(commandBuf));
 		CCommand tempCommand = *(CCommand*)&commandBuf;
-		if (CCommand__Tokenize(tempCommand, fmt::format("exec cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
+		if (CCommand__Tokenize(tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
 		{
 			_Cmd_Exec_f(tempCommand, false, false);
 			Cbuf_Execute();

--- a/NorthstarDLL/engine/hoststate.cpp
+++ b/NorthstarDLL/engine/hoststate.cpp
@@ -34,7 +34,8 @@ void ServerStartingOrChangingMap()
 	memset(commandBuf, 0, sizeof(commandBuf));
 	CCommand tempCommand = *(CCommand*)&commandBuf;
 	if (sLastMode.length() &&
-		CCommand__Tokenize(tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
+		CCommand__Tokenize(
+			tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
 		_Cmd_Exec_f(tempCommand, false, false);
 
 	memset(commandBuf, 0, sizeof(commandBuf));
@@ -151,7 +152,8 @@ void, __fastcall, (CHostState* self))
 		char* commandBuf[1040]; // assumedly this is the size of CCommand since we don't have an actual constructor
 		memset(commandBuf, 0, sizeof(commandBuf));
 		CCommand tempCommand = *(CCommand*)&commandBuf;
-		if (CCommand__Tokenize(tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
+		if (CCommand__Tokenize(
+				tempCommand, fmt::format("exec server/cleanup_gamemode_{}", sLastMode).c_str(), R2::cmd_source_t::kCommandSrcCode))
 		{
 			_Cmd_Exec_f(tempCommand, false, false);
 			Cbuf_Execute();

--- a/NorthstarDLL/engine/r2engine.cpp
+++ b/NorthstarDLL/engine/r2engine.cpp
@@ -10,6 +10,8 @@ namespace R2
 	Cbuf_AddTextType Cbuf_AddText;
 	Cbuf_ExecuteType Cbuf_Execute;
 
+	bool (*CCommand__Tokenize)(CCommand& self, const char* pCommandString, R2::cmd_source_t commandSource);
+
 	CEngine* g_pEngine;
 
 	void (*CBaseClient__Disconnect)(void* self, uint32_t unknownButAlways1, const char* reason, ...);
@@ -26,6 +28,8 @@ ON_DLL_LOAD("engine.dll", R2Engine, (CModule module))
 	Cbuf_GetCurrentPlayer = module.Offset(0x120630).As<Cbuf_GetCurrentPlayerType>();
 	Cbuf_AddText = module.Offset(0x1203B0).As<Cbuf_AddTextType>();
 	Cbuf_Execute = module.Offset(0x1204B0).As<Cbuf_ExecuteType>();
+
+	CCommand__Tokenize = module.Offset(0x418380).As<bool (*)(CCommand&, const char*, R2::cmd_source_t)>();
 
 	g_pEngine = module.Offset(0x7D70C8).Deref().As<CEngine*>();
 

--- a/NorthstarDLL/engine/r2engine.h
+++ b/NorthstarDLL/engine/r2engine.h
@@ -59,6 +59,8 @@ namespace R2
 	typedef void (*Cbuf_ExecuteType)();
 	extern Cbuf_ExecuteType Cbuf_Execute;
 
+	extern bool (*CCommand__Tokenize)(CCommand& self, const char* pCommandString, R2::cmd_source_t commandSource);
+
 	// CEngine
 
 	enum EngineQuitState

--- a/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
@@ -266,8 +266,6 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 }
 
 // ratelimit stringcmds, and prevent remote clients from calling commands that they shouldn't
-bool (*CCommand__Tokenize)(CCommand& self, const char* pCommandString, R2::cmd_source_t commandSource);
-
 // clang-format off
 AUTOHOOK(CGameClient__ExecuteStringCommand, engine.dll + 0x1022E0,
 bool, __fastcall, (R2::CBaseClient* self, uint32_t unknown, const char* pCommandString))
@@ -287,7 +285,7 @@ bool, __fastcall, (R2::CBaseClient* self, uint32_t unknown, const char* pCommand
 	memset(commandBuf, 0, sizeof(commandBuf));
 	CCommand tempCommand = *(CCommand*)&commandBuf;
 
-	if (!CCommand__Tokenize(tempCommand, pCommandString, R2::cmd_source_t::kCommandSrcCode) || !tempCommand.ArgC())
+	if (!R2::CCommand__Tokenize(tempCommand, pCommandString, R2::cmd_source_t::kCommandSrcCode) || !tempCommand.ArgC())
 		return false;
 
 	ConCommand* command = R2::g_pCVar->FindCommand(tempCommand.Arg(0));
@@ -401,8 +399,6 @@ bool, __fastcall, (void* a1))
 ON_DLL_LOAD("engine.dll", EngineExploitFixes, (CModule module))
 {
 	AUTOHOOK_DISPATCH_MODULE(engine.dll)
-
-	CCommand__Tokenize = module.Offset(0x418380).As<bool (*)(CCommand&, const char*, R2::cmd_source_t)>();
 
 	// allow client/ui to run clientcommands despite restricting servercommands
 	module.Offset(0x4FB65).Patch("EB 11");

--- a/NorthstarDLL/shared/misccommands.cpp
+++ b/NorthstarDLL/shared/misccommands.cpp
@@ -45,6 +45,72 @@ void ConCommand_ns_end_reauth_and_leave_to_lobby(const CCommand& arg)
 	}
 }
 
+void ConCommand_cvar_setdefaultvalue(const CCommand& arg)
+{
+	if (arg.ArgC() < 3)
+	{
+		spdlog::info("usage: cvar_setdefaultvalue mp_gamemode tdm");
+		return;
+	}
+
+	ConVar* pCvar = R2::g_pCVar->FindVar(arg.Arg(1));
+	if (!pCvar)
+	{
+		spdlog::info("usage: cvar_setdefaultvalue mp_gamemode tdm");
+		return;
+	}
+
+	// unfortunately no way for us to not leak memory here, as default value might not be in writeable memory by default
+	int nLen = strlen(arg.Arg(2));
+	char* pBuf = new char[nLen + 1];
+	strncpy_s(pBuf, nLen + 1, arg.Arg(2), nLen);
+
+	pCvar->m_pszDefaultValue = pBuf;
+}
+
+void ConCommand_cvar_setvalueanddefaultvalue(const CCommand& arg)
+{
+	if (arg.ArgC() < 3)
+	{
+		spdlog::info("usage: cvar_setvalueanddefaultvalue mp_gamemode tdm");
+		return;
+	}
+
+	ConVar* pCvar = R2::g_pCVar->FindVar(arg.Arg(1));
+	if (!pCvar)
+	{
+		spdlog::info("usage: cvar_setvalueanddefaultvalue mp_gamemode tdm");
+		return;
+	}
+
+	// unfortunately no way for us to not leak memory here, as default value might not be in writeable memory by default
+	int nLen = strlen(arg.Arg(2));
+	char* pBuf = new char[nLen + 1];
+	strncpy_s(pBuf, nLen + 1, arg.Arg(2), nLen);
+
+	pCvar->m_pszDefaultValue = pBuf;
+	pCvar->SetValue(pCvar->m_pszDefaultValue);
+}
+
+void ConCommand_cvar_reset(const CCommand& arg)
+{
+	if (arg.ArgC() < 2)
+	{
+		spdlog::info("usage: cvar_reset mp_gamemode");
+		return;
+	}
+
+	ConVar* pCvar = R2::g_pCVar->FindVar(arg.Arg(1));
+	if (!pCvar)
+	{
+		spdlog::info("usage: cvar_reset mp_gamemode");
+		return;
+	}
+
+	// reset cvar
+	pCvar->SetValue(pCvar->m_pszDefaultValue);
+}
+
 void AddMiscConCommands()
 {
 	RegisterConCommand(
@@ -61,6 +127,18 @@ void AddMiscConCommands()
 
 	// this is a concommand because we make a deferred call to it from another thread
 	RegisterConCommand("ns_end_reauth_and_leave_to_lobby", ConCommand_ns_end_reauth_and_leave_to_lobby, "", FCVAR_NONE);
+
+	RegisterConCommand(
+		"cvar_setdefaultvalue",
+		ConCommand_cvar_setdefaultvalue,
+		"overwrites the default value of a cvar, for use with script and cvar_reset",
+		FCVAR_NONE);
+	RegisterConCommand(
+		"cvar_setvalueanddefaultvalue",
+		ConCommand_cvar_setvalueanddefaultvalue,
+		"overwrites the current value and default value of a cvar, for use with script and cvar_reset",
+		FCVAR_NONE);
+	RegisterConCommand("cvar_reset", ConCommand_cvar_reset, "resets a cvar's value to its default value", FCVAR_NONE);
 }
 
 // fixes up various cvar flags to have more sane values


### PR DESCRIPTION
Allows mods to create a cfg for the initialisation and cleanup of gamemodes, to be run on server before the server initialises. This is mainly to setup engine vars that need to be set before server init (i.e. the network convars required for FW to work correctly)
to use, create a `setup_gamemode_{gamemode}.cfg` and `cleanup_gamemode_{gamemode}.cfg` file in `mod/cfg/server`, and they will be run automatically on server startup/destruction.

Also contains utility commands primarily for these cfgs, mainly `cvar_reset`, that resets a cvar to its default value