### PR TITLE
CI create release and upload files on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          ls -alh
           zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/*
           zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
       - name: Upload files to release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
             x64/Release/*.pdb
 
   upload-launcher-to-release:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: build-launcher
     runs-on: ubuntu-22.04
     steps:
@@ -68,7 +69,6 @@ jobs:
           zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           body: ":warning: These are development files! If you want to download Northstar, [go here instead](https://github.com/R2Northstar/Northstar/releases) :warning:"
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Build
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run'
+        required: true
+        default: 'build-thunderstore-package'
+
+permissions:
+  contents: write # Needed to write to GitHub draft release
+
+env:
+  NORTHSTAR_VERSION: ${{ github.ref_name }}
+
+jobs:
+  build-launcher:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+      - name: Setup resource file version
+        shell: bash
+        run: |
+          sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarLauncher/resources.rc
+          FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
+          sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDLL/ns_version.h
+      - name: Build
+        run: |
+          msbuild /p:Configuration=Release R2Northstar.sln
+      - name: Upload launcher build as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: northstar-launcher
+          path: |
+            x64/Release/*.dll
+            x64/Release/*.exe
+            x64/Release/*.txt
+      - name: Upload debug build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: launcher-debug-files
+          path: |
+            x64/Release/*.pdb
+
+  upload-launcher-to-release:
+    needs: build-launcher
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download compiled launcher
+        uses: actions/download-artifact@v2
+        with:
+          name: northstar-launcher
+          path: northstar-launcher
+      - name: Download compiled launcher
+        uses: actions/download-artifact@v2
+        with:
+          name: launcher-debug-files
+          path: launcher-debug-files
+      - name: Create zip to upload
+        run: |
+          ls -alh
+          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/*
+          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
+      - name: Upload files to release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(env.NORTHSTAR_VERSION, '-rc')
+        with:
+          body: ":warning: These are development files! If you want to download Northstar, [go here instead](https://github.com/R2Northstar/Northstar/releases) :warning:"
+          draft: false
+          files: |
+            northstar-launcher.zip
+            launcher-debug-files.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/*
-          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
+          zip --recurse-paths --quiet --junk-paths northstar-launcher.zip northstar-launcher/
+          zip --recurse-paths --quiet --junk-paths launcher-debug-files.zip launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(env.NORTHSTAR_VERSION, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v')
         with:
           body: ":warning: These are development files! If you want to download Northstar, [go here instead](https://github.com/R2Northstar/Northstar/releases) :warning:"
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:
-    inputs:
-      job:
-        description: 'Job to run'
-        required: true
-        default: 'build-thunderstore-package'
 
 permissions:
   contents: write # Needed to write to GitHub draft release


### PR DESCRIPTION
On tag creation, this creates a new release and uploads the corresponding compiled launcher and debug files, so that we can just pull the fully compiled binary from [release repo](https://github.com/R2Northstar/Northstar) afterwards instead of having to rebuild it.

This is one puzzle piece in resolving https://github.com/R2Northstar/Northstar/issues/431

For a finished test run of the same code, see
- CI run: https://github.com/GeckoEidechse/Temp-NorthstarLauncher/actions/runs/4374532041
- Uploaded files: https://github.com/GeckoEidechse/Temp-NorthstarLauncher/releases/tag/v0.0.13