### PR TITLE
Fix getvector returning garbage data

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.h
+++ b/NorthstarDLL/squirrel/squirrel.h
@@ -223,8 +223,7 @@ class SquirrelManagerBase
 
 	inline Vector3 getvector(HSquirrelVM* sqvm, const SQInteger stackpos)
 	{
-		float* pRet = __sq_getvector(sqvm, stackpos);
-		return *(Vector3*)&pRet;
+		return *(Vector3*)__sq_getvector(sqvm, stackpos);
 	}
 
 	inline int sq_getfunction(HSquirrelVM* sqvm, const char* name, SQObject* returnObj, const char* signature)

--- a/NorthstarDLL/squirrel/squirrelclasstypes.h
+++ b/NorthstarDLL/squirrel/squirrelclasstypes.h
@@ -220,7 +220,7 @@ typedef SQBool (*sq_getboolType)(HSquirrelVM*, SQInteger iStackpos);
 typedef SQRESULT (*sq_getType)(HSquirrelVM* sqvm, SQInteger iStackpos);
 typedef SQRESULT (*sq_getassetType)(HSquirrelVM* sqvm, SQInteger iStackpos, const char** pResult);
 typedef SQRESULT (*sq_getuserdataType)(HSquirrelVM* sqvm, SQInteger iStackpos, void** pData, uint64_t* pTypeId);
-typedef SQFloat* (*sq_getvectorType)(HSquirrelVM* sqvm, SQInteger iStackpos);
+typedef long long* (*sq_getvectorType)(HSquirrelVM* sqvm, SQInteger iStackpos);
 typedef SQBool (*sq_getthisentityType)(HSquirrelVM*, void** ppEntity);
 typedef void (*sq_getobjectType)(HSquirrelVM*, SQInteger iStackPos, SQObject* pOutObj);
 


### PR DESCRIPTION
`sq_getvector+0x6120` returns a pointer to a vector:
```c
longlong sq_getvector(longlong sqvm,int stackpos)

{
  return *(longlong *)(sqvm + 0x48) + 4 + (longlong)stackpos * 0x10;
}
```
This PR fixes the casting in `squirrel.h`