### PR TITLE
Fix build errors due to declaration order in scripthttprequesthandler

### DIFF
--- a/NorthstarDLL/scripts/scripthttprequesthandler.cpp
+++ b/NorthstarDLL/scripts/scripthttprequesthandler.cpp
@@ -448,33 +448,6 @@ template <ScriptContext context> int HttpRequestHandler::MakeHttpRequest(const H
 	return handle;
 }
 
-template <ScriptContext context> void HttpRequestHandler::RegisterSQFuncs()
-{
-	g_pSquirrel<context>->AddFuncRegistration(
-		"int",
-		"NS_InternalMakeHttpRequest",
-		"int method, string baseUrl, table<string, array<string> > headers, table<string, array<string> > queryParams, string contentType, "
-		"string body, "
-		"int timeout, string userAgent",
-		"[Internal use only] Passes the HttpRequest struct fields to be reconstructed in native and used for an http request",
-		SQ_InternalMakeHttpRequest<context>);
-
-	g_pSquirrel<context>->AddFuncRegistration(
-		"bool",
-		"NSIsHttpEnabled",
-		"",
-		"Whether or not HTTP requests are enabled. You can opt-out by starting the game with -disablehttprequests.",
-		SQ_IsHttpEnabled<context>);
-
-	g_pSquirrel<context>->AddFuncRegistration(
-		"bool",
-		"NSIsLocalHttpAllowed",
-		"",
-		"Whether or not HTTP requests can be made to a private network address. You can enable this by starting the game with "
-		"-allowlocalhttp.",
-		SQ_IsLocalHttpAllowed<context>);
-}
-
 // int NS_InternalMakeHttpRequest(int method, string baseUrl, table<string, string> headers, table<string, string> queryParams,
 //	string contentType, string body, int timeout, string userAgent)
 template <ScriptContext context> SQRESULT SQ_InternalMakeHttpRequest(HSquirrelVM* sqvm)
@@ -565,6 +538,33 @@ template <ScriptContext context> SQRESULT SQ_IsLocalHttpAllowed(HSquirrelVM* sqv
 {
 	g_pSquirrel<context>->pushbool(sqvm, IsLocalHttpAllowed());
 	return SQRESULT_NOTNULL;
+}
+
+template <ScriptContext context> void HttpRequestHandler::RegisterSQFuncs()
+{
+	g_pSquirrel<context>->AddFuncRegistration(
+		"int",
+		"NS_InternalMakeHttpRequest",
+		"int method, string baseUrl, table<string, array<string> > headers, table<string, array<string> > queryParams, string contentType, "
+		"string body, "
+		"int timeout, string userAgent",
+		"[Internal use only] Passes the HttpRequest struct fields to be reconstructed in native and used for an http request",
+		SQ_InternalMakeHttpRequest<context>);
+
+	g_pSquirrel<context>->AddFuncRegistration(
+		"bool",
+		"NSIsHttpEnabled",
+		"",
+		"Whether or not HTTP requests are enabled. You can opt-out by starting the game with -disablehttprequests.",
+		SQ_IsHttpEnabled<context>);
+
+	g_pSquirrel<context>->AddFuncRegistration(
+		"bool",
+		"NSIsLocalHttpAllowed",
+		"",
+		"Whether or not HTTP requests can be made to a private network address. You can enable this by starting the game with "
+		"-allowlocalhttp.",
+		SQ_IsLocalHttpAllowed<context>);
 }
 
 ON_DLL_LOAD_RELIESON("client.dll", HttpRequestHandler_ClientInit, ClientSquirrel, (CModule module))


### PR DESCRIPTION
e.g., `error C3861: 'SQ_InternalMakeHttpRequest': identifier not found`