### PR TITLE
Set `spewlog_enable` default value to 0

### DIFF
--- a/NorthstarDLL/logging/loghooks.cpp
+++ b/NorthstarDLL/logging/loghooks.cpp
@@ -249,7 +249,7 @@ ON_DLL_LOAD_RELIESON("engine.dll", EngineSpewFuncHooks, ConVar, (CModule module)
 {
 	AUTOHOOK_DISPATCH_MODULE(engine.dll)
 
-	Cvar_spewlog_enable = new ConVar("spewlog_enable", "1", FCVAR_NONE, "Enables/disables whether the engine spewfunc should be logged");
+	Cvar_spewlog_enable = new ConVar("spewlog_enable", "0", FCVAR_NONE, "Enables/disables whether the engine spewfunc should be logged");
 }
 
 ON_DLL_LOAD_CLIENT_RELIESON("client.dll", ClientPrintHooks, ConVar, (CModule module))


### PR DESCRIPTION
Closes [#506](https://github.com/R2Northstar/Northstar/issues/506)

Would like to add a launch arg in the future ( smth like `-nsdev` ) that would enable all log funcs and other features.

This log call can sometimes slow the game down