### PR TITLE
Add OS, Wine and Proton logging

### DIFF
--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -52,9 +52,7 @@ bool InitialiseNorthstar()
 	InitialiseCrashHandler();
 
 	// Write launcher version to log
-	spdlog::info("NorthstarLauncher version: {}", version);
-	spdlog::info("Command line: {}", GetCommandLineA());
-	spdlog::info("Using profile: {}", GetNorthstarPrefix());
+	StartupLog();
 
 	InstallInitialHooks();
 

--- a/NorthstarDLL/logging/logging.cpp
+++ b/NorthstarDLL/logging/logging.cpp
@@ -3,6 +3,7 @@
 #include "core/convar/concommand.h"
 #include "config/profile.h"
 #include "core/tier0.h"
+#include "util/version.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
 #include <iomanip>
@@ -219,4 +220,11 @@ void NS::log::FlushLoggers()
 		logger->flush();
 
 	spdlog::default_logger()->flush();
+}
+
+void StartupLog()
+{
+	spdlog::info("NorthstarLauncher version: {}", version);
+	spdlog::info("Command line: {}", GetCommandLineA());
+	spdlog::info("Using profile: {}", GetNorthstarPrefix());
 }

--- a/NorthstarDLL/logging/logging.cpp
+++ b/NorthstarDLL/logging/logging.cpp
@@ -232,7 +232,7 @@ typedef const char*(CDECL* wine_get_build_id_type)(void);
 wine_get_build_id_type wine_get_build_id;
 
 // Not exported Winapi methods
-typedef NTSTATUS (WINAPI* RtlGetVersion_type)(PRTL_OSVERSIONINFOW);
+typedef NTSTATUS(WINAPI* RtlGetVersion_type)(PRTL_OSVERSIONINFOW);
 RtlGetVersion_type RtlGetVersion;
 
 void StartupLog()

--- a/NorthstarDLL/logging/logging.cpp
+++ b/NorthstarDLL/logging/logging.cpp
@@ -6,6 +6,7 @@
 #include "util/version.h"
 #include "spdlog/sinks/basic_file_sink.h"
 
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 
@@ -222,9 +223,61 @@ void NS::log::FlushLoggers()
 	spdlog::default_logger()->flush();
 }
 
+// Wine specific functions
+typedef const char*(CDECL* wine_get_host_version_type)(const char**, const char**);
+wine_get_host_version_type wine_get_host_version;
+
+typedef const char*(CDECL* wine_get_build_id_type)(void);
+wine_get_build_id_type wine_get_build_id;
+
 void StartupLog()
 {
 	spdlog::info("NorthstarLauncher version: {}", version);
 	spdlog::info("Command line: {}", GetCommandLineA());
 	spdlog::info("Using profile: {}", GetNorthstarPrefix());
+
+	HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+	if (!ntdll)
+	{
+		// How did we get here
+		spdlog::info("Operating System: Unknown");
+		return;
+	}
+
+	wine_get_host_version = (wine_get_host_version_type)GetProcAddress(ntdll, "wine_get_host_version");
+	if (wine_get_host_version)
+	{
+		// Load the rest of the functions we need
+		wine_get_build_id = (wine_get_build_id_type)GetProcAddress(ntdll, "wine_get_build_id");
+
+		const char* sysname;
+		wine_get_host_version(&sysname, NULL);
+
+		spdlog::info("Operating System: {} (Wine)", sysname);
+		spdlog::info("Wine build: {}", wine_get_build_id());
+
+		char* compatToolPtr = std::getenv("STEAM_COMPAT_TOOL_PATHS");
+		if (compatToolPtr)
+		{
+			std::string compatToolPath(compatToolPtr);
+
+			spdlog::info("Proton build: {}", compatToolPath.substr(compatToolPath.rfind("/") + 1));
+		}
+	}
+	else
+	{
+		// We are real Windows (hopefully)
+		const char* win_ver = "Unknown";
+
+		OSVERSIONINFO osvi;
+		BOOL bIsWindowsXPorLater;
+
+		ZeroMemory(&osvi, sizeof(OSVERSIONINFO));
+		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+		GetVersionEx(&osvi);
+
+		// a reference table can be found in the OSVERSIONINFOA documentation
+		// https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
+		spdlog::info("Operating System: Windows (NT{}.{})", osvi.dwMajorVersion, osvi.dwMinorVersion);
+	}
 }

--- a/NorthstarDLL/logging/logging.h
+++ b/NorthstarDLL/logging/logging.h
@@ -7,6 +7,7 @@
 void CreateLogFiles();
 void InitialiseLogging();
 void InitialiseConsole();
+void StartupLog();
 
 class ColoredLogger;
 


### PR DESCRIPTION
Relevant log on Fedora 38 running NorthstarProton 8.1
```
[15:16:48] [NORTHSTAR] [info] NorthstarLauncher version: 0.0.0.1+dev
[15:16:48] [NORTHSTAR] [info] Command line: "Z:\home\sentry\.local\share\Steam\steamapps\common\Titanfall2\Titanfall2.exe"   -northstar --use-gl=osmesa
[15:16:48] [NORTHSTAR] [info] Using profile: R2Northstar
[15:16:48] [NORTHSTAR] [info] Operating System: Linux (Wine)
[15:16:48] [NORTHSTAR] [info] Wine build: wine-8.1.r0.gdde73435 ( TkG Staging Esync Fsync )
[15:16:48] [NORTHSTAR] [info] Proton build: NorthstarProton-8.1-1
```
