### PR TITLE
feat: Remote mods directory

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -375,9 +375,13 @@ void ModManager::LoadMods()
 	}
 
 	// get mod directories
-	for (fs::directory_entry dir : fs::directory_iterator(GetModFolderPath()))
-		if (fs::exists(dir.path() / "mod.json"))
-			modDirs.push_back(dir.path());
+	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
+	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
+
+	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
+		for (fs::directory_entry dir : modIterator)
+			if (fs::exists(dir.path() / "mod.json"))
+				modDirs.push_back(dir.path());
 
 	for (fs::path modDir : modDirs)
 	{

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -354,6 +354,7 @@ void ModManager::LoadMods()
 	// ensure dirs exist
 	fs::remove_all(GetCompiledAssetsPath());
 	fs::create_directories(GetModFolderPath());
+	fs::create_directories(GetRemoteModFolderPath());
 
 	m_DependencyConstants.clear();
 
@@ -804,6 +805,10 @@ void ConCommand_reload_mods(const CCommand& args)
 fs::path GetModFolderPath()
 {
 	return fs::path(GetNorthstarPrefix() + MOD_FOLDER_SUFFIX);
+}
+fs::path GetRemoteModFolderPath()
+{
+	return fs::path(GetNorthstarPrefix() + REMOTE_MOD_FOLDER_SUFFIX);
 }
 fs::path GetCompiledAssetsPath()
 {

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -161,6 +161,7 @@ class ModManager
 };
 
 fs::path GetModFolderPath();
+fs::path GetRemoteModFolderPath();
 fs::path GetCompiledAssetsPath();
 
 extern ModManager* g_pModManager;


### PR DESCRIPTION
This pull request introduces remote mods folder, located at `/runtime/remote/mods`, that will store future auto-installed mods.

In short, it's the *"mods need to pull from 2 folders, local (user-installed) and remote (auto-installed)"* mentioned by @BobTheBob9 in https://github.com/R2Northstar/NorthstarLauncher/issues/396.

##### Changes

* Creates remote mod directory if it does not exist;
* When loading mods, check local folder AND remote mod folder

*(note: there was already a `REMOTE_MOD_FOLDER_SUFFIX` variable in code, I simply added some stuff around to use it)*
