### PR TITLE
Add support for loading Thunderstore mods natively

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -413,9 +413,16 @@ void ModManager::LoadMods()
 
 	// Special case for Thunderstore mods dir
 	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	// Set up regex for `AUTHOR-MOD-VERSION` pattern
+	std::regex pattern(R"(.*\\([a-zA-Z0-9_]+)-([a-zA-Z0-9_]+)-(\d+\.\d+\.\d+))");
 	for (fs::directory_entry dir : thunderstoreModsDir)
 	{
 		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
+		// Use regex to match `AUTHOR-MOD-VERSION` pattern
+		if (!std::regex_match(dir.path().string(), pattern)) {
+			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION' {}", modsDir.string());
+			continue; // skip loading mod that doesn't match
+		}
 		if (fs::exists(modsDir) && fs::is_directory(modsDir))
 		{
 			for (fs::directory_entry subDir : fs::directory_iterator(modsDir))

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -419,7 +419,8 @@ void ModManager::LoadMods()
 	{
 		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
 		// Use regex to match `AUTHOR-MOD-VERSION` pattern
-		if (!std::regex_match(dir.path().string(), pattern)) {
+		if (!std::regex_match(dir.path().string(), pattern))
+		{
 			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
 			continue; // skip loading mod that doesn't match
 		}

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -413,7 +413,7 @@ void ModManager::LoadMods()
 				modDirs.push_back(dir.path());
 
 	// Special case for Thunderstore mods dir
-	// for (fs::directory_entry dir : thunderstoreModsDir) // TODO: Use this 
+	// for (fs::directory_entry dir : thunderstoreModsDir) // TODO: Use this
 	for (fs::directory_entry dir : fs::recursive_directory_iterator(GetThunderstoreModFolderPath())) // TODO: remove me, temp
 		if (fs::exists(dir.path() / "mod.json"))
 			modDirs.push_back(dir.path());

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -413,10 +413,16 @@ void ModManager::LoadMods()
 				modDirs.push_back(dir.path());
 
 	// Special case for Thunderstore mods dir
-	// for (fs::directory_entry dir : thunderstoreModsDir) // TODO: Use this
-	for (fs::directory_entry dir : fs::recursive_directory_iterator(GetThunderstoreModFolderPath())) // TODO: remove me, temp
-		if (fs::exists(dir.path() / "mod.json"))
-			modDirs.push_back(dir.path());
+	for (fs::directory_entry dir : thunderstoreModsDir) {
+		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
+		if (fs::exists(modsDir) && fs::is_directory(modsDir)) {
+			for (fs::directory_entry subDir : fs::directory_iterator(modsDir)) {
+				if (fs::exists(subDir.path() / "mod.json")) {
+					modDirs.push_back(subDir.path());
+				}
+			}
+		}
+	}
 
 	for (fs::path modDir : modDirs)
 	{

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -405,7 +405,6 @@ void ModManager::LoadMods()
 	// get mod directories
 	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
-	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 
 	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
 		for (fs::directory_entry dir : modIterator)
@@ -413,6 +412,7 @@ void ModManager::LoadMods()
 				modDirs.push_back(dir.path());
 
 	// Special case for Thunderstore mods dir
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 	for (fs::directory_entry dir : thunderstoreModsDir) {
 		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
 		if (fs::exists(modsDir) && fs::is_directory(modsDir)) {

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -420,7 +420,7 @@ void ModManager::LoadMods()
 		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
 		// Use regex to match `AUTHOR-MOD-VERSION` pattern
 		if (!std::regex_match(dir.path().string(), pattern)) {
-			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION' {}", modsDir.string());
+			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
 			continue; // skip loading mod that doesn't match
 		}
 		if (fs::exists(modsDir) && fs::is_directory(modsDir))

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -413,11 +413,15 @@ void ModManager::LoadMods()
 
 	// Special case for Thunderstore mods dir
 	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
-	for (fs::directory_entry dir : thunderstoreModsDir) {
+	for (fs::directory_entry dir : thunderstoreModsDir)
+	{
 		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
-		if (fs::exists(modsDir) && fs::is_directory(modsDir)) {
-			for (fs::directory_entry subDir : fs::directory_iterator(modsDir)) {
-				if (fs::exists(subDir.path() / "mod.json")) {
+		if (fs::exists(modsDir) && fs::is_directory(modsDir))
+		{
+			for (fs::directory_entry subDir : fs::directory_iterator(modsDir))
+			{
+				if (fs::exists(subDir.path() / "mod.json"))
+				{
 					modDirs.push_back(subDir.path());
 				}
 			}

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -381,6 +381,7 @@ void ModManager::LoadMods()
 	// ensure dirs exist
 	fs::remove_all(GetCompiledAssetsPath());
 	fs::create_directories(GetModFolderPath());
+	fs::create_directories(GetThunderstoreModFolderPath());
 	fs::create_directories(GetRemoteModFolderPath());
 
 	m_DependencyConstants.clear();
@@ -404,11 +405,18 @@ void ModManager::LoadMods()
 	// get mod directories
 	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 
 	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
 		for (fs::directory_entry dir : modIterator)
 			if (fs::exists(dir.path() / "mod.json"))
 				modDirs.push_back(dir.path());
+
+	// Special case for Thunderstore mods dir
+	// for (fs::directory_entry dir : thunderstoreModsDir) // TODO: Use this 
+	for (fs::directory_entry dir : fs::recursive_directory_iterator(GetThunderstoreModFolderPath())) // TODO: remove me, temp
+		if (fs::exists(dir.path() / "mod.json"))
+			modDirs.push_back(dir.path());
 
 	for (fs::path modDir : modDirs)
 	{
@@ -836,6 +844,10 @@ void ConCommand_reload_mods(const CCommand& args)
 fs::path GetModFolderPath()
 {
 	return fs::path(GetNorthstarPrefix() + MOD_FOLDER_SUFFIX);
+}
+fs::path GetThunderstoreModFolderPath()
+{
+	return fs::path(GetNorthstarPrefix() + THUNDERSTORE_MOD_FOLDER_SUFFIX);
 }
 fs::path GetRemoteModFolderPath()
 {

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -9,7 +9,7 @@
 #include <filesystem>
 
 const std::string MOD_FOLDER_SUFFIX = "/mods";
-const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "/thunderstore-mods";
+const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "/packages";
 const std::string REMOTE_MOD_FOLDER_SUFFIX = "/runtime/remote/mods";
 const fs::path MOD_OVERRIDE_DIR = "mod";
 const std::string COMPILED_ASSETS_SUFFIX = "/runtime/compiled";

--- a/NorthstarDLL/mods/modmanager.h
+++ b/NorthstarDLL/mods/modmanager.h
@@ -9,6 +9,7 @@
 #include <filesystem>
 
 const std::string MOD_FOLDER_SUFFIX = "/mods";
+const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "/thunderstore-mods";
 const std::string REMOTE_MOD_FOLDER_SUFFIX = "/runtime/remote/mods";
 const fs::path MOD_OVERRIDE_DIR = "mod";
 const std::string COMPILED_ASSETS_SUFFIX = "/runtime/compiled";
@@ -168,6 +169,7 @@ class ModManager
 
 fs::path GetModFolderPath();
 fs::path GetRemoteModFolderPath();
+fs::path GetThunderstoreModFolderPath();
 fs::path GetCompiledAssetsPath();
 
 extern ModManager* g_pModManager;


### PR DESCRIPTION
This PR allows for loading Thunderstore mods directly from a separate directory (called `thunderstore-mods` rn, I'm happy to change).

It expects a folder that represents the unpacked zip from the mod from Thunderstore. This heavily simplifies mod management as now there's a direct link between Thunderstore mod and Northstar (Thunderstore folder name).

![image](https://github.com/R2Northstar/NorthstarLauncher/assets/40122905/3879c649-6144-46d6-8c16-59f0edf21c7a)


Loading user installed Northstar mods from `R2Northstar/mods/` is still supported for now as mod-managers need to be updated first and as a fallback for mods not on Thunderstore.

Mod-managers could then also take care of moving existing Thunderstore mods from `mods/` to `thunderstore-mods/`

I will take care of notifying mod-manager authors once a decision about merging (or not merging) this PR has been made.

This PR is an initial implementation and could be adapted based on feedback. As a reminder I barely know how to read C++ and simply took existing code as an inspiration. If something's done in a peculiar way, it's most likely not cause I was trying to be "clever" but simply used what worked so please point out anything odd you might see in the code.

Related: https://github.com/R2Northstar/Northstar/issues/472