### PR TITLE
make `-norestrictservercommands` command work in Steam

### DIFF
--- a/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
@@ -261,7 +261,7 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 	R2::g_pModName = new char[iSize + 1];
 	strcpy(R2::g_pModName, pModName);
 
-	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !Tier0::CommandLine()->CheckParm("-norestrictservercommands");
+	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !strstr(GetCommandLineA(), "-norestrictservercommands");
 }
 
 // ratelimit stringcmds, and prevent remote clients from calling commands that they shouldn't


### PR DESCRIPTION
When a player buys Titanfall2 in steam and uses Northstar in vanilla, they can't normal play game.
(Example: cannot connect to the match; cannot enter the private match)