### PR TITLE
Fix initscript issue

### DIFF
--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -415,7 +415,7 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 	bool ret = CSquirrelVM_init<context>(vm, realContext, time);
 	for (Mod mod : g_pModManager->m_LoadedMods)
 	{
-		if (mod.initScript.size() != 0)
+		if (mod.m_bEnabled && mod.initScript.size() != 0)
 		{
 			std::string name = mod.initScript.substr(mod.initScript.find_last_of('/') + 1);
 			std::string path = std::string("scripts/vscripts/") + mod.initScript;


### PR DESCRIPTION
fixes the issue described by #456 by adding a check if the mods are actually enabled.

should be checked if there are any side effects from this ( from my testing there doesn't appear to be any )

## how to test this

after installing the pr disable `Northstar.Client` if you crash then the pr doesn't work, script errors will happen (because you disabled a core mod lol)

fixes #456