### PR TITLE
Use detailed master server error messages when available

### DIFF
--- a/NorthstarDLL/masterserver/masterserver.cpp
+++ b/NorthstarDLL/masterserver/masterserver.cpp
@@ -497,7 +497,9 @@ void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char*
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
 
-					if (authInfoJson["error"].HasMember("enum"))
+					if (authInfoJson["error"].HasMember("msg"))
+						m_sAuthFailureReason = authInfoJson["error"]["msg"].GetString();
+					else if (authInfoJson["error"].HasMember("enum"))
 						m_sAuthFailureReason = authInfoJson["error"]["enum"].GetString();
 					else
 						m_sAuthFailureReason = "No error message provided";
@@ -650,7 +652,9 @@ void MasterServerManager::AuthenticateWithServer(const char* uid, const char* pl
 					spdlog::error("Failed reading masterserver response: got fastify error response");
 					spdlog::error(readBuffer);
 
-					if (connectionInfoJson["error"].HasMember("enum"))
+					if (connectionInfoJson["error"].HasMember("msg"))
+						m_sAuthFailureReason = connectionInfoJson["error"]["msg"].GetString();
+					else if (connectionInfoJson["error"].HasMember("enum"))
 						m_sAuthFailureReason = connectionInfoJson["error"]["enum"].GetString();
 					else
 						m_sAuthFailureReason = "No error message provided";

--- a/NorthstarDLL/masterserver/masterserver.cpp
+++ b/NorthstarDLL/masterserver/masterserver.cpp
@@ -449,6 +449,7 @@ void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char*
 	m_bAuthenticatingWithGameServer = true;
 	m_bScriptAuthenticatingWithGameServer = true;
 	m_bSuccessfullyAuthenticatedWithGameServer = false;
+	m_sAuthFailureReason = "Authentication Failed";
 
 	std::string uidStr(uid);
 	std::string tokenStr(playerToken);
@@ -583,6 +584,7 @@ void MasterServerManager::AuthenticateWithServer(const char* uid, const char* pl
 	m_bAuthenticatingWithGameServer = true;
 	m_bScriptAuthenticatingWithGameServer = true;
 	m_bSuccessfullyAuthenticatedWithGameServer = false;
+	m_sAuthFailureReason = "Authentication Failed";
 
 	std::string uidStr(uid);
 	std::string tokenStr(playerToken);


### PR DESCRIPTION
The error.msg field has always been around, but we never used it.

recommends R2Northstar/NorthstarMods#598 (to show it for server auth as well as self auth)