### PR TITLE
Update release action to match push action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/
-          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/
+          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/northstar-launcher/
+          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --quiet --junk-paths northstar-launcher.zip northstar-launcher/
-          zip --recurse-paths --quiet --junk-paths launcher-debug-files.zip launcher-debug-files/
+          zip northstar-launcher.zip northstar-launcher/
+          zip launcher-debug-files.zip launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/northstar-launcher/
-          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/launcher-debug-files/
+          zip -r northstar-launcher.zip northstar-launcher/northstar-launcher/
+          zip -r launcher-debug-files.zip launcher-debug-files/launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,10 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/*
-          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
+          cd northstar-launcher
+          zip --recurse-paths --quiet ../northstar-launcher.zip *
+          cd ../launcher-debug-files
+          zip --recurse-paths --quiet launcher-debug-files.zip *
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,14 @@ jobs:
         with:
           name: launcher-debug-files
           path: launcher-debug-files
-      - name: Create zip to upload
+      - name: Create zip with binaries
         run: |
           cd northstar-launcher
           zip --recurse-paths --quiet ../northstar-launcher.zip *
-          cd ../launcher-debug-files
-          zip --recurse-paths --quiet launcher-debug-files.zip *
+      - name: Create zip with debug symbols
+        run: |
+          cd launcher-debug-files
+          zip --recurse-paths --quiet ../launcher-debug-files.zip *
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip -r northstar-launcher.zip northstar-launcher/*
-          zip -r launcher-debug-files.zip launcher-debug-files/*
+          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/*
+          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/*
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip northstar-launcher.zip northstar-launcher/
-          zip launcher-debug-files.zip launcher-debug-files/
+          zip --recurse-paths --quiet northstar-launcher.zip northstar-launcher/
+          zip --recurse-paths --quiet launcher-debug-files.zip launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip -r northstar-launcher.zip northstar-launcher/northstar-launcher/
-          zip -r launcher-debug-files.zip launcher-debug-files/launcher-debug-files/
+          zip -r northstar-launcher.zip northstar-launcher/*
+          zip -r launcher-debug-files.zip launcher-debug-files/*
       - name: Upload files to release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           name: northstar-launcher
           path: |
-            game/
+            game/*.exe
+            game/*.dll
+            game/bin/x64_retail/*.dll
       - name: Upload debug build artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           path: launcher-debug-files
       - name: Create zip to upload
         run: |
-          zip --recurse-paths --quiet --junk-paths northstar-launcher.zip northstar-launcher/
+          zip --quiet --junk-paths northstar-launcher.zip northstar-launcher/
           zip --recurse-paths --quiet --junk-paths launcher-debug-files.zip launcher-debug-files/
       - name: Upload files to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Currently cmake builds like this:
```
root/
├── NorthstarLauncher.exe
├── Northstar.dll
└── bin/
    └── x64_retail/
        └── wsock32.dll
```

This PR makes the release gh actions zip into the same structure as normal CI builds. It currently puts all binaries into the root of the zip which is inconsistent with building on push.