### PR TITLE
Rename `InitilaseNorthstar` to `Northstar_Init`

### DIFF
--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -32,7 +32,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 	return TRUE;
 }
 
-bool InitialiseNorthstar()
+bool Northstar_Init()
 {
 	static bool bInitialised = false;
 	if (bInitialised)

--- a/NorthstarDLL/dllmain.h
+++ b/NorthstarDLL/dllmain.h
@@ -1,3 +1,3 @@
 #pragma once
 
-extern "C" __declspec(dllexport) bool InitialiseNorthstar();
+extern "C" __declspec(dllexport) bool Northstar_Init();

--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -281,7 +281,7 @@ bool LoadNorthstar()
 		swprintf_s(buffer, L"%s\\Northstar.dll", exePath);
 		hHookModule = LoadLibraryExW(buffer, 0, 8u);
 		if (hHookModule)
-			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
+			Hook_Init = GetProcAddress(hHookModule, "Northstar_Init");
 		if (!hHookModule || Hook_Init == nullptr)
 		{
 			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer);

--- a/loader_wsock32_proxy/dllmain.cpp
+++ b/loader_wsock32_proxy/dllmain.cpp
@@ -41,7 +41,7 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 
 		SetCurrentDirectoryW(exePath);
 
-		if (!ProvisionNorthstar()) // does not call InitialiseNorthstar yet, will do it on LauncherMain hook
+		if (!ProvisionNorthstar()) // does not call Northstar_Init yet, will do it on LauncherMain hook
 			return true;
 
 		// copy the original library for system to our local directory, with changed name so that we can load it

--- a/loader_wsock32_proxy/loader.cpp
+++ b/loader_wsock32_proxy/loader.cpp
@@ -49,7 +49,7 @@ bool LoadNorthstar()
 		swprintf_s(buffer1, L"%s\\Northstar.dll", exePath);
 		auto hHookModule = LoadLibraryExW(buffer1, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
 		if (hHookModule)
-			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
+			Hook_Init = GetProcAddress(hHookModule, "Northstar_Init");
 		if (!hHookModule || Hook_Init == nullptr)
 		{
 			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer1);


### PR DESCRIPTION
Renames `InitilaseNorthstar` to `Northstar_Init`. 

Personally i prefer `<subsystem>_Init` / `<subsystem>_Shutdown` over what we do now. As `InitilaseNorthstar` is exported i made a separate PR.

Unless one is using #451 this shouldnt impact the end user.