### PR TITLE
Make sure `packages` dir exists when loading plugins

### DIFF
--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -211,6 +211,8 @@ bool PluginManager::LoadPlugins()
 		return false;
 	}
 
+	fs::create_directories(GetThunderstoreModFolderPath());
+
 	std::vector<fs::path> paths;
 
 	pluginPath = GetNorthstarPrefix() + "/plugins";


### PR DESCRIPTION
Fixes a crash introduced in #513 which occured when no `<Profile>/packages` dir was present

fs::create_directories doesnt throw when the dir already exists so its safe calling this in both PluginManager and ModManager