### PR TITLE
Add a safeguard to map command

### DIFF
--- a/NorthstarDLL/core/filesystem/filesystem.h
+++ b/NorthstarDLL/core/filesystem/filesystem.h
@@ -19,19 +19,7 @@ OFFSET_STRUCT(VPKFileEntry)
 // clang-format on
 #pragma pack(pop)
 
-#pragma pack(push, 1)
-// clang-format off
-struct VPKData
-{
-	STRUCT_SIZE(0x50);
-	FIELDS(0x0,
-		char* directory;
-		char* filename;
-		char* extension;
-	)
-};
-// clang-format on
-#pragma pack(pop)
+struct VPKData;
 
 enum SearchPathAdd_t
 {

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -31,7 +31,7 @@ struct MapVPKInfo
 // our current list of maps in the game
 std::vector<MapVPKInfo> vMapList;
 
-FnCommandCallback_t OrignalMapCommand = NULL;
+FnCommandCallback_t OriginalMapCommand = NULL;
 
 void RefreshMapList()
 {
@@ -186,20 +186,16 @@ void ConCommand_maps(const CCommand& args)
 
 void ConCommand_map(const CCommand& args)
 {
-	if (args.ArgC() > 1)
-	{
-		RefreshMapList();
+	RefreshMapList();
 
-		const char* arg = args.Arg(1);
-		auto f = [&](MapVPKInfo map) -> bool { return map.name == arg; };
-		if (std::find_if(vMapList.begin(), vMapList.end(), f) == vMapList.end())
-		{
-			spdlog::info("Invalid map found");
-			return;
-		}
+	if (args.ArgC() > 1 &&
+		std::find_if(vMapList.begin(), vMapList.end(), [&](MapVPKInfo map) -> bool { return map.name == args.Arg(1); }) == vMapList.end())
+	{
+		spdlog::warn("Map load failed: {} not found or invalid", args.Arg(1));
+		return;
 	}
 
-	OrignalMapCommand(args);
+	OriginalMapCommand(args);
 }
 
 void InitialiseMapsPrint()
@@ -210,6 +206,6 @@ void InitialiseMapsPrint()
 	mapsCommand->m_pCommandCallback = ConCommand_maps;
 
 	ConCommand* mapCommand = R2::g_pCVar->FindCommand("map");
-	OrignalMapCommand = mapCommand->m_pCommandCallback;
+	OriginalMapCommand = mapCommand->m_pCommandCallback;
 	mapCommand->m_pCommandCallback = ConCommand_map;
 }

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -209,7 +209,7 @@ AUTOHOOK(Host_Map_f, engine.dll + 0x15B340, void, __fastcall, (const CCommand& a
 	if (*R2::g_pServerState >= R2::server_state_t::ss_active)
 		return Host_Changelevel_f(args);
 	else
-		return Host_Map_helper(args, std::nullptr_t());
+		return Host_Map_helper(args, nullptr);
 }
 
 void InitialiseMapsPrint()

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -188,6 +188,8 @@ void ConCommand_map(const CCommand& args)
 {
 	if (args.ArgC() > 1)
 	{
+		RefreshMapList();
+
 		const char* arg = args.Arg(1);
 		auto f = [&](MapVPKInfo map) -> bool { return map.name == arg; };
 		if (std::find_if(vMapList.begin(), vMapList.end(), f) == vMapList.end())

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -194,6 +194,10 @@ void ConCommand_map(const CCommand& args)
 		spdlog::warn("Map load failed: {} not found or invalid", args.Arg(1));
 		return;
 	}
+	else
+	{
+		spdlog::warn("Map load failed: no map name provided");
+	}
 
 	OriginalMapCommand(args);
 }


### PR DESCRIPTION
adds safeguard to the map command that prevents it from executing if the map is invalid.

I wanted to implement this originally as a plugin but I think it might be quite useful for everyone.

![image](https://github.com/R2Northstar/NorthstarLauncher/assets/41955154/ea9038f0-86c4-4b34-9fc3-55e69f86208a)

 