### PR TITLE
Fix incorrect script ConCommand argc

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -298,11 +298,18 @@ template <ScriptContext context> auto ModConCommandCallback_Internal(std::string
 {
 	if (g_pSquirrel<context>->m_pSQVM && g_pSquirrel<context>->m_pSQVM)
 	{
-		std::vector<std::string> args;
-		args.reserve(command.ArgC());
-		for (int i = 1; i < command.ArgC(); i++)
-			args.push_back(command.Arg(i));
-		g_pSquirrel<context>->AsyncCall(name, args);
+		if (command.ArgC() == 1)
+		{
+			g_pSquirrel<context>->AsyncCall(name);
+		}
+		else
+		{
+			std::vector<std::string> args;
+			args.reserve(command.ArgC());
+			for (int i = 1; i < command.ArgC(); i++)
+				args.push_back(command.Arg(i));
+			g_pSquirrel<context>->AsyncCall(name, args);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

Calling a ConCommand added in `mod.json` (introduced in #373) with 0 args raises an error

```
> concommand_test
> SCRIPT ERROR: [UI] wrong number of parameters (calling ConCommandTest): found 2, expected 1
```
where `ConCommandTest()` is a Squrriel function with **0** argument. `command.ArgC()` is 1 when no arg is inputted to console so wrong args are passed to squirrel.

Here's a example of my mod.json.
```json
"ConCommands": [
	{
	  "Name": "concommand_test",
	  "Function": "ConCommandTest",
	  "Context": "UI",
	  "Flags": 0,
	  "HelpString": "example script concommand"
	}
  ],
```

Tested:
- ConCommand with 0 and 1 arg works fine.

BTW: args passed to squirrel is always a array of string so `command.ArgC()` is always 2 if more than 0 arg is inputted in console. Not the point of this pr but should we change it?
