### PR TITLE
Restore `-noplugins` command arg

### DIFF
--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -207,6 +207,11 @@ bool PluginManager::LoadPlugins()
 	data.version = ns_version.c_str();
 	data.northstarModule = g_NorthstarModule;
 
+	if (strstr(GetCommandLineA(), "-noplugins") != NULL)
+	{
+		NS::log::PLUGINSYS->warn("-noplugins detected; skipping loading plugins");
+		return false;
+	}
 	if (!fs::exists(pluginPath))
 	{
 		NS::log::PLUGINSYS->warn("Could not find a plugins directory. Skipped loading plugins");


### PR DESCRIPTION
this command arg was removed in plugins v2

basically it prevents plugins from being loaded

### testing 
a batch file to start northstar with `-noplugins`
[noplugins-test.zip](https://github.com/R2Northstar/NorthstarLauncher/files/11327229/noplugins-test.zip)
can't upload bat files lol