### PR TITLE
Convar print commands

### DIFF
--- a/NorthstarDLL/util/printcommands.cpp
+++ b/NorthstarDLL/util/printcommands.cpp
@@ -160,14 +160,50 @@ void ConCommand_findflags(const CCommand& arg)
 	delete[] upperFlag;
 }
 
+void ConCommand_list(const CCommand& arg)
+{
+	for (auto& map : R2::g_pCVar->DumpToMap())
+	{
+		PrintCommandHelpDialogue(map.second, map.second->m_pszName);
+	}
+}
+
+void ConCommand_differences(const CCommand& arg)
+{
+	for (auto& map : R2::g_pCVar->DumpToMap())
+	{
+		ConVar* cvar = R2::g_pCVar->FindVar(map.second->m_pszName);
+		if (cvar && strcmp(cvar->GetString(), "FCVAR_NEVER_AS_STRING") != NULL)
+		{
+			if (strcmp(cvar->GetString(), cvar->m_pszDefaultValue) != NULL)
+			{
+				PrintCommandHelpDialogue(map.second, map.second->m_pszName);
+				spdlog::info("Current Value: {}", cvar->m_Value.m_pszString);
+				spdlog::info("Default Value: {}", cvar->m_pszDefaultValue);
+			}
+		}
+	}
+}
+
 void InitialiseCommandPrint()
 {
-	RegisterConCommand("find", ConCommand_find, "Find concommands with the specified string in their name/help text.", FCVAR_NONE);
-	RegisterConCommand("findflags", ConCommand_findflags, "Find concommands by flags.", FCVAR_NONE);
+	RegisterConCommand("convar_find", ConCommand_find, "Find concommands with the specified string in their name/help text.", FCVAR_NONE);
 
-	// help is already a command, so we need to modify the preexisting command to use our func instead
+	// these commands already exist, so we need to modify the preexisting command to use our func instead
 	// and clear the flags also
 	ConCommand* helpCommand = R2::g_pCVar->FindCommand("help");
 	helpCommand->m_nFlags = FCVAR_NONE;
 	helpCommand->m_pCommandCallback = ConCommand_help;
+
+	ConCommand* findCommand = R2::g_pCVar->FindCommand("convar_findByFlags");
+	findCommand->m_nFlags = FCVAR_NONE;
+	findCommand->m_pCommandCallback = ConCommand_findflags;
+
+	ConCommand* listCommand = R2::g_pCVar->FindCommand("convar_list");
+	listCommand->m_nFlags = FCVAR_NONE;
+	listCommand->m_pCommandCallback = ConCommand_list;
+
+	ConCommand* diffCommand = R2::g_pCVar->FindCommand("convar_differences");
+	diffCommand->m_nFlags = FCVAR_NONE;
+	diffCommand->m_pCommandCallback = ConCommand_differences;
 }

--- a/NorthstarDLL/util/printcommands.cpp
+++ b/NorthstarDLL/util/printcommands.cpp
@@ -209,7 +209,8 @@ void ConCommand_differences(const CCommand& arg)
 
 void InitialiseCommandPrint()
 {
-	RegisterConCommand("convar_find", ConCommand_find, "Find concommands with the specified string in their name/help text.", FCVAR_NONE);
+	RegisterConCommand(
+		"convar_find", ConCommand_find, "Find convars/concommands with the specified string in their name/help text.", FCVAR_NONE);
 
 	// these commands already exist, so we need to modify the preexisting command to use our func instead
 	// and clear the flags also

--- a/NorthstarDLL/util/printcommands.cpp
+++ b/NorthstarDLL/util/printcommands.cpp
@@ -237,24 +237,26 @@ void ConCommand_differences(const CCommand& arg)
 			continue;
 		}
 
-		if (strcmp(cvar->GetString(), cvar->m_pszDefaultValue) != NULL)
+		if (strcmp(cvar->GetString(), cvar->m_pszDefaultValue) == NULL)
 		{
-			std::string formatted =
-				fmt::format("\"{}\" = \"{}\" ( def. \"{}\" )", cvar->GetBaseName(), cvar->GetString(), cvar->m_pszDefaultValue);
-
-			if (cvar->m_bHasMin)
-			{
-				formatted.append(fmt::format(" min. {}", cvar->m_fMinVal));
-			}
-
-			if (cvar->m_bHasMax)
-			{
-				formatted.append(fmt::format(" max. {}", cvar->m_fMaxVal));
-			}
-
-			formatted.append(fmt::format(" - {}", cvar->GetHelpText()));
-			spdlog::info(formatted);
+			continue;
 		}
+
+		std::string formatted =
+			fmt::format("\"{}\" = \"{}\" ( def. \"{}\" )", cvar->GetBaseName(), cvar->GetString(), cvar->m_pszDefaultValue);
+
+		if (cvar->m_bHasMin)
+		{
+			formatted.append(fmt::format(" min. {}", cvar->m_fMinVal));
+		}
+
+		if (cvar->m_bHasMax)
+		{
+			formatted.append(fmt::format(" max. {}", cvar->m_fMaxVal));
+		}
+
+		formatted.append(fmt::format(" - {}", cvar->GetHelpText()));
+		spdlog::info(formatted);
 	}
 }
 

--- a/NorthstarDLL/util/printcommands.cpp
+++ b/NorthstarDLL/util/printcommands.cpp
@@ -3,16 +3,6 @@
 #include "core/convar/convar.h"
 #include "core/convar/concommand.h"
 
-std::vector<std::pair<std::string, ConCommandBase*>> ConvarSort(std::unordered_map<std::string, ConCommandBase*> map)
-{
-	std::vector<std::pair<std::string, ConCommandBase*>> sorted(map.begin(), map.end());
-	std::sort(
-		sorted.begin(),
-		sorted.end(),
-		[](std::pair<std::string, ConCommandBase*>& a, std::pair<std::string, ConCommandBase*>& b) { return a.first < b.first; });
-	return sorted;
-}
-
 void PrintCommandHelpDialogue(const ConCommandBase* command, const char* name)
 {
 	if (!command)
@@ -107,18 +97,16 @@ void ConCommand_find(const CCommand& arg)
 
 	ConCommandBase* var;
 	CCVarIteratorInternal* itint = R2::g_pCVar->FactoryInternalIterator();
-	std::unordered_map<std::string, ConCommandBase*> unsortedConvars;
+	std::map<std::string, ConCommandBase*> sorted;
 	for (itint->SetFirst(); itint->IsValid(); itint->Next())
 	{
 		var = itint->Get();
 		if (!var->IsFlagSet(FCVAR_DEVELOPMENTONLY) && !var->IsFlagSet(FCVAR_HIDDEN))
 		{
-			unsortedConvars.insert({var->m_pszName, var});
+			sorted.insert({var->m_pszName, var});
 		}
 	}
 	delete itint;
-
-	std::vector<std::pair<std::string, ConCommandBase*>> sorted = ConvarSort(unsortedConvars);
 
 	for (auto& map : sorted)
 	{
@@ -178,18 +166,16 @@ void ConCommand_findflags(const CCommand& arg)
 
 	ConCommandBase* var;
 	CCVarIteratorInternal* itint = R2::g_pCVar->FactoryInternalIterator();
-	std::unordered_map<std::string, ConCommandBase*> unsortedConvars;
+	std::map<std::string, ConCommandBase*> sorted;
 	for (itint->SetFirst(); itint->IsValid(); itint->Next())
 	{
 		var = itint->Get();
 		if (!var->IsFlagSet(FCVAR_DEVELOPMENTONLY) && !var->IsFlagSet(FCVAR_HIDDEN))
 		{
-			unsortedConvars.insert({var->m_pszName, var});
+			sorted.insert({var->m_pszName, var});
 		}
 	}
 	delete itint;
-
-	std::vector<std::pair<std::string, ConCommandBase*>> sorted = ConvarSort(unsortedConvars);
 
 	for (auto& map : sorted)
 	{
@@ -204,18 +190,16 @@ void ConCommand_list(const CCommand& arg)
 {
 	ConCommandBase* var;
 	CCVarIteratorInternal* itint = R2::g_pCVar->FactoryInternalIterator();
-	std::unordered_map<std::string, ConCommandBase*> unsortedConvars;
+	std::map<std::string, ConCommandBase*> sorted;
 	for (itint->SetFirst(); itint->IsValid(); itint->Next())
 	{
 		var = itint->Get();
 		if (!var->IsFlagSet(FCVAR_DEVELOPMENTONLY) && !var->IsFlagSet(FCVAR_HIDDEN))
 		{
-			unsortedConvars.insert({var->m_pszName, var});
+			sorted.insert({var->m_pszName, var});
 		}
 	}
 	delete itint;
-
-	std::vector<std::pair<std::string, ConCommandBase*>> sorted = ConvarSort(unsortedConvars);
 
 	for (auto& map : sorted)
 	{
@@ -227,18 +211,16 @@ void ConCommand_differences(const CCommand& arg)
 {
 	ConCommandBase* var;
 	CCVarIteratorInternal* itint = R2::g_pCVar->FactoryInternalIterator();
-	std::unordered_map<std::string, ConCommandBase*> unsortedConvars;
+	std::map<std::string, ConCommandBase*> sorted;
 	for (itint->SetFirst(); itint->IsValid(); itint->Next())
 	{
 		var = itint->Get();
 		if (!var->IsFlagSet(FCVAR_DEVELOPMENTONLY) && !var->IsFlagSet(FCVAR_HIDDEN))
 		{
-			unsortedConvars.insert({var->m_pszName, var});
+			sorted.insert({var->m_pszName, var});
 		}
 	}
 	delete itint;
-
-	std::vector<std::pair<std::string, ConCommandBase*>> sorted = ConvarSort(unsortedConvars);
 
 	for (auto& map : sorted)
 	{

--- a/NorthstarDLL/util/printcommands.cpp
+++ b/NorthstarDLL/util/printcommands.cpp
@@ -11,6 +11,7 @@ std::vector<std::pair<std::string, ConCommandBase*>> ConvarSort(std::unordered_m
 		[](std::pair<std::string, ConCommandBase*>& a, std::pair<std::string, ConCommandBase*>& b) { return a.first < b.first; });
 	return sorted;
 }
+
 void PrintCommandHelpDialogue(const ConCommandBase* command, const char* name)
 {
 	if (!command)


### PR DESCRIPTION
Adds various concommands such as 
- `convar_findByFlags`
- `convar_list`
- `convar_differences`
- `convar_find`

The first 3 listed above are already registered as concommands natively but didn't seem to do anything when tested.
`convar_findByFlags` and `convar_find` were already implemented by Bob under the names `findflags` and `find` respectively but the names have been changed to reflect already existing convars. 

All outputs into the console are also alphabetically sorted.
![image](https://github.com/R2Northstar/NorthstarLauncher/assets/97146561/b8edcb8c-dbc2-434a-a1fe-0938ad3327bf)
