### PR TITLE
Fix stringcmd limits causing unnecessary disconnects

### DIFF
--- a/NorthstarDLL/shared/exploit_fixes/ns_limits.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/ns_limits.cpp
@@ -56,10 +56,10 @@ bool ServerLimitsManager::CheckStringCommandLimits(R2::CBaseClient* player)
 	if (CVar_sv_quota_stringcmdspersecond->GetInt() != -1)
 	{
 		// note: this isn't super perfect, legit clients can trigger it in lobby if they try, mostly good enough tho imo
-		if (R2::g_pGlobals->m_flCurTime - m_PlayerLimitData[player].lastClientCommandQuotaStart >= 1.0)
+		if (Tier0::Plat_FloatTime() - m_PlayerLimitData[player].lastClientCommandQuotaStart >= 1.0)
 		{
 			// reset quota
-			m_PlayerLimitData[player].lastClientCommandQuotaStart = R2::g_pGlobals->m_flCurTime;
+			m_PlayerLimitData[player].lastClientCommandQuotaStart = Tier0::Plat_FloatTime();
 			m_PlayerLimitData[player].numClientCommandsInQuota = 0;
 		}
 
@@ -76,9 +76,9 @@ bool ServerLimitsManager::CheckStringCommandLimits(R2::CBaseClient* player)
 
 bool ServerLimitsManager::CheckChatLimits(R2::CBaseClient* player)
 {
-	if (R2::g_pGlobals->m_flCurTime - m_PlayerLimitData[player].lastSayTextLimitStart >= 1.0)
+	if (Tier0::Plat_FloatTime() - m_PlayerLimitData[player].lastSayTextLimitStart >= 1.0)
 	{
-		m_PlayerLimitData[player].lastSayTextLimitStart = R2::g_pGlobals->m_flCurTime;
+		m_PlayerLimitData[player].lastSayTextLimitStart = Tier0::Plat_FloatTime();
 		m_PlayerLimitData[player].sayTextLimitCount = 0;
 	}
 
@@ -100,7 +100,7 @@ char, __fastcall, (void* self, void* buf))
 		NETCHANLIMIT_KICK
 	};
 
-	double startTime = R2::g_pGlobals->m_flCurTime;
+	double startTime = Tier0::Plat_FloatTime();
 	char ret = CNetChan__ProcessMessages(self, buf);
 
 	// check processing limits, unless we're in a level transition
@@ -121,7 +121,7 @@ char, __fastcall, (void* self, void* buf))
 			g_pServerLimits->m_PlayerLimitData[sender].lastNetChanProcessingLimitStart = startTime;
 			g_pServerLimits->m_PlayerLimitData[sender].netChanProcessingLimitTime = 0.0;
 		}
-		g_pServerLimits->m_PlayerLimitData[sender].netChanProcessingLimitTime += (R2::g_pGlobals->m_flCurTime * 1000) - (startTime * 1000);
+		g_pServerLimits->m_PlayerLimitData[sender].netChanProcessingLimitTime += (Tier0::Plat_FloatTime() * 1000) - (startTime * 1000);
 
 		if (g_pServerLimits->m_PlayerLimitData[sender].netChanProcessingLimitTime >=
 			g_pServerLimits->Cvar_net_chan_limit_msec_per_sec->GetInt())
@@ -172,12 +172,12 @@ bool, , (void* a1, R2::netpacket_t* packet))
 			memcpy(sendData->ip, packet->adr.ip, 16);
 		}
 
-		if (R2::g_pGlobals->m_flCurTime < sendData->timeoutEnd)
+		if (Tier0::Plat_FloatTime() < sendData->timeoutEnd)
 			return false;
 
-		if (R2::g_pGlobals->m_flCurTime - sendData->lastQuotaStart >= 1.0)
+		if (Tier0::Plat_FloatTime() - sendData->lastQuotaStart >= 1.0)
 		{
-			sendData->lastQuotaStart = R2::g_pGlobals->m_flCurTime;
+			sendData->lastQuotaStart = Tier0::Plat_FloatTime();
 			sendData->packetCount = 0;
 		}
 
@@ -191,7 +191,7 @@ bool, , (void* a1, R2::netpacket_t* packet))
 				packet->data[4]);
 
 			// timeout for a minute
-			sendData->timeoutEnd = R2::g_pGlobals->m_flCurTime + 60.0;
+			sendData->timeoutEnd = Tier0::Plat_FloatTime() + 60.0;
 			return false;
 		}
 	}


### PR DESCRIPTION
reverts some changes made by #411 , specifically to do with replacing Plat_FloatTime

Explanation of why this was a problem yoinked from discord
![image](https://user-images.githubusercontent.com/66967891/230738548-ae8e995d-5889-418d-94d0-624e0687378a.png)

should fix
- https://github.com/R2Northstar/Northstar/issues/448

maybe also fixes
- https://github.com/R2Northstar/Northstar/issues/449 
- https://github.com/R2Northstar/Northstar/issues/450