### PR TITLE
replace dependent names with explicit template definition

### DIFF
--- a/NorthstarDLL/scripts/scriptdatatables.cpp
+++ b/NorthstarDLL/scripts/scriptdatatables.cpp
@@ -116,7 +116,7 @@ REPLACE_SQFUNC(GetDataTable, (ScriptContext::UI | ScriptContext::CLIENT | Script
 		// first, check the cache
 		if (CSVCache.find(pAssetName) != CSVCache.end())
 		{
-			CSVData** pUserdata = g_pSquirrel<context>->createuserdata<CSVData*>(sqvm, sizeof(CSVData*));
+			CSVData** pUserdata = g_pSquirrel<context>->template createuserdata<CSVData*>(sqvm, sizeof(CSVData*));
 			g_pSquirrel<context>->setuserdatatypeid(sqvm, -1, USERDATA_TYPE_DATATABLE_CUSTOM);
 			*pUserdata = &CSVCache[pAssetName];
 
@@ -251,7 +251,7 @@ REPLACE_SQFUNC(GetDataTable, (ScriptContext::UI | ScriptContext::CLIENT | Script
 			}
 
 			// add to cache and return
-			CSVData** pUserdata = g_pSquirrel<context>->createuserdata<CSVData*>(sqvm, sizeof(CSVData*));
+			CSVData** pUserdata = g_pSquirrel<context>->template createuserdata<CSVData*>(sqvm, sizeof(CSVData*));
 			g_pSquirrel<context>->setuserdatatypeid(sqvm, -1, USERDATA_TYPE_DATATABLE_CUSTOM);
 			CSVCache[pAssetName] = csv;
 			*pUserdata = &CSVCache[pAssetName];

--- a/NorthstarDLL/scripts/server/miscserverscript.cpp
+++ b/NorthstarDLL/scripts/server/miscserverscript.cpp
@@ -9,7 +9,7 @@
 
 ADD_SQFUNC("void", NSEarlyWritePlayerPersistenceForLeave, "entity player", "", ScriptContext::SERVER)
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	if (!pPlayer)
 	{
 		spdlog::warn("NSEarlyWritePlayerPersistenceForLeave got null player");
@@ -38,7 +38,7 @@ ADD_SQFUNC("bool", NSIsWritingPlayerPersistence, "", "", ScriptContext::SERVER)
 
 ADD_SQFUNC("bool", NSIsPlayerLocalPlayer, "entity player", "", ScriptContext::SERVER)
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	if (!pPlayer)
 	{
 		spdlog::warn("NSIsPlayerLocalPlayer got null player");
@@ -65,7 +65,7 @@ ADD_SQFUNC(
 	"Disconnects the player from the server with the given reason",
 	ScriptContext::SERVER)
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<context>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	const char* reason = g_pSquirrel<context>->getstring(sqvm, 2);
 
 	if (!pPlayer)

--- a/NorthstarDLL/scripts/server/scriptuserinfo.cpp
+++ b/NorthstarDLL/scripts/server/scriptuserinfo.cpp
@@ -7,7 +7,7 @@ ADD_SQFUNC("string", GetUserInfoKVString_Internal, "entity player, string key, s
 	"Gets the string value of a given player's userinfo convar by name", ScriptContext::SERVER)
 // clang-format on
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	if (!pPlayer)
 	{
 		g_pSquirrel<ScriptContext::SERVER>->raiseerror(sqvm, "player is null");
@@ -27,7 +27,7 @@ ADD_SQFUNC("asset", GetUserInfoKVAsset_Internal, "entity player, string key, ass
 	"Gets the asset value of a given player's userinfo convar by name", ScriptContext::SERVER)
 // clang-format on
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	if (!pPlayer)
 	{
 		g_pSquirrel<ScriptContext::SERVER>->raiseerror(sqvm, "player is null");
@@ -48,7 +48,7 @@ ADD_SQFUNC("int", GetUserInfoKVInt_Internal, "entity player, string key, int def
 	"Gets the int value of a given player's userinfo convar by name", ScriptContext::SERVER)
 // clang-format on
 {
-	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->getentity<R2::CBasePlayer>(sqvm, 1);
+	const R2::CBasePlayer* pPlayer = g_pSquirrel<ScriptContext::SERVER>->template getentity<R2::CBasePlayer>(sqvm, 1);
 	if (!pPlayer)
 	{
 		g_pSquirrel<ScriptContext::SERVER>->raiseerror(sqvm, "player is null");


### PR DESCRIPTION
some calls to `g_pSquirrel` methods depend on what context is and this may change how `<` is interepreted.

Explicitly labeling it as a template makes it clear to the compiler what it is.