### PR TITLE
Validate package pattern before checking for plugins

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <regex>
 
 ModManager* g_pModManager;
 

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -628,7 +628,7 @@ void ModManager::LoadMods()
 		// Use regex to match `AUTHOR-MOD-VERSION` pattern
 		if (!std::regex_match(dir.path().string(), pattern))
 		{
-			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
+			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
 			continue; // skip loading mod that doesn't match
 		}
 		if (fs::exists(modsDir) && fs::is_directory(modsDir))

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -246,7 +246,7 @@ bool PluginManager::LoadPlugins()
 			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
 			continue; // skip loading package that doesn't match
 		}
-		FindPlugins(pluginDir, paths);
+		FindPlugins(pluginsDir, paths);
 	}
 
 	if (paths.empty())

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -7,6 +7,7 @@
 #include "core/convar/convar.h"
 #include "server/serverpresence.h"
 #include <optional>
+#include <regex>
 
 #include "util/version.h"
 #include "pluginbackend.h"

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -216,7 +216,7 @@ bool PluginManager::LoadPlugins()
 
 	std::vector<fs::path> paths;
 
-	pluginPath = GetNorthstarPrefix() + "/plugins";
+	pluginPath = GetNorthstarPrefix() + "\\plugins";
 
 	PluginNorthstarData data {};
 	std::string ns_version {version};

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -243,7 +243,7 @@ bool PluginManager::LoadPlugins()
 		// Use regex to match `AUTHOR-MOD-VERSION` pattern
 		if (!std::regex_match(dir.path().string(), pattern))
 		{
-			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
+			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
 			continue; // skip loading package that doesn't match
 		}
 		FindPlugins(pluginsDir, paths);

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -232,11 +232,19 @@ bool PluginManager::LoadPlugins()
 
 	FindPlugins(pluginPath, paths);
 
-	// Special case for Thunderstore plugin dirs
-
-	for (fs::directory_entry dir : fs::directory_iterator(GetThunderstoreModFolderPath()))
+	// Special case for Thunderstore mods dir
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	// Set up regex for `AUTHOR-MOD-VERSION` pattern
+	std::regex pattern(R"(.*\\([a-zA-Z0-9_]+)-([a-zA-Z0-9_]+)-(\d+\.\d+\.\d+))");
+	for (fs::directory_entry dir : thunderstoreModsDir)
 	{
-		fs::path pluginDir = dir.path() / "plugins";
+		fs::path pluginsDir = dir.path() / "plugins";
+		// Use regex to match `AUTHOR-MOD-VERSION` pattern
+		if (!std::regex_match(dir.path().string(), pattern))
+		{
+			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", modsDir.string());
+			continue; // skip loading package that doesn't match
+		}
 		FindPlugins(pluginDir, paths);
 	}
 


### PR DESCRIPTION
Closes #524

Added the package pattern to validate if the package is actually valid, copied the code structure from `modmanager.cpp` so its easier to catch anything misbehaving.