### PR TITLE
feat: Bad mod formatting warnings

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -381,19 +381,23 @@ void ModManager::LoadMods()
 
 	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
 		for (fs::directory_entry dir : modIterator)
+		{
 			if (fs::exists(dir.path() / "mod.json"))
 				modDirs.push_back(dir.path());
 			else
 			{
+				std::string filename = dir.path().filename().generic_string().c_str();
+				// Don't display an error for hidden directories
+				if (filename.at(0) == '.')
+					continue;
+
 				spdlog::warn("Directory {} has no mod.json file.", dir.path().generic_string().c_str());
 				std::string errorMessage = std::format(
 					"The directory {} does not contain a mod.json file.\nMake sure you correctly installed it.",
 					dir.path().generic_string().c_str());
-				MessageBoxA(
-					GetForegroundWindow(), errorMessage.c_str(),
-					"Badly formatted mod",
-					0);
+				MessageBoxA(GetForegroundWindow(), errorMessage.c_str(), "Badly formatted mod", 0);
 			}
+		}
 
 	for (fs::path modDir : modDirs)
 	{

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <server/serverchathooks.h>
 
 ModManager* g_pModManager;
 
@@ -382,6 +383,17 @@ void ModManager::LoadMods()
 		for (fs::directory_entry dir : modIterator)
 			if (fs::exists(dir.path() / "mod.json"))
 				modDirs.push_back(dir.path());
+			else
+			{
+				spdlog::warn("Directory {} has no mod.json file.", dir.path().generic_string().c_str());
+				std::string errorMessage = std::format(
+					"The directory {} does not contain a mod.json file.\nMake sure you correctly installed it.",
+					dir.path().generic_string().c_str());
+				MessageBoxA(
+					GetForegroundWindow(), errorMessage.c_str(),
+					"Badly formatted mod",
+					0);
+			}
 
 	for (fs::path modDir : modDirs)
 	{

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -17,7 +17,6 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include <server/serverchathooks.h>
 
 ModManager* g_pModManager;
 


### PR DESCRIPTION
While loading mods, this checks if a `mod.json` file is present in mods directories; if not, this will display a warning message, telling user mod hasn't been installed properly.

This does not analyze hidden directories (with a filename beginning with a `.`).

![image](https://user-images.githubusercontent.com/11993538/216793874-c6578cbe-1e83-416b-aef8-fcc4a70ecc19.png)
