### PR TITLE
Bump download-artifact action to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,12 +48,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download compiled launcher
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: northstar-launcher
           path: northstar-launcher
       - name: Download compiled launcher
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: launcher-debug-files
           path: launcher-debug-files


### PR DESCRIPTION
To address a warning currently shown when running the checkout action:

>   Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/download-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

