### PR TITLE
Improve `ShouldLoadNorthstar()` logic readability

### DIFF
--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -256,13 +256,9 @@ void PrependPath()
 
 bool ShouldLoadNorthstar(int argc, char* argv[])
 {
-	bool loadNorthstar = true;
 	for (int i = 0; i < argc; i++)
 		if (!strcmp(argv[i], "-vanilla"))
-			loadNorthstar = false;
-
-	if (!loadNorthstar)
-		return loadNorthstar;
+			return false;
 
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");
 	if (runNorthstarFile)
@@ -271,9 +267,9 @@ bool ShouldLoadNorthstar(int argc, char* argv[])
 		runNorthstarFileBuffer << runNorthstarFile.rdbuf();
 		runNorthstarFile.close();
 		if (runNorthstarFileBuffer.str().starts_with("0"))
-			loadNorthstar = false;
+			return false;
 	}
-	return loadNorthstar;
+	return true;
 }
 
 bool LoadNorthstar()


### PR DESCRIPTION
This changes no functionality but just improves the readability of the control flow of the function. Instead of hiding value behind variable that gets updated, explicitly return early based on value.

These lines have triggered me every time I have read over them so far to the point that I got annoyed enough to change them.

(not tested btw but change should be obvious enough to see that the resulting logic is the same)