### PR TITLE
Remove `-vanilla` check

### DIFF
--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -255,12 +255,6 @@ void PrependPath()
 bool ShouldLoadNorthstar(int argc, char* argv[])
 {
 	bool loadNorthstar = true;
-	for (int i = 0; i < argc; i++)
-		if (!strcmp(argv[i], "-vanilla"))
-			loadNorthstar = false;
-
-	if (!loadNorthstar)
-		return loadNorthstar;
 
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");
 	if (runNorthstarFile)


### PR DESCRIPTION
Removes `-vanilla` arg check in launcher as it disables loading of `Northstar.dll` which completely defeats the purpose of launching northstar.

The check also checks for `run_northstar.txt` which seems to have been used for launching on linux. Might be also worth removing as, again, there's no point in not loading `Northstar.dll`