### PR TITLE
Remove `pch.cpp` and all `#include "pch.h"` occurrences 

### DIFF
--- a/NorthstarDLL/dedicated/dedicatedlogtoclient.cpp
+++ b/NorthstarDLL/dedicated/dedicatedlogtoclient.cpp
@@ -1,4 +1,3 @@
-#include "pch.h"
 #include "dedicatedlogtoclient.h"
 #include "engine/r2engine.h"
 

--- a/NorthstarDLL/mods/modsavefiles.cpp
+++ b/NorthstarDLL/mods/modsavefiles.cpp
@@ -1,4 +1,3 @@
-#include "pch.h"
 #include <filesystem>
 #include <sstream>
 #include <fstream>

--- a/NorthstarDLL/pch.cpp
+++ b/NorthstarDLL/pch.cpp
@@ -1,5 +1,0 @@
-// pch.cpp: source file corresponding to the pre-compiled header
-
-#include "pch.h"
-
-// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/NorthstarDLL/plugins/pluginbackend.cpp
+++ b/NorthstarDLL/plugins/pluginbackend.cpp
@@ -1,4 +1,3 @@
-#include "pch.h"
 #include "pluginbackend.h"
 #include "plugin_abi.h"
 #include "server/serverpresence.h"

--- a/NorthstarDLL/plugins/pluginbackend.h
+++ b/NorthstarDLL/plugins/pluginbackend.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "pch.h"
 #include "plugin_abi.h"
 #include "shared/gamepresence.h"
 

--- a/NorthstarDLL/scripts/scriptjson.h
+++ b/NorthstarDLL/scripts/scriptjson.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "pch.h"
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
 #include "rapidjson/stringbuffer.h"

--- a/NorthstarDLL/shared/gamepresence.cpp
+++ b/NorthstarDLL/shared/gamepresence.cpp
@@ -1,5 +1,3 @@
-#include "pch.h"
-
 #include "gamepresence.h"
 #include "plugins/pluginbackend.h"
 #include "plugins/plugins.h"

--- a/NorthstarDLL/shared/gamepresence.h
+++ b/NorthstarDLL/shared/gamepresence.h
@@ -1,6 +1,5 @@
-
 #pragma once
-#include "pch.h"
+
 #include "server/serverpresence.h"
 
 class GameStateServerPresenceReporter : public ServerPresenceReporter

--- a/loader_wsock32_proxy/CMakeLists.txt
+++ b/loader_wsock32_proxy/CMakeLists.txt
@@ -6,8 +6,6 @@ add_library(loader_wsock32_proxy SHARED
             "dllmain.cpp"
             "loader.cpp"
             "loader.h"
-            "pch.cpp"
-            "pch.h"
             "wsock32.asm"
             "wsock32.def"
 )

--- a/loader_wsock32_proxy/dllmain.cpp
+++ b/loader_wsock32_proxy/dllmain.cpp
@@ -1,4 +1,3 @@
-#include "pch.h"
 #include "loader.h"
 
 #include <shlwapi.h>

--- a/loader_wsock32_proxy/loader.cpp
+++ b/loader_wsock32_proxy/loader.cpp
@@ -1,4 +1,3 @@
-#include "pch.h"
 #include "loader.h"
 #include <string>
 #include <system_error>

--- a/loader_wsock32_proxy/pch.cpp
+++ b/loader_wsock32_proxy/pch.cpp
@@ -1,5 +1,0 @@
-// pch.cpp: source file corresponding to the pre-compiled header
-
-#include "pch.h"
-
-// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.


### PR DESCRIPTION
With the move to cmake there is no need for the `pch.cpp` files as it generates them automatically.

Also removes leftover `#include "pch.h"` occurrences 