### PR TITLE
Replace `set-output` in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Extract Short Commit Hash
         id: extract
         shell: bash
-        run: echo ::set-output name=commit::`git rev-parse --short HEAD`
+        run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
`set-output` is being deprecated as per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/