### PR TITLE
Search for mod json recursively

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -374,7 +374,7 @@ void ModManager::LoadMods()
 	}
 
 	// get mod directories
-	for (fs::directory_entry dir : fs::directory_iterator(GetModFolderPath()))
+	for (fs::directory_entry dir : fs::recursive_directory_iterator(GetModFolderPath()))
 		if (fs::exists(dir.path() / "mod.json"))
 			modDirs.push_back(dir.path());
 


### PR DESCRIPTION
The mod json will now be searched recursively throughout the `mods` folder.

## Why? 
Tbh I was fed up with all the ppl asking why their mod they just downloaded from Thunderstore isn't loaded in game  : ^)

_And honestly I would love the idea of mod collections in the future_

---

PS: This will 100% solve all tickets, yes yes

(b'-')b