### PR TITLE
Allow `launchplaylist` to be used to start dedicated servers

### DIFF
--- a/NorthstarDLL/dedicated/dedicated.cpp
+++ b/NorthstarDLL/dedicated/dedicated.cpp
@@ -48,9 +48,9 @@ void RunServer(CDedicatedExports* dedicated)
 	// initialise engine
 	g_pEngine->Frame();
 
-	// add +map if not present
+	// add +map if no map loading command is present
 	// don't manually execute this from cbuf as users may have it in their startup args anyway, easier just to run from stuffcmds if present
-	if (!Tier0::CommandLine()->CheckParm("+map"))
+	if (!Tier0::CommandLine()->CheckParm("+map") && !Tier0::CommandLine()->CheckParm("+launchplaylist"))
 		Tier0::CommandLine()->AppendParm("+map", g_pCVar->FindVar("match_defaultMap")->GetString());
 
 	// re-run commandline


### PR DESCRIPTION
`launchplaylist` selects a random map and mode from a given playlist and starts a server on that playlist, this PR allows it to be used as a startup command to set startup map on a dedicated server