### PR TITLE
Always allow the local player through the banlist

### DIFF
--- a/NorthstarDLL/server/auth/bansystem.cpp
+++ b/NorthstarDLL/server/auth/bansystem.cpp
@@ -3,6 +3,7 @@
 #include "core/convar/concommand.h"
 #include "server/r2server.h"
 #include "engine/r2engine.h"
+#include "client/r2client.h"
 #include "config/profile.h"
 
 #include <filesystem>
@@ -172,6 +173,10 @@ void ServerBanSystem::UnbanUID(uint64_t uid)
 
 bool ServerBanSystem::IsUIDAllowed(uint64_t uid)
 {
+	uint64_t localPlayerUserID = strtoull(R2::g_pLocalPlayerUserID, nullptr, 10);
+	if (localPlayerUserID == uid)
+		return true;
+
 	ReloadBanlist(); // Reload to have up to date list on join
 	return std::find(m_vBannedUids.begin(), m_vBannedUids.end(), uid) == m_vBannedUids.end();
 }


### PR DESCRIPTION
closes #163

The local player (host) should be exempt from the banlist. Note that this doesn't remove the local player through the banlist, it simply doesn't check if they are banned or not