### PR TITLE
Use 4th digit in version number for CI build number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 env:
   BUILD_PROFILE: Release
+  NORTHSTAR_VERSION: 0.0.0.${{github.run_number}}
 
 jobs:
   build:
@@ -16,6 +17,12 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure cmake
         run: cmake -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="${{ env.BUILD_PROFILE }}"
+      - name: Setup resource file version
+        shell: bash
+        run: |
+          sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarLauncher/resources.rc
+          FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
+          sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDLL/ns_version.h
       - name: Build
         run: cmake --build .
       - name: Extract Short Commit Hash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         shell: bash
         run: |
           sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarLauncher/resources.rc
+          sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarDLL/resources.rc
           FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
           sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDLL/ns_version.h
       - name: Build

--- a/NorthstarDLL/util/version.cpp
+++ b/NorthstarDLL/util/version.cpp
@@ -11,9 +11,9 @@ void InitialiseVersion()
 	int ua_len = 0;
 
 	// We actually use the rightmost integer do determine whether or not we're a debug/dev build
-	// If it is set to 1, we are a dev build
-	// On github CI, we set this 1 to a 0 automatically as we replace the 0,0,0,1 with the real version number
-	if (northstar_version[3] == 1)
+	// If it is set to a non-zero value, we are a dev build
+	// On github CI, we set this to a 0 automatically as we replace the 0,0,0,1 with the real version number
+	if (northstar_version[3])
 	{
 		sprintf(version, "%d.%d.%d.%d+dev", northstar_version[0], northstar_version[1], northstar_version[2], northstar_version[3]);
 		ua_len += snprintf(


### PR DESCRIPTION
closes #369

example of working CI:
https://github.com/ASpoonPlaysGames/NorthstarLauncher/actions/runs/6076234977