### PR TITLE
Reject banned players during masterserver auth

### DIFF
--- a/NorthstarDLL/server/auth/serverauthentication.cpp
+++ b/NorthstarDLL/server/auth/serverauthentication.cpp
@@ -74,7 +74,7 @@ void ServerAuthenticationManager::StartPlayerAuthServer()
 					}
 					if (!g_pBanSystem->IsUIDAllowed(uid))
 					{
-						response.set_content("{\"success\":false,\"reject\":\"Banned from server.\"}", "application/json");
+						response.set_content("{\"success\":false,\"reject\":\"Banned from this server.\"}", "application/json");
 						return;
 					}
 
@@ -325,7 +325,7 @@ bool,, (R2::CBaseClient* self, char* pName, void* pNetChannel, char bFakePlayer,
 		if (!g_pServerAuthentication->VerifyPlayerName(pNextPlayerToken, pName, pVerifiedName))
 			pAuthenticationFailure = "Invalid name.";
 		else if (!g_pBanSystem->IsUIDAllowed(iNextPlayerUid))
-			pAuthenticationFailure = "Banned from server.";
+			pAuthenticationFailure = "Banned from this server.";
 		else if (!g_pServerAuthentication->CheckAuthentication(self, iNextPlayerUid, pNextPlayerToken))
 			pAuthenticationFailure = "Authentication failed.";
 	}

--- a/NorthstarDLL/server/auth/serverauthentication.cpp
+++ b/NorthstarDLL/server/auth/serverauthentication.cpp
@@ -62,6 +62,22 @@ void ServerAuthenticationManager::StartPlayerAuthServer()
 						return;
 					}
 
+					uint64_t uid;
+					try
+					{
+						uid = std::strtoull(request.get_param_value("id").c_str(), nullptr, 10);
+					}
+					catch (std::exception const& ex)
+					{
+						response.set_content("{\"success\":false}", "application/json");
+						return;
+					}
+					if (!g_pBanSystem->IsUIDAllowed(uid))
+					{
+						response.set_content("{\"success\":false,\"reject\":\"Banned from server.\"}", "application/json");
+						return;
+					}
+
 					RemoteAuthData newAuthData {};
 					strncpy_s(newAuthData.uid, sizeof(newAuthData.uid), request.get_param_value("id").c_str(), sizeof(newAuthData.uid) - 1);
 					strncpy_s(
@@ -307,11 +323,11 @@ bool,, (R2::CBaseClient* self, char* pName, void* pNetChannel, char bFakePlayer,
 	if (!bFakePlayer)
 	{
 		if (!g_pServerAuthentication->VerifyPlayerName(pNextPlayerToken, pName, pVerifiedName))
-			pAuthenticationFailure = "Invalid Name.";
+			pAuthenticationFailure = "Invalid name.";
 		else if (!g_pBanSystem->IsUIDAllowed(iNextPlayerUid))
-			pAuthenticationFailure = "Banned From server.";
+			pAuthenticationFailure = "Banned from server.";
 		else if (!g_pServerAuthentication->CheckAuthentication(self, iNextPlayerUid, pNextPlayerToken))
-			pAuthenticationFailure = "Authentication Failed.";
+			pAuthenticationFailure = "Authentication failed.";
 	}
 	else // need to copy name for bots still
 		strncpy_s(pVerifiedName, pName, 63);


### PR DESCRIPTION
This is backwards-compatible with old masterserver versions (it will be treated as a general authentication failure).

closes #431 
recommends #433 (client support)
recommends R2Northstar/Atlas#30 (atlas support)
recommends R2Northstar/NorthstarMods#598 (client support)