### PR TITLE
me when case inconsistency

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.h
+++ b/NorthstarDLL/squirrel/squirrel.h
@@ -245,7 +245,7 @@ class SquirrelManagerBase
 		sq_stackinfos(sqvm, 1 + depth, stackInfo);
 		std::string sourceName = stackInfo._sourceName;
 		std::replace(sourceName.begin(), sourceName.end(), '/', '\\');
-		std::string filename = "scripts\\vscripts\\" + sourceName;
+		std::string filename = g_pModManager->NormaliseModFilePath(fs::path("scripts\\vscripts\\" + sourceName));
 		if (auto res = g_pModManager->m_ModFiles.find(filename); res != g_pModManager->m_ModFiles.end())
 		{
 			return res->second.m_pOwningMod;


### PR DESCRIPTION
one line fix baby!

`callingmodfunc` fails when a file path uses uppercase letters, because `ModManager::NormaliseModFilePath` is not used to convert uppercase letters to lowercase ones.

This is the fix.

das it :)