### PR TITLE
Flush loggers properly on dedicated server shutdown

### DIFF
--- a/NorthstarDLL/dedicated/dedicated.cpp
+++ b/NorthstarDLL/dedicated/dedicated.cpp
@@ -278,7 +278,10 @@ void, __fastcall, (void* sqvm))
 	// atm, this will crash if not aborted, so this just closes more gracefully
 	static ConVar* Cvar_fatal_script_errors = g_pCVar->FindVar("fatal_script_errors");
 	if (Cvar_fatal_script_errors->GetBool())
+	{
+		NS::log::FlushLoggers();
 		abort();
+	}
 }
 
 ON_DLL_LOAD_DEDI("server.dll", DedicatedServerGameDLL, (CModule module))

--- a/NorthstarDLL/logging/crashhandler.cpp
+++ b/NorthstarDLL/logging/crashhandler.cpp
@@ -72,6 +72,8 @@ void PrintExceptionLog(ExceptionLog& exc)
 			"Northstar has crashed! Crash info can be found in R2Northstar/logs",
 			"Northstar has crashed!",
 			MB_ICONERROR | MB_OK | MB_SYSTEMMODAL);
+
+	NS::log::FlushLoggers();
 }
 
 std::string GetExceptionName(ExceptionLog& exc)

--- a/NorthstarDLL/logging/logging.cpp
+++ b/NorthstarDLL/logging/logging.cpp
@@ -203,3 +203,11 @@ void InitialiseLogging()
 	loggers.push_back(NS::log::rpak);
 	loggers.push_back(NS::log::echo);
 }
+
+void NS::log::FlushLoggers()
+{
+	for (auto& logger : loggers)
+		logger->flush();
+
+	spdlog::default_logger()->flush();
+}

--- a/NorthstarDLL/logging/logging.h
+++ b/NorthstarDLL/logging/logging.h
@@ -100,6 +100,8 @@ namespace NS::log
 	extern std::shared_ptr<ColoredLogger> echo;
 
 	extern std::shared_ptr<ColoredLogger> NORTHSTAR;
+
+	void FlushLoggers();
 }; // namespace NS::log
 
 void RegisterCustomSink(std::shared_ptr<CustomSink> sink);


### PR DESCRIPTION
loggers don't seem to flush properly on `abort()`, this flushes them beforehand