### PR TITLE
cast types in MAKEHOOK macro to follow C++ Standard

### DIFF
--- a/NorthstarDLL/core/hooks.h
+++ b/NorthstarDLL/core/hooks.h
@@ -280,7 +280,7 @@ class ManualHook
 	args
 
 void MakeHook(LPVOID pTarget, LPVOID pDetour, void* ppOriginal, const char* pFuncName = "");
-#define MAKEHOOK(pTarget, pDetour, ppOriginal) MakeHook(pTarget, pDetour, ppOriginal, __STR(pDetour))
+#define MAKEHOOK(pTarget, pDetour, ppOriginal) MakeHook((LPVOID)pTarget, (LPVOID)pDetour, (void*)ppOriginal, __STR(pDetour))
 
 class __autovar
 {


### PR DESCRIPTION
various things passed to MAKEHOOK are not of the correct type (LPVOID/void*) so explicitly cast them to follow Standard C++.