### PR TITLE
feat: Enforce Thunderstore format for remote mods

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -612,32 +612,36 @@ void ModManager::LoadMods()
 	// get mod directories
 	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 
 	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
 		for (fs::directory_entry dir : modIterator)
 			if (fs::exists(dir.path() / "mod.json"))
 				modDirs.push_back(dir.path());
 
-	// Special case for Thunderstore mods dir
-	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	// Special case for Thunderstore and remote mods directories
 	// Set up regex for `AUTHOR-MOD-VERSION` pattern
 	std::regex pattern(R"(.*\\([a-zA-Z0-9_]+)-([a-zA-Z0-9_]+)-(\d+\.\d+\.\d+))");
-	for (fs::directory_entry dir : thunderstoreModsDir)
+
+	for (fs::directory_iterator dirIterator : {thunderstoreModsDir, remoteModsDir})
 	{
-		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
-		// Use regex to match `AUTHOR-MOD-VERSION` pattern
-		if (!std::regex_match(dir.path().string(), pattern))
+		for (fs::directory_entry dir : dirIterator)
 		{
-			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
-			continue; // skip loading mod that doesn't match
-		}
-		if (fs::exists(modsDir) && fs::is_directory(modsDir))
-		{
-			for (fs::directory_entry subDir : fs::directory_iterator(modsDir))
+			fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
+			// Use regex to match `AUTHOR-MOD-VERSION` pattern
+			if (!std::regex_match(dir.path().string(), pattern))
 			{
-				if (fs::exists(subDir.path() / "mod.json"))
+				spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
+				continue; // skip loading mod that doesn't match
+			}
+			if (fs::exists(modsDir) && fs::is_directory(modsDir))
+			{
+				for (fs::directory_entry subDir : fs::directory_iterator(modsDir))
 				{
-					modDirs.push_back(subDir.path());
+					if (fs::exists(subDir.path() / "mod.json"))
+					{
+						modDirs.push_back(subDir.path());
+					}
 				}
 			}
 		}

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -614,10 +614,9 @@ void ModManager::LoadMods()
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
 	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 
-	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
-		for (fs::directory_entry dir : modIterator)
-			if (fs::exists(dir.path() / "mod.json"))
-				modDirs.push_back(dir.path());
+	for (fs::directory_entry dir : classicModsDir)
+		if (fs::exists(dir.path() / "mod.json"))
+			modDirs.push_back(dir.path());
 
 	// Special case for Thunderstore and remote mods directories
 	// Set up regex for `AUTHOR-MOD-VERSION` pattern


### PR DESCRIPTION
Implements https://github.com/R2Northstar/NorthstarLauncher/pull/503 for remote mods (*i.e.* mods located in the `%profile%/runtime/remote/mods` directory), expecting them to be named after the `AUTHOR-MOD-VERSION` pattern.

### Testing this

Put mods respecting the Thunderstore format in the remote mods directory, and they should be loaded and usable just like mods located in the `packages` directory.