### PR TITLE
Add support for loading plugins from Thunderstore packages

### DIFF
--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -190,18 +190,23 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 
 inline void findPlugins(fs::path pluginPath, std::vector<fs::path>& paths)
 {
-	if (fs::exists(pluginPath) && fs::is_directory(pluginPath))
+	// ensure dirs exist
+	if (!fs::exists(pluginPath) || !fs::is_directory(pluginPath))
 	{
-		// ensure dirs exist
-		fs::recursive_directory_iterator iterator(pluginPath);
-		if (std::filesystem::begin(iterator) != std::filesystem::end(iterator))
-		{
-			for (auto const& entry : iterator)
-			{
-				if (fs::is_regular_file(entry) && entry.path().extension() == ".dll")
-					paths.emplace_back(entry.path());
-			}
-		}
+		return;
+	}
+
+	fs::recursive_directory_iterator iterator(pluginPath);
+	// ensure iterator is not empty
+	if (std::filesystem::begin(iterator) != std::filesystem::end(iterator))
+	{
+		return;
+	}
+
+	for (auto const& entry : iterator)
+	{
+		if (fs::is_regular_file(entry) && entry.path().extension() == ".dll")
+			paths.emplace_back(entry.path());
 	}
 }
 

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -188,7 +188,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 	return plugin;
 }
 
-inline void findPlugins(fs::path pluginPath, std::vector<fs::path>& paths)
+inline void FindPlugins(fs::path pluginPath, std::vector<fs::path>& paths)
 {
 	// ensure dirs exist
 	if (!fs::exists(pluginPath) || !fs::is_directory(pluginPath))
@@ -235,14 +235,14 @@ bool PluginManager::LoadPlugins()
 	data.version = ns_version.c_str();
 	data.northstarModule = g_NorthstarModule;
 
-	findPlugins(pluginPath, paths);
+	FindPlugins(pluginPath, paths);
 
 	// Special case for Thunderstore plugin dirs
 
 	for (fs::directory_entry dir : fs::directory_iterator(GetThunderstoreModFolderPath()))
 	{
 		fs::path pluginDir = dir.path() / "plugins";
-		findPlugins(pluginDir, paths);
+		FindPlugins(pluginDir, paths);
 	}
 
 	if (paths.empty())


### PR DESCRIPTION
closes #509

reposition things a bit, adds a few more sanity checks and looks for dlls in packages.

Tested with the kyurid plugin.
