### PR TITLE
Support DLLs in Profile from wsock32 proxy

### DIFF
--- a/loader_wsock32_proxy/loader.cpp
+++ b/loader_wsock32_proxy/loader.cpp
@@ -44,18 +44,53 @@ bool LoadNorthstar()
 {
 	FARPROC Hook_Init = nullptr;
 	{
-		swprintf_s(buffer1, L"%s\\Northstar.dll", exePath);
-		auto hHookModule = LoadLibraryExW(buffer1, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+		std::string strProfile = "R2Northstar";
+		char* clachar = strstr(GetCommandLineA(), "-profile=");
+		if (clachar)
+		{
+			std::string cla = std::string(clachar);
+			if (strncmp(cla.substr(9, 1).c_str(), "\"", 1))
+			{
+				int space = cla.find(" ");
+				std::string dirname = cla.substr(9, space - 9);
+				std::cout << "[*] Found profile in command line arguments: " << dirname << std::endl;
+				strProfile = dirname.c_str();
+			}
+			else
+			{
+				std::string quote = "\"";
+				int quote1 = cla.find(quote);
+				int quote2 = (cla.substr(quote1 + 1)).find(quote);
+				std::string dirname = cla.substr(quote1 + 1, quote2);
+				std::cout << "[*] Found profile in command line arguments: " << dirname << std::endl;
+				strProfile = dirname;
+			}
+		}
+		else
+		{
+			std::cout << "[*] Profile was not found in command line arguments. Using default: R2Northstar" << std::endl;
+			strProfile = "R2Northstar";
+		}
+
+		// Check if "Northstar.dll" exists in profile directory, if it doesnt fall back to root
+		swprintf_s(buffer, L"%s\\%s\\Northstar.dll", exePath, std::wstring(strProfile.begin(), strProfile.end()).c_str());
+
+		if (!fs::exists(fs::path(buffer)))
+			swprintf_s(buffer, L"%s\\Northstar.dll", exePath);
+
+		std::wcout << L"[*] Using: " << buffer << std::endl;
+
+		hHookModule = LoadLibraryExW(buffer, 0, 8u);
 		if (hHookModule)
 			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
 		if (!hHookModule || Hook_Init == nullptr)
 		{
-			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer1);
+			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer);
 			return false;
 		}
 	}
-
 	((bool (*)())Hook_Init)();
+
 	return true;
 }
 

--- a/loader_wsock32_proxy/loader.cpp
+++ b/loader_wsock32_proxy/loader.cpp
@@ -4,6 +4,9 @@
 #include <sstream>
 #include <fstream>
 #include <filesystem>
+#include <iostream>
+
+namespace fs = std::filesystem;
 
 void LibraryLoadError(DWORD dwMessageId, const wchar_t* libName, const wchar_t* location)
 {
@@ -72,6 +75,8 @@ bool LoadNorthstar()
 			strProfile = "R2Northstar";
 		}
 
+		wchar_t buffer[8192];
+
 		// Check if "Northstar.dll" exists in profile directory, if it doesnt fall back to root
 		swprintf_s(buffer, L"%s\\%s\\Northstar.dll", exePath, std::wstring(strProfile.begin(), strProfile.end()).c_str());
 
@@ -80,7 +85,7 @@ bool LoadNorthstar()
 
 		std::wcout << L"[*] Using: " << buffer << std::endl;
 
-		hHookModule = LoadLibraryExW(buffer, 0, 8u);
+		HMODULE hHookModule = LoadLibraryExW(buffer, 0, 8u);
 		if (hHookModule)
 			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
 		if (!hHookModule || Hook_Init == nullptr)


### PR DESCRIPTION
The wsock32 proxy didn't support loading Northstar.dll from a profile, for some reason.

This PR copies the function from NorthstarLauncher, which prior for #451 had the exact same code.