### PR TITLE
Remove `ns_startup_args*.txt` functionality

### DIFF
--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -388,19 +388,13 @@ int main(int argc, char* argv[])
 	{
 		PrependPath();
 
-		if (!fs::exists("ns_startup_args.txt"))
+		if (fs::exists("ns_startup_args.txt"))
 		{
-			std::ofstream file("ns_startup_args.txt");
-			std::string defaultArgs = "-multiple";
-			file.write(defaultArgs.c_str(), defaultArgs.length());
-			file.close();
+			std::cout << "[*] WARNING: 'ns_startup_args.txt' is no longer supported!" << std::endl;
 		}
-		if (!fs::exists("ns_startup_args_dedi.txt"))
+		if (fs::exists("ns_startup_args_dedi.txt"))
 		{
-			std::ofstream file("ns_startup_args_dedi.txt");
-			std::string defaultArgs = "+setplaylist private_match";
-			file.write(defaultArgs.c_str(), defaultArgs.length());
-			file.close();
+			std::cout << "[*] WARNING: 'ns_startup_args_dedi.txt' is no longer supported!" << std::endl;
 		}
 
 		std::cout << "[*] Loading tier0.dll" << std::endl;


### PR DESCRIPTION
Removes `ns_startup_args*.txt` functionality as discussed at #507 

Main reason for doing this is getting rid of having to hook `GetCommandLineA`, which meant some args would only work when passed directly to the exe.