### PR TITLE
Disable run_northstar.txt using preprocessor

### DIFF
--- a/primedev/primelauncher/main.cpp
+++ b/primedev/primelauncher/main.cpp
@@ -258,6 +258,7 @@ bool ShouldLoadNorthstar(int argc, char* argv[])
 		if (!strcmp(argv[i], "-nonorthstardll"))
 			return false;
 
+#if 0
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");
 	if (runNorthstarFile)
 	{
@@ -267,6 +268,8 @@ bool ShouldLoadNorthstar(int argc, char* argv[])
 		if (runNorthstarFileBuffer.str().starts_with("0"))
 			return false;
 	}
+#endif
+
 	return true;
 }
 

--- a/primedev/wsockproxy/loader.cpp
+++ b/primedev/wsockproxy/loader.cpp
@@ -47,6 +47,7 @@ bool ShouldLoadNorthstar()
 	if (loadNorthstar)
 		return loadNorthstar;
 
+#if 0
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");
 	if (runNorthstarFile)
 	{
@@ -56,6 +57,8 @@ bool ShouldLoadNorthstar()
 		if (!runNorthstarFileBuffer.str().starts_with("0"))
 			loadNorthstar = true;
 	}
+#endif
+
 	return loadNorthstar;
 }
 


### PR DESCRIPTION
Related to #508 

Disables `run_northstar.txt` logic via preprocessors.

The main use case for it has mostly been Linux where steam_helper incorrectly handled arguments.

With NorthstarProton and GE-Proton containing a patch to fix the bug this is mostly a non issue these days.