### PR TITLE
Inital native code for verified mod auto-downloading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,6 @@
 	path = thirdparty/minhook
 	url = https://github.com/TsudaKageyu/minhook
 	ignore = untracked
+[submodule "thirdparty/minizip"]
+	path = thirdparty/minizip
+	url = https://github.com/zlib-ng/minizip-ng.git

--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 find_package(minhook REQUIRED)
 find_package(libcurl REQUIRED)
+find_package(minizip REQUIRED)
 
 add_library(NorthstarDLL SHARED
             "client/audio.cpp"
@@ -154,6 +155,7 @@ add_library(NorthstarDLL SHARED
 target_link_libraries(NorthstarDLL PRIVATE
                       minhook
                       libcurl
+					  minizip
                       WS2_32.lib
                       Crypt32.lib
                       Cryptui.lib

--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(NorthstarDLL SHARED
             "logging/sourceconsole.h"
             "masterserver/masterserver.cpp"
             "masterserver/masterserver.h"
+            "mods/autodownload/moddownloader.h"
+            "mods/autodownload/moddownloader.cpp"
             "mods/compiled/kb_act.cpp"
             "mods/compiled/modkeyvalues.cpp"
             "mods/compiled/modpdef.cpp"
@@ -149,8 +151,7 @@ add_library(NorthstarDLL SHARED
             "audio_asm.asm"
             "dllmain.cpp"
             "dllmain.h"
-            "ns_version.h"
- "mods/autodownload/moddownloader.h" "mods/autodownload/moddownloader.cpp")
+            "ns_version.h")
 
 target_link_libraries(NorthstarDLL PRIVATE
                       minhook

--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -157,7 +157,7 @@ add_library(NorthstarDLL SHARED
 target_link_libraries(NorthstarDLL PRIVATE
                       minhook
                       libcurl
-					  minizip
+                      minizip
                       WS2_32.lib
                       Crypt32.lib
                       Cryptui.lib

--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -151,7 +151,8 @@ add_library(NorthstarDLL SHARED
             "audio_asm.asm"
             "dllmain.cpp"
             "dllmain.h"
-            "ns_version.h")
+            "ns_version.h"
+)
 
 target_link_libraries(NorthstarDLL PRIVATE
                       minhook

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -217,7 +217,12 @@ void ModDownloader::ExtractMod(fs::path modPath)
 			// ...else create file
 			else
 			{
-				// TODO create file
+				// Ensure file is in zip archive
+				if (unzLocateFile(file, filename_inzip, 0) != UNZ_OK)
+				{
+					spdlog::error("File \"{}\" was not found in archive.", filename_inzip);
+					return;
+				}
 			}
 		}
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -131,8 +131,10 @@ REQUEST_END_CLEANUP:
 
 std::optional<fs::path> ModDownloader::FetchModFromDistantStore(std::string_view modName, std::string_view modVersion)
 {
+	// Retrieve mod prefix from local mods list, or use mod name as mod prefix if bypass flag is set
+	std::string modPrefix = strstr(GetCommandLineA(), VERIFICATION_FLAG) ? modName.data() : verifiedMods[modName.data()].dependencyPrefix;
 	// Build archive distant URI
-	std::string archiveName = std::format("{}-{}.zip", verifiedMods[modName.data()].dependencyPrefix, modVersion.data());
+	std::string archiveName = std::format("{}-{}.zip", modPrefix, modVersion.data());
 	std::string url = STORE_URL + archiveName;
 	spdlog::info(std::format("Fetching mod archive from {}", url));
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -165,16 +165,27 @@ void ModDownloader::DownloadMod(char* modName, char* modVersion)
 		return;
 	}
 
-	// Download mod archive
-	std::string expectedHash = "TODO";
-	fs::path archiveLocation = FetchModFromDistantStore(modName, modVersion);
-	if (!IsModLegit(archiveLocation, (char*)expectedHash.c_str()))
-	{
-		spdlog::warn("Archive hash does not match expected checksum, aborting.");
-		return;
-	}
+	std::thread requestThread(
+		[this, modName, modVersion]()
+		{
+			// Download mod archive
+			std::string expectedHash = "TODO";
+			fs::path archiveLocation = FetchModFromDistantStore(modName, modVersion);
+			if (!IsModLegit(archiveLocation, (char*)expectedHash.c_str()))
+			{
+				spdlog::warn("Archive hash does not match expected checksum, aborting.");
+				return;
+			}
 
-	// TODO extract mod archive
+			spdlog::info("Hash OK");
+
+			// TODO extract mod archive
+
+		REQUEST_END_CLEANUP:
+			spdlog::info("ok");
+		});
+
+	requestThread.detach();
 }
 
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -135,7 +135,8 @@ fs::path ModDownloader::FetchModFromDistantStore(char* modName, char* modVersion
 
 bool ModDownloader::IsModLegit(fs::path modPath, char* expectedChecksum)
 {
-	return false;
+	// TODO implement
+	return true;
 }
 
 bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
@@ -162,15 +163,13 @@ void ModDownloader::DownloadMod(char* modName, char* modVersion)
 		[this, modName, modVersion]()
 		{
 			// Download mod archive
-			std::string expectedHash = "TODO";
+			std::string expectedHash = verifiedMods[modName].versions[modVersion].checksum;
 			fs::path archiveLocation = FetchModFromDistantStore(modName, modVersion);
 			if (!IsModLegit(archiveLocation, (char*)expectedHash.c_str()))
 			{
 				spdlog::warn("Archive hash does not match expected checksum, aborting.");
 				return;
 			}
-
-			spdlog::info("Hash OK");
 
 			// TODO extract mod archive
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -271,7 +271,7 @@ cleanup:
 	return false;
 }
 
-bool ModDownloader::IsModAuthorized(std::string modName, std::string modVersion)
+bool ModDownloader::IsModAuthorized(std::string_view modName, std::string_view modVersion)
 {
 	if (strstr(GetCommandLineA(), VERIFICATION_FLAG))
 	{
@@ -279,13 +279,13 @@ bool ModDownloader::IsModAuthorized(std::string modName, std::string modVersion)
 		return true;
 	}
 
-	if (!verifiedMods.contains(modName))
+	if (!verifiedMods.contains(modName.data()))
 	{
 		return false;
 	}
 
-	std::unordered_map<std::string, VerifiedModVersion> versions = verifiedMods[modName].versions;
-	return versions.count(modVersion) != 0;
+	std::unordered_map<std::string, VerifiedModVersion> versions = verifiedMods[modName.data()].versions;
+	return versions.count(modVersion.data()) != 0;
 }
 
 void ModDownloader::ExtractMod(fs::path modPath)
@@ -448,7 +448,7 @@ EXTRACTION_CLEANUP:
 void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 {
 	// Check if mod can be auto-downloaded
-	if (!IsModAuthorized(modName, modVersion))
+	if (!IsModAuthorized(std::string_view(modName), std::string_view(modVersion)))
 	{
 		spdlog::warn("Tried to download a mod that is not verified, aborting.");
 		return;

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -65,7 +65,7 @@ void ModDownloader::FetchModsListFromAPI()
 					assert(attribute.IsObject());
 					std::string version = attribute["Version"].GetString();
 					std::string checksum = attribute["Checksum"].GetString();
-					modVersions.push_back({.version = (char*)version.c_str(), .checksum = (char*)checksum.c_str()});
+					modVersions.push_back({.version = version, .checksum = checksum});
 				}
 
 				VerifiedModDetails modConfig = {.dependencyPrefix = (char*)dependency.c_str(), .versions = modVersions};
@@ -94,7 +94,7 @@ bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
 		versions.begin(),
 		versions.end(),
 		std::back_inserter(matchingVersions),
-		[modVersion](VerifiedModVersion v) { return strcmp(modVersion, v.version) == 0; });
+		[modVersion](VerifiedModVersion v) { return strcmp(modVersion, v.version.c_str()) == 0; });
 
 	return matchingVersions.size() != 0;
 }

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -3,7 +3,8 @@
 
 ModDownloader* g_pModDownloader;
 
-ModDownloader::ModDownloader() {
+ModDownloader::ModDownloader()
+{
 	spdlog::info("Mod downloaded initialized");
 	modState = {};
 }
@@ -72,11 +73,11 @@ void ModDownloader::FetchModsListFromAPI()
 				spdlog::info("==> Loaded configuration for mod \"" + name + "\"");
 			}
 
-			spdlog::info("Done loading verified mods list."); 
+			spdlog::info("Done loading verified mods list.");
 
 		REQUEST_END_CLEANUP:
 			curl_easy_cleanup(easyhandle);
-	});
+		});
 	requestThread.detach();
 }
 
@@ -88,5 +89,6 @@ void ConCommand_fetch_verified_mods(const CCommand& args)
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {
 	g_pModDownloader = new ModDownloader();
-	RegisterConCommand("fetch_verified_mods", ConCommand_fetch_verified_mods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
+	RegisterConCommand(
+		"fetch_verified_mods", ConCommand_fetch_verified_mods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
 }

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -88,7 +88,7 @@ size_t write_data(void* ptr, size_t size, size_t nmemb, FILE* stream)
 	return written;
 }
 
-fs::path ModDownloader::FetchModFromDistantStore(char* modName, char* modVersion)
+fs::path ModDownloader::FetchModFromDistantStore(std::string modName, std::string modVersion)
 {
 	// Build archive distant URI
 	std::string archiveName = std::format("{}-{}.zip", verifiedMods[modName].dependencyPrefix, modVersion);
@@ -134,13 +134,13 @@ fs::path ModDownloader::FetchModFromDistantStore(char* modName, char* modVersion
 	return downloadPath;
 }
 
-bool ModDownloader::IsModLegit(fs::path modPath, char* expectedChecksum)
+bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
 {
 	// TODO implement
 	return true;
 }
 
-bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
+bool ModDownloader::IsModAuthorized(std::string modName, std::string modVersion)
 {
 	if (!verifiedMods.contains(modName))
 	{
@@ -151,7 +151,7 @@ bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
 	return versions.count(modVersion) != 0;
 }
 
-void ModDownloader::DownloadMod(char* modName, char* modVersion)
+void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 {
 	// Check if mod can be auto-downloaded
 	if (!IsModAuthorized(modName, modVersion))
@@ -166,7 +166,7 @@ void ModDownloader::DownloadMod(char* modName, char* modVersion)
 			// Download mod archive
 			std::string expectedHash = verifiedMods[modName].versions[modVersion].checksum;
 			fs::path archiveLocation = FetchModFromDistantStore(modName, modVersion);
-			if (!IsModLegit(archiveLocation, (char*)expectedHash.c_str()))
+			if (!IsModLegit(archiveLocation, expectedHash))
 			{
 				spdlog::warn("Archive hash does not match expected checksum, aborting.");
 				return;
@@ -200,8 +200,8 @@ void ConCommand_is_mod_verified(const CCommand& args)
 	while (ss >> buf)
 		tokens.push_back(buf);
 
-	char* modName = (char*)tokens[0].c_str();
-	char* modVersion = (char*)tokens[1].c_str();
+	std::string modName = tokens[0];
+	std::string modVersion = tokens[1];
 	bool result = g_pModDownloader->IsModAuthorized(modName, modVersion);
 	std::string msg = std::format("Mod \"{}\" (version {}) is verified: {}", modName, modVersion, result);
 	spdlog::info(msg);
@@ -221,8 +221,8 @@ void ConCommand_download_mod(const CCommand& args)
 	while (ss >> buf)
 		tokens.push_back(buf);
 
-	char* modName = (char*)tokens[0].c_str();
-	char* modVersion = (char*)tokens[1].c_str();
+	std::string modName = tokens[0];
+	std::string modVersion = tokens[1];
 	g_pModDownloader->DownloadMod(modName, modVersion);
 }
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -97,6 +97,7 @@ fs::path ModDownloader::FetchModFromDistantStore(char* modName, char* modVersion
 
 	// Download destination
 	std::filesystem::path downloadPath = std::filesystem::temp_directory_path() / archiveName;
+	spdlog::info(std::format("Downloading archive to {}", downloadPath.generic_string()));
 
 	// Download the actual archive
 	std::thread requestThread(

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -150,7 +150,7 @@ std::optional<fs::path> ModDownloader::FetchModFromDistantStore(std::string_view
 	return f.get();
 }
 
-bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
+bool ModDownloader::IsModLegit(fs::path modPath, std::string_view expectedChecksum)
 {
 	if (strstr(GetCommandLineA(), VERIFICATION_FLAG))
 	{
@@ -251,7 +251,7 @@ bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
 		ss << std::hex << std::setw(2) << static_cast<int>(hash.data()[i]);
 	}
 
-	spdlog::info("Expected checksum: {}", expectedChecksum);
+	spdlog::info("Expected checksum: {}", expectedChecksum.data());
 	spdlog::info("Computed checksum: {}", ss.str());
 	return expectedChecksum.compare(ss.str()) == 0;
 
@@ -468,7 +468,7 @@ void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 				goto REQUEST_END_CLEANUP;
 			}
 			archiveLocation = fetchingResult.value();
-			if (!IsModLegit(archiveLocation, expectedHash))
+			if (!IsModLegit(archiveLocation, std::string_view(expectedHash)))
 			{
 				spdlog::warn("Archive hash does not match expected checksum, aborting.");
 				goto REQUEST_END_CLEANUP;

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -347,7 +347,6 @@ void ModDownloader::ExtractMod(fs::path modPath)
 					goto EXTRACTION_CLEANUP;
 				}
 			}
-
 			// ...else create file
 			else
 			{

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -196,7 +196,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 			if (!std::filesystem::exists(fileDestination.parent_path()))
 			{
 				spdlog::warn("Parent directory does not exist for file {}, creating it.", fileDestination.generic_string());
-				if (!std::filesystem::create_directories(fileDestination.parent_path(), ec))
+				if (!std::filesystem::create_directories(fileDestination.parent_path(), ec) && ec.value() != 0)
 				{
 					spdlog::error("Parent directory ({}) creation failed.", fileDestination.parent_path().generic_string());
 					return;
@@ -207,7 +207,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 			if (fileDestination.generic_string().back() == '/')
 			{
 				// Create directory
-				if (!std::filesystem::create_directory(fileDestination, ec))
+				if (!std::filesystem::create_directory(fileDestination, ec) && ec.value() != 0)
 				{
 					spdlog::error("Directory creation failed: {}", ec.message());
 					return;

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -358,7 +358,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 				}
 
 				// Create file
-				int bufferSize;
+				int bufferSize = 8192;
 				void* buffer;
 				int err = UNZ_OK;
 				FILE* fout = NULL;
@@ -380,7 +380,6 @@ void ModDownloader::ExtractMod(fs::path modPath)
 				}
 
 				// Allocate memory for buffer
-				bufferSize = 8192;
 				buffer = (void*)malloc(bufferSize);
 				if (buffer == NULL)
 				{

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -15,7 +15,7 @@ ModDownloader* g_pModDownloader;
 
 ModDownloader::ModDownloader()
 {
-	spdlog::info("Mod downloaded initialized");
+	spdlog::info("Mod downloader initialized");
 	modState = {};
 }
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -339,27 +339,6 @@ void ConCommandFetchVerifiedMods(const CCommand& args)
 	g_pModDownloader->FetchModsListFromAPI();
 }
 
-void ConCommandIsModVerified(const CCommand& args)
-{
-	if (args.ArgC() < 3)
-	{
-		return;
-	}
-
-	// Split arguments string by whitespaces (https://stackoverflow.com/a/5208977)
-	std::string buffer;
-	std::stringstream ss(args.ArgS());
-	std::vector<std::string> tokens;
-	while (ss >> buffer)
-		tokens.push_back(buffer);
-
-	std::string modName = tokens[0];
-	std::string modVersion = tokens[1];
-	bool result = g_pModDownloader->IsModAuthorized(modName, modVersion);
-	std::string msg = std::format("Mod \"{}\" (version {}) is verified: {}", modName, modVersion, result);
-	spdlog::info(msg);
-}
-
 void ConCommandDownloadMod(const CCommand& args)
 {
 	if (args.ArgC() < 3)
@@ -383,6 +362,5 @@ ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module)
 {
 	g_pModDownloader = new ModDownloader();
 	RegisterConCommand("fetch_verified_mods", ConCommandFetchVerifiedMods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
-	RegisterConCommand("is_mod_verified", ConCommandIsModVerified, "checks if a mod is included in verified mods list", FCVAR_NONE);
 	RegisterConCommand("download_mod", ConCommandDownloadMod, "downloads a mod from remote store", FCVAR_NONE);
 }

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -164,6 +164,7 @@ bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
 	std::vector<uint8_t> hash;
 	DWORD hashLength = 0;
 	DWORD resultLength = 0;
+	std::stringstream ss;
 
 	constexpr size_t bufferSize {1 << 12};
 	std::vector<char> buffer(bufferSize, '\0');
@@ -243,10 +244,16 @@ bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
 		goto cleanup;
 	}
 
-	spdlog::info("Expected checksum: {}", expectedChecksum);
-	spdlog::info("Computed checksum: {}", (char*)hash.data());
+	// Convert hash to string using bytes raw values
+	ss << std::hex << std::setfill('0');
+	for (int i = 0; i < hashLength; i++)
+	{
+		ss << std::hex << std::setw(2) << static_cast<int>(hash.data()[i]);
+	}
 
-	// TODO compare hash
+	spdlog::info("Expected checksum: {}", expectedChecksum);
+	spdlog::info("Computed checksum: {}", ss.str());
+	return expectedChecksum.compare(ss.str()) == 0;
 
 cleanup:
 	if (NULL != hashHandle)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -187,9 +187,39 @@ void ModDownloader::ExtractMod(fs::path modPath)
 		status = unzGetCurrentFileInfo64(file, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
 
 		// Extract file
-		fs::path fileDestination = modDirectory / filename_inzip;
-		spdlog::info("{}", fileDestination.generic_string());
+		{
+			std::error_code ec;
+			fs::path fileDestination = modDirectory / filename_inzip;
+			spdlog::info("{}", fileDestination.generic_string());
 
+			// Create parent directory if needed
+			if (!std::filesystem::exists(fileDestination.parent_path()))
+			{
+				spdlog::warn("Parent directory does not exist for file {}, creating it.", fileDestination.generic_string());
+				if (!std::filesystem::create_directories(fileDestination.parent_path(), ec))
+				{
+					spdlog::error("Parent directory ({}) creation failed.", fileDestination.parent_path().generic_string());
+					return;
+				}
+			}
+
+			// If current file is a directory, create directory...
+			if (fileDestination.generic_string().back() == '/')
+			{
+				// Create directory
+				if (!std::filesystem::create_directory(fileDestination, ec))
+				{
+					spdlog::error("Directory creation failed: {}", ec.message());
+					return;
+				}
+			}
+
+			// ...else create file
+			else
+			{
+				// TODO create file
+			}
+		}
 
 		// Go to next file
 		if ((i + 1) < gi.number_entry)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -230,6 +230,13 @@ void ModDownloader::ExtractMod(fs::path modPath)
 				int err = UNZ_OK;
 				FILE* fout = NULL;
 
+				// Open zip file to prepare its extraction
+				status = unzOpenCurrentFile(file);
+				if (status != UNZ_OK)
+				{
+					spdlog::error("Could not open file {} from archive.", filename_inzip);
+				}
+
 				// Create destination file
 				fout = fopen(fileDestination.generic_string().c_str(), "wb");
 				if (fout == NULL)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -277,7 +277,6 @@ void ModDownloader::ExtractMod(fs::path modPath)
 				if (err != UNZ_OK)
 				{
 					spdlog::error("An error occurred during file extraction (code: {})", err);
-					
 				}
 				err = unzCloseCurrentFile(file);
 				if (err != UNZ_OK)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -285,7 +285,8 @@ void ModDownloader::ExtractMod(fs::path modPath)
 						spdlog::error("error {} with zipfile in unzCloseCurrentFile", err);
 					}
 				}
-				else {
+				else
+				{
 					spdlog::info("yo? {}", err);
 					unzCloseCurrentFile(file);
 				}

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -303,7 +303,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 	unz_global_info64 gi;
 	int status;
 	status = unzGetGlobalInfo64(file, &gi);
-	if (file != UNZ_OK)
+	if (status != UNZ_OK)
 	{
 		spdlog::error("Failed getting information from archive (error code: {})", status);
 	}

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -16,7 +16,6 @@ ModDownloader* g_pModDownloader;
 ModDownloader::ModDownloader()
 {
 	spdlog::info("Mod downloader initialized");
-	modState = {};
 }
 
 size_t WriteToString(void* ptr, size_t size, size_t count, void* stream)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -68,9 +68,8 @@ void ModDownloader::FetchModsListFromAPI()
 				std::unordered_map<std::string, VerifiedModVersion> modVersions;
 				rapidjson::Value& versions = i->value["Versions"];
 				assert(versions.IsArray());
-				for (rapidjson::Value::ConstValueIterator itr = versions.Begin(); itr != versions.End(); ++itr)
+				for (auto& attribute : versions.GetArray())
 				{
-					const rapidjson::Value& attribute = *itr;
 					assert(attribute.IsObject());
 					std::string version = attribute["Version"].GetString();
 					std::string checksum = attribute["Checksum"].GetString();

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -175,12 +175,21 @@ void ModDownloader::ExtractMod(fs::path modPath)
 		spdlog::error("Failed getting information from archive (error code: {})", status);
 	}
 
+	// Mod directory name (removing the ".zip" fom the archive name)
+	std::string name = modPath.filename().string();
+	name = name.substr(0, name.length() - 4);
+	fs::path modDirectory = GetRemoteModFolderPath() / name;
+
 	for (int i = 0; i < gi.number_entry; i++)
 	{
 		char filename_inzip[256];
 		unz_file_info64 file_info;
 		status = unzGetCurrentFileInfo64(file, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
-		spdlog::info("{}", filename_inzip);
+
+		// Extract file
+		fs::path fileDestination = modDirectory / filename_inzip;
+		spdlog::info("{}", fileDestination.generic_string());
+
 
 		// Go to next file
 		if ((i + 1) < gi.number_entry)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -382,8 +382,7 @@ void ConCommandDownloadMod(const CCommand& args)
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {
 	g_pModDownloader = new ModDownloader();
-	RegisterConCommand(
-		"fetch_verified_mods", ConCommandFetchVerifiedMods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
+	RegisterConCommand("fetch_verified_mods", ConCommandFetchVerifiedMods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
 	RegisterConCommand("is_mod_verified", ConCommandIsModVerified, "checks if a mod is included in verified mods list", FCVAR_NONE);
 	RegisterConCommand("download_mod", ConCommandDownloadMod, "downloads a mod from remote store", FCVAR_NONE);
 }

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -16,6 +16,34 @@ ModDownloader* g_pModDownloader;
 ModDownloader::ModDownloader()
 {
 	spdlog::info("Mod downloader initialized");
+
+	// Initialise mods list URI
+	char* clachar = strstr(GetCommandLineA(), CUSTOM_MODS_URL_FLAG);
+	if (clachar)
+	{
+		std::string url;
+		int iFlagStringLength = strlen(CUSTOM_MODS_URL_FLAG);
+		std::string cla = std::string(clachar);
+		if (strncmp(cla.substr(iFlagStringLength, 1).c_str(), "\"", 1))
+		{
+			int space = cla.find(" ");
+			url = cla.substr(iFlagStringLength, space - iFlagStringLength);
+		}
+		else
+		{
+			std::string quote = "\"";
+			int quote1 = cla.find(quote);
+			int quote2 = (cla.substr(quote1 + 1)).find(quote);
+			url = cla.substr(quote1 + 1, quote2);
+		}
+		spdlog::info("Found custom verified mods URL in command line argument: {}", url);
+		modsListUrl = strdup(url.c_str());
+	}
+	else
+	{
+		spdlog::info("Custom verified mods URL not found in command line arguments, using default URL.");
+		modsListUrl = strdup(DEFAULT_MODS_LIST_URL);
+	}
 }
 
 size_t WriteToString(void* ptr, size_t size, size_t count, void* stream)
@@ -32,7 +60,7 @@ void ModDownloader::FetchModsListFromAPI()
 			CURLcode result;
 			CURL* easyhandle;
 			rapidjson::Document verifiedModsJson;
-			std::string url = MODS_LIST_URL;
+			std::string url = modsListUrl;
 
 			curl_global_init(CURL_GLOBAL_ALL);
 			easyhandle = curl_easy_init();

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -99,6 +99,29 @@ bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
 	return matchingVersions.size() != 0;
 }
 
+void ModDownloader::DownloadMod(char* modName, char* modVersion)
+{
+	// Check if mod can be auto-downloaded
+	if (!IsModAuthorized(modName, modVersion))
+	{
+		spdlog::warn("Tried to download a mod that is not verified, aborting.");
+		return;
+	}
+
+	// Download mod archive
+	std::string expectedHash = "TODO";
+	fs::path archiveLocation = FetchModFromDistantStore(modName, modVersion);
+	if (!IsModLegit(archiveLocation, (char*)expectedHash.c_str()))
+	{
+		spdlog::info("Archive hash does not match expected checksum, aborting.");
+		return;
+	}
+
+	// TODO extract mod archive
+}
+
+
+
 void ConCommand_fetch_verified_mods(const CCommand& args)
 {
 	g_pModDownloader->FetchModsListFromAPI();

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -68,7 +68,7 @@ void ModDownloader::FetchModsListFromAPI()
 					modVersions.push_back({.version = version, .checksum = checksum});
 				}
 
-				VerifiedModDetails modConfig = {.dependencyPrefix = (char*)dependency.c_str(), .versions = modVersions};
+				VerifiedModDetails modConfig = {.dependencyPrefix = dependency, .versions = modVersions};
 				verifiedMods.insert({name, modConfig});
 				spdlog::info("==> Loaded configuration for mod \"" + name + "\"");
 			}

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -190,12 +190,12 @@ void ModDownloader::ExtractMod(fs::path modPath)
 		{
 			std::error_code ec;
 			fs::path fileDestination = modDirectory / filename_inzip;
-			spdlog::info("{}", fileDestination.generic_string());
+			spdlog::info("=> {}", fileDestination.generic_string());
 
 			// Create parent directory if needed
 			if (!std::filesystem::exists(fileDestination.parent_path()))
 			{
-				spdlog::warn("Parent directory does not exist for file {}, creating it.", fileDestination.generic_string());
+				spdlog::info("Parent directory does not exist, creating it.", fileDestination.generic_string());
 				if (!std::filesystem::create_directories(fileDestination.parent_path(), ec) && ec.value() != 0)
 				{
 					spdlog::error("Parent directory ({}) creation failed.", fileDestination.parent_path().generic_string());
@@ -265,30 +265,24 @@ void ModDownloader::ExtractMod(fs::path modPath)
 					}
 					if (err > 0)
 					{
-						spdlog::info("oi oi oi {}", buf);
 						if (fwrite(buf, (unsigned)err, 1, fout) != 1)
 						{
 							spdlog::error("error in writing extracted file\n");
 							err = UNZ_ERRNO;
 							break;
 						}
-						spdlog::info("fwrite result: {}", err);
 					}
 				} while (err > 0);
 
-				if (err == UNZ_OK)
+				if (err != UNZ_OK)
 				{
-					spdlog::info("CLOSING FILE");
-					err = unzCloseCurrentFile(file);
-					if (err != UNZ_OK)
-					{
-						spdlog::error("error {} with zipfile in unzCloseCurrentFile", err);
-					}
+					spdlog::error("An error occurred during file extraction (code: {})", err);
+					
 				}
-				else
+				err = unzCloseCurrentFile(file);
+				if (err != UNZ_OK)
 				{
-					spdlog::info("yo? {}", err);
-					unzCloseCurrentFile(file);
+					spdlog::error("error {} with zipfile in unzCloseCurrentFile", err);
 				}
 
 				// Cleanup
@@ -335,7 +329,7 @@ void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 			ExtractMod(archiveLocation);
 
 		REQUEST_END_CLEANUP:
-			spdlog::info("ok");
+			spdlog::info("Done downloading {}.", modName);
 		});
 
 	requestThread.detach();

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -306,6 +306,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 	if (status != UNZ_OK)
 	{
 		spdlog::error("Failed getting information from archive (error code: {})", status);
+		goto EXTRACTION_CLEANUP;
 	}
 
 	// Mod directory name (removing the ".zip" fom the archive name)

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -104,9 +104,32 @@ void ConCommand_fetch_verified_mods(const CCommand& args)
 	g_pModDownloader->FetchModsListFromAPI();
 }
 
+void ConCommand_is_mod_verified(const CCommand& args)
+{
+	if (args.ArgC() < 3)
+	{
+		return;
+	}
+
+	// Split arguments string by whitespaces (https://stackoverflow.com/a/5208977)
+	std::string buf;
+	std::stringstream ss(args.ArgS());
+	std::vector<std::string> tokens;
+	while (ss >> buf)
+		tokens.push_back(buf);
+
+	char* modName = (char*)tokens[0].c_str();
+	char* modVersion = (char*)tokens[1].c_str();
+	bool result = g_pModDownloader->IsModAuthorized(modName, modVersion);
+	std::string msg = std::format("Mod \"{}\" (version {}) is verified: {}", modName, modVersion, result);
+	spdlog::info(msg);
+}
+
+
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {
 	g_pModDownloader = new ModDownloader();
 	RegisterConCommand(
 		"fetch_verified_mods", ConCommand_fetch_verified_mods, "fetches verified mods list from GitHub repository", FCVAR_NONE);
+	RegisterConCommand("is_mod_verified", ConCommand_is_mod_verified, "checks if a mod is included in verified mods list", FCVAR_NONE);
 }

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -180,8 +180,6 @@ void ModDownloader::DownloadMod(char* modName, char* modVersion)
 	requestThread.detach();
 }
 
-
-
 void ConCommand_fetch_verified_mods(const CCommand& args)
 {
 	g_pModDownloader->FetchModsListFromAPI();
@@ -226,7 +224,6 @@ void ConCommand_download_mod(const CCommand& args)
 	char* modVersion = (char*)tokens[1].c_str();
 	g_pModDownloader->DownloadMod(modName, modVersion);
 }
-
 
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -358,7 +358,7 @@ void ModDownloader::ExtractMod(fs::path modPath)
 				}
 
 				// Create file
-				int bufferSize = 8192;
+				const int bufferSize = 8192;
 				void* buffer;
 				int err = UNZ_OK;
 				FILE* fout = NULL;

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -81,6 +81,24 @@ void ModDownloader::FetchModsListFromAPI()
 	requestThread.detach();
 }
 
+bool ModDownloader::IsModAuthorized(char* modName, char* modVersion)
+{
+	if (!verifiedMods.contains(modName))
+	{
+		return false;
+	}
+
+	std::vector<VerifiedModVersion> versions = verifiedMods[modName].versions;
+	std::vector<VerifiedModVersion> matchingVersions;
+	std::copy_if(
+		versions.begin(),
+		versions.end(),
+		std::back_inserter(matchingVersions),
+		[modVersion](VerifiedModVersion v) { return strcmp(modVersion, v.version) == 0; });
+
+	return matchingVersions.size() != 0;
+}
+
 void ConCommand_fetch_verified_mods(const CCommand& args)
 {
 	g_pModDownloader->FetchModsListFromAPI();

--- a/NorthstarDLL/mods/autodownload/moddownloader.cpp
+++ b/NorthstarDLL/mods/autodownload/moddownloader.cpp
@@ -215,13 +215,18 @@ bool ModDownloader::IsModLegit(fs::path modPath, std::string expectedChecksum)
 		spdlog::error("Unable to open archive.");
 		return false;
 	}
+	fp.seekg(0, fp.beg);
 	while (fp.good())
 	{
 		fp.read(buffer.data(), bufferSize);
-		status = BCryptHashData(hashHandle, (PBYTE)buffer.data(), bufferSize, 0);
-		if (!NT_SUCCESS(status))
+		std::streamsize bytesRead = fp.gcount();
+		if (bytesRead > 0)
 		{
-			goto cleanup;
+			status = BCryptHashData(hashHandle, (PBYTE)buffer.data(), bytesRead, 0);
+			if (!NT_SUCCESS(status))
+			{
+				goto cleanup;
+			}
 		}
 	}
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -29,6 +29,20 @@ class ModDownloader
 	fs::path FetchModFromDistantStore(std::string modName, std::string modVersion);
 
 	/**
+	 * Checks whether a mod is verified.
+	 *
+	 * A mod is deemed verified/authorized through a manual validation process that is
+	 * described here: https://github.com/R2Northstar/VerifiedMods; in practice, a mod
+	 * is considered authorized if their name AND exact version appear in the
+	 * `verifiedMods` variable.
+	 *
+	 * @param modName name of the mod to be checked
+	 * @param modVersion version of the mod to be checked, must follow semantic versioning
+	 * @returns whether the mod is authorized and can be auto-downloaded
+	 */
+	bool IsModAuthorized(std::string modName, std::string modVersion);
+
+	/**
 	 * Tells if a mod archive has not been corrupted.
 	 *
 	 * The mod validation procedure includes computing the SHA256 hash of the final
@@ -80,20 +94,6 @@ class ModDownloader
 	 * @returns nothing
 	 **/
 	void DownloadMod(std::string modName, std::string modVersion);
-
-	/**
-	 * Checks whether a mod is verified.
-	 *
-	 * A mod is deemed verified/authorized through a manual validation process that is
-	 * described here: https://github.com/R2Northstar/VerifiedMods; in practice, a mod
-	 * is considered authorized if their name AND exact version appear in the
-	 * `verifiedMods` variable.
-	 *
-	 * @param modName name of the mod to be checked
-	 * @param modVersion version of the mod to be checked, must follow semantic versioning
-	 * @returns whether the mod is authorized and can be auto-downloaded
-	 */
-	bool IsModAuthorized(std::string modName, std::string modVersion);
 
 	enum ModInstallState
 	{

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -58,7 +58,7 @@ class ModDownloader
 	 * @param expectedChecksum checksum the archive should have
 	 * @returns whether archive is legit
 	 */
-	bool IsModLegit(fs::path modPath, std::string expectedChecksum);
+	bool IsModLegit(fs::path modPath, std::string_view expectedChecksum);
 
 	/**
 	 * Extracts a mod archive to the game folder.

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -6,8 +6,8 @@ class ModDownloader
 
 	struct VerifiedModVersion
 	{
-		char* version;
-		char* checksum;
+		std::string version;
+		std::string checksum;
 	};
 	struct VerifiedModDetails
 	{

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -1,9 +1,11 @@
 class ModDownloader
 {
   private:
-	const char* STORE_URL = "https://gcdn.thunderstore.io/live/repository/packages/";
-	const char* MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json";
 	const char* VERIFICATION_FLAG = "-disablemodverification";
+	const char* CUSTOM_MODS_URL_FLAG = "-customverifiedurl=";
+	const char* STORE_URL = "https://gcdn.thunderstore.io/live/repository/packages/";
+	const char* DEFAULT_MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json";
+	char* modsListUrl;
 
 	struct VerifiedModVersion
 	{

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -129,16 +129,13 @@ class ModDownloader
 	} modState = {};
 
 	/**
-	 * Cancels installation of a mod.
+	 * Cancels installation of the mod.
 	 *
-	 * Prevents installation of a mod currently being installed, no matter the install
+	 * Prevents installation of the mod currently being installed, no matter the install
 	 * progress (downloading, checksuming, extracting), and frees all resources currently
 	 * being used in this purpose.
 	 *
-	 * Does nothing if mod passed as argument is not being installed.
-	 *
-	 * @param modName name of the mod to prevent installation of
 	 * @returns nothing
 	 */
-	void CancelDownload(std::string modName);
+	void CancelDownload();
 };

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -11,7 +11,7 @@ class ModDownloader
 	};
 	struct VerifiedModDetails
 	{
-		char* dependencyPrefix;
+		std::string dependencyPrefix;
 		std::vector<VerifiedModVersion> versions;
 	};
 	std::unordered_map<std::string, VerifiedModDetails> verifiedMods = {};

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -20,7 +20,8 @@ class ModDownloader
 	 * Downloads a mod archive from distant store.
 	 *
 	 * This rebuilds the URI of the mod archive using both a predefined store URI
-	 * and the mod dependency string from the `verifiedMods` variable; fetched
+	 * and the mod dependency string from the `verifiedMods` variable, or using
+	 * input mod name as mod dependency string if bypass flag is set up; fetched
 	 * archive is then stored in a temporary location.
 	 *
 	 * If something went wrong during archive download, this will return an empty

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -1,150 +1,149 @@
 class ModDownloader
 {
-	private:
-		const char* STORE_URL = "https://gcdn.thunderstore.io/live/repository/packages/";
-		const char* MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json";
+  private:
+	const char* STORE_URL = "https://gcdn.thunderstore.io/live/repository/packages/";
+	const char* MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json";
 
-		struct VerifiedModVersion
-		{
-			char* version;
-			char* checksum;
-		};
-		struct VerifiedModDetails
-		{
-			char* dependencyPrefix;
-			std::vector<VerifiedModVersion> versions;
-		};
-		std::unordered_map<std::string, VerifiedModDetails> verifiedMods = {};
-		
-		/**
-		 * Downloads a mod archive from distant store.
-		 *
-		 * This rebuilds the URI of the mod archive using both a predefined store URI
-		 * and the mod dependency string from the `verifiedMods` variabl; fetched
-		 * archive is then stored in a temporary location.
-		 *
-		 * @param modName name of the mod to be downloaded
-		 * @param modVersion version of the mod to be downloaded
-		 * @returns location of the downloaded archive
-		 */
-		fs::path FetchModFromDistantStore(char* modName, char* modVersion);
+	struct VerifiedModVersion
+	{
+		char* version;
+		char* checksum;
+	};
+	struct VerifiedModDetails
+	{
+		char* dependencyPrefix;
+		std::vector<VerifiedModVersion> versions;
+	};
+	std::unordered_map<std::string, VerifiedModDetails> verifiedMods = {};
 
-		/**
-		 * Tells if a mod archive has not been corrupted.
-		 *
-		 * The mod validation procedure includes computing the SHA256 hash of the final
-		 * archive, which is stored in the verified mods list. This hash is used by this
-		 * very method to ensure the archive downloaded from the Internet is the exact
-		 * same that has been manually verified.
-		 * 
-		 * @param modPath path of the archive to check
-		 * @param expectedChecksum checksum the archive should have
-		 * @returns whether archive is legit
-		 */
-		bool IsModLegit(fs::path modPath, char* expectedChecksum);
+	/**
+	 * Downloads a mod archive from distant store.
+	 *
+	 * This rebuilds the URI of the mod archive using both a predefined store URI
+	 * and the mod dependency string from the `verifiedMods` variabl; fetched
+	 * archive is then stored in a temporary location.
+	 *
+	 * @param modName name of the mod to be downloaded
+	 * @param modVersion version of the mod to be downloaded
+	 * @returns location of the downloaded archive
+	 */
+	fs::path FetchModFromDistantStore(char* modName, char* modVersion);
 
-		/**
-		 * Extracts a mod archive to the game folder.
-		 *
-		 * This extracts a downloaded mod archive from its original location to the
-		 * current game profile, in the remote mods folder.
-		 *
-		 * @param modPath location of the downloaded archive
-		 * @returns nothing
-		 */
-		void ExtractMod(fs::path modPath);
+	/**
+	 * Tells if a mod archive has not been corrupted.
+	 *
+	 * The mod validation procedure includes computing the SHA256 hash of the final
+	 * archive, which is stored in the verified mods list. This hash is used by this
+	 * very method to ensure the archive downloaded from the Internet is the exact
+	 * same that has been manually verified.
+	 *
+	 * @param modPath path of the archive to check
+	 * @param expectedChecksum checksum the archive should have
+	 * @returns whether archive is legit
+	 */
+	bool IsModLegit(fs::path modPath, char* expectedChecksum);
 
-	public:
-		ModDownloader();
+	/**
+	 * Extracts a mod archive to the game folder.
+	 *
+	 * This extracts a downloaded mod archive from its original location to the
+	 * current game profile, in the remote mods folder.
+	 *
+	 * @param modPath location of the downloaded archive
+	 * @returns nothing
+	 */
+	void ExtractMod(fs::path modPath);
 
-		/**
-		 * Retrieves the verified mods list from the central authority.
-		 *
-		 * The Northstar auto-downloading feature does NOT allow automatically installing
-		 * all mods for various (notably security) reasons; mods that are candidate to
-		 * auto-downloading are rather listed on a GitHub repository
-		 * (https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json),
-		 * which this method gets via a HTTP call to load into local state.
-		 *
-		 * If list fetching fails, local mods list will be initialized as empty, thus
-		 * preventing any mod from being auto-downloaded.
-		 *
-		 * @returns nothing
-		 */
-		void FetchModsListFromAPI();
+  public:
+	ModDownloader();
 
-		/**
-		 * Downloads a given mod from Thunderstore API to local game profile.
-		 *
-		 * @param modName name of the mod to be downloaded
-		 * @param modVersion version of the mod to be downloaded
-		 * @returns nothing
-		 **/
-		void DownloadMod(char* modName, char* modVersion);
+	/**
+	 * Retrieves the verified mods list from the central authority.
+	 *
+	 * The Northstar auto-downloading feature does NOT allow automatically installing
+	 * all mods for various (notably security) reasons; mods that are candidate to
+	 * auto-downloading are rather listed on a GitHub repository
+	 * (https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/mods.json),
+	 * which this method gets via a HTTP call to load into local state.
+	 *
+	 * If list fetching fails, local mods list will be initialized as empty, thus
+	 * preventing any mod from being auto-downloaded.
+	 *
+	 * @returns nothing
+	 */
+	void FetchModsListFromAPI();
 
-		/**
-		 * Checks whether a mod is verified.
-		 *
-		 * A mod is deemed verified/authorized through a manual validation process that is
-		 * described here: https://github.com/R2Northstar/VerifiedMods; in practice, a mod
-		 * is considered authorized if their name AND exact version appear in the
-		 * `verifiedMods` variable.
-		 *
-		 * @param modName name of the mod to be checked
-		 * @param modVersion version of the mod to be checked, must follow semantic versioning
-		 * @returns whether the mod is authorized and can be auto-downloaded
-		 */
-		bool IsModAuthorized(char* modName, char* modVersion);
+	/**
+	 * Downloads a given mod from Thunderstore API to local game profile.
+	 *
+	 * @param modName name of the mod to be downloaded
+	 * @param modVersion version of the mod to be downloaded
+	 * @returns nothing
+	 **/
+	void DownloadMod(char* modName, char* modVersion);
 
+	/**
+	 * Checks whether a mod is verified.
+	 *
+	 * A mod is deemed verified/authorized through a manual validation process that is
+	 * described here: https://github.com/R2Northstar/VerifiedMods; in practice, a mod
+	 * is considered authorized if their name AND exact version appear in the
+	 * `verifiedMods` variable.
+	 *
+	 * @param modName name of the mod to be checked
+	 * @param modVersion version of the mod to be checked, must follow semantic versioning
+	 * @returns whether the mod is authorized and can be auto-downloaded
+	 */
+	bool IsModAuthorized(char* modName, char* modVersion);
 
-		enum ModInstallState
-		{
-			// Normal installation process
-			DOWNLOADING,
-			CHECKSUMING,
-			EXTRACTING,
-			DONE, // Everything went great, mod can be used in-game
+	enum ModInstallState
+	{
+		// Normal installation process
+		DOWNLOADING,
+		CHECKSUMING,
+		EXTRACTING,
+		DONE, // Everything went great, mod can be used in-game
 
-			// Errors
-			FAILED, // Generic error message, should be avoided as much as possible
-			FAILED_READING_ARCHIVE,
-			FAILED_WRITING_TO_DISK,
-			MOD_FETCHING_FAILED,
-			MOD_CORRUPTED, // Downloaded archive checksum does not match verified hash
-			NO_DISK_SPACE_AVAILABLE,
-			NOT_FOUND // Mod is not currently being auto-downloaded
-		};
+		// Errors
+		FAILED, // Generic error message, should be avoided as much as possible
+		FAILED_READING_ARCHIVE,
+		FAILED_WRITING_TO_DISK,
+		MOD_FETCHING_FAILED,
+		MOD_CORRUPTED, // Downloaded archive checksum does not match verified hash
+		NO_DISK_SPACE_AVAILABLE,
+		NOT_FOUND // Mod is not currently being auto-downloaded
+	};
 
-		struct MOD_STATE
-		{
-			ModInstallState state;
-			int progress;
-			int total;
-			float ratio;
-		} modState;
+	struct MOD_STATE
+	{
+		ModInstallState state;
+		int progress;
+		int total;
+		float ratio;
+	} modState;
 
-		/**
-		 * Retrieves installation information of a mod.
-		 *
-		 * Since mods are installed one at a time, mod installation data is stored in a global
-		 * MOD_STATE instance.
-		 *
-		 * @param modName name of the mod to get information of
-		 * @returns the class MOD_STATE instance
-		 */
-		MOD_STATE GetModInstallProgress(char* modName);
+	/**
+	 * Retrieves installation information of a mod.
+	 *
+	 * Since mods are installed one at a time, mod installation data is stored in a global
+	 * MOD_STATE instance.
+	 *
+	 * @param modName name of the mod to get information of
+	 * @returns the class MOD_STATE instance
+	 */
+	MOD_STATE GetModInstallProgress(char* modName);
 
-		/**
-		 * Cancels installation of a mod.
-		 *
-		 * Prevents installation of a mod currently being installed, no matter the install
-		 * progress (downloading, checksuming, extracting), and frees all resources currently
-		 * being used in this purpose.
-		 *
-		 * Does nothing if mod passed as argument is not being installed.
-		 *
-		 * @param modName name of the mod to prevent installation of
-		 * @returns nothing
-		 */
-		void CancelDownload(char* modName);
+	/**
+	 * Cancels installation of a mod.
+	 *
+	 * Prevents installation of a mod currently being installed, no matter the install
+	 * progress (downloading, checksuming, extracting), and frees all resources currently
+	 * being used in this purpose.
+	 *
+	 * Does nothing if mod passed as argument is not being installed.
+	 *
+	 * @param modName name of the mod to prevent installation of
+	 * @returns nothing
+	 */
+	void CancelDownload(char* modName);
 };

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -44,7 +44,7 @@ class ModDownloader
 	 * @param modVersion version of the mod to be checked, must follow semantic versioning
 	 * @returns whether the mod is authorized and can be auto-downloaded
 	 */
-	bool IsModAuthorized(std::string modName, std::string modVersion);
+	bool IsModAuthorized(std::string_view modName, std::string_view modVersion);
 
 	/**
 	 * Tells if a mod archive has not been corrupted.

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -26,7 +26,7 @@ class ModDownloader
 	 * @param modVersion version of the mod to be downloaded
 	 * @returns location of the downloaded archive
 	 */
-	fs::path FetchModFromDistantStore(char* modName, char* modVersion);
+	fs::path FetchModFromDistantStore(std::string modName, std::string modVersion);
 
 	/**
 	 * Tells if a mod archive has not been corrupted.
@@ -40,7 +40,7 @@ class ModDownloader
 	 * @param expectedChecksum checksum the archive should have
 	 * @returns whether archive is legit
 	 */
-	bool IsModLegit(fs::path modPath, char* expectedChecksum);
+	bool IsModLegit(fs::path modPath, std::string expectedChecksum);
 
 	/**
 	 * Extracts a mod archive to the game folder.
@@ -79,7 +79,7 @@ class ModDownloader
 	 * @param modVersion version of the mod to be downloaded
 	 * @returns nothing
 	 **/
-	void DownloadMod(char* modName, char* modVersion);
+	void DownloadMod(std::string modName, std::string modVersion);
 
 	/**
 	 * Checks whether a mod is verified.
@@ -93,7 +93,7 @@ class ModDownloader
 	 * @param modVersion version of the mod to be checked, must follow semantic versioning
 	 * @returns whether the mod is authorized and can be auto-downloaded
 	 */
-	bool IsModAuthorized(char* modName, char* modVersion);
+	bool IsModAuthorized(std::string modName, std::string modVersion);
 
 	enum ModInstallState
 	{
@@ -130,7 +130,7 @@ class ModDownloader
 	 * @param modName name of the mod to get information of
 	 * @returns the class MOD_STATE instance
 	 */
-	MOD_STATE GetModInstallProgress(char* modName);
+	MOD_STATE GetModInstallProgress(std::string modName);
 
 	/**
 	 * Cancels installation of a mod.
@@ -144,5 +144,5 @@ class ModDownloader
 	 * @param modName name of the mod to prevent installation of
 	 * @returns nothing
 	 */
-	void CancelDownload(char* modName);
+	void CancelDownload(std::string modName);
 };

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -123,7 +123,7 @@ class ModDownloader
 		int progress;
 		int total;
 		float ratio;
-	} modState;
+	} modState = {};
 
 	/**
 	 * Retrieves installation information of a mod.

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -30,7 +30,7 @@ class ModDownloader
 	 * @param modVersion version of the mod to be downloaded
 	 * @returns location of the downloaded archive
 	 */
-	std::optional<fs::path> FetchModFromDistantStore(std::string modName, std::string modVersion);
+	std::optional<fs::path> FetchModFromDistantStore(std::string_view modName, std::string_view modVersion);
 
 	/**
 	 * Checks whether a mod is verified.

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -6,13 +6,12 @@ class ModDownloader
 
 	struct VerifiedModVersion
 	{
-		std::string version;
 		std::string checksum;
 	};
 	struct VerifiedModDetails
 	{
 		std::string dependencyPrefix;
-		std::vector<VerifiedModVersion> versions;
+		std::unordered_map<std::string, VerifiedModVersion> versions = {};
 	};
 	std::unordered_map<std::string, VerifiedModDetails> verifiedMods = {};
 

--- a/NorthstarDLL/mods/autodownload/moddownloader.h
+++ b/NorthstarDLL/mods/autodownload/moddownloader.h
@@ -129,17 +129,6 @@ class ModDownloader
 	} modState = {};
 
 	/**
-	 * Retrieves installation information of a mod.
-	 *
-	 * Since mods are installed one at a time, mod installation data is stored in a global
-	 * MOD_STATE instance.
-	 *
-	 * @param modName name of the mod to get information of
-	 * @returns the class MOD_STATE instance
-	 */
-	MOD_STATE GetModInstallProgress(std::string modName);
-
-	/**
 	 * Cancels installation of a mod.
 	 *
 	 * Prevents installation of a mod currently being installed, no matter the install

--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -612,32 +612,36 @@ void ModManager::LoadMods()
 	// get mod directories
 	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
 
 	for (std::filesystem::directory_iterator modIterator : {classicModsDir, remoteModsDir})
 		for (fs::directory_entry dir : modIterator)
 			if (fs::exists(dir.path() / "mod.json"))
 				modDirs.push_back(dir.path());
 
-	// Special case for Thunderstore mods dir
-	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	// Special case for Thunderstore and remote mods directories
 	// Set up regex for `AUTHOR-MOD-VERSION` pattern
 	std::regex pattern(R"(.*\\([a-zA-Z0-9_]+)-([a-zA-Z0-9_]+)-(\d+\.\d+\.\d+))");
-	for (fs::directory_entry dir : thunderstoreModsDir)
+
+	for (fs::directory_iterator dirIterator : {thunderstoreModsDir, remoteModsDir})
 	{
-		fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
-		// Use regex to match `AUTHOR-MOD-VERSION` pattern
-		if (!std::regex_match(dir.path().string(), pattern))
+		for (fs::directory_entry dir : dirIterator)
 		{
-			spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
-			continue; // skip loading mod that doesn't match
-		}
-		if (fs::exists(modsDir) && fs::is_directory(modsDir))
-		{
-			for (fs::directory_entry subDir : fs::directory_iterator(modsDir))
+			fs::path modsDir = dir.path() / "mods"; // Check for mods folder in the Thunderstore mod
+			// Use regex to match `AUTHOR-MOD-VERSION` pattern
+			if (!std::regex_match(dir.path().string(), pattern))
 			{
-				if (fs::exists(subDir.path() / "mod.json"))
+				spdlog::warn("The following directory did not match 'AUTHOR-MOD-VERSION': {}", dir.path().string());
+				continue; // skip loading mod that doesn't match
+			}
+			if (fs::exists(modsDir) && fs::is_directory(modsDir))
+			{
+				for (fs::directory_entry subDir : fs::directory_iterator(modsDir))
 				{
-					modDirs.push_back(subDir.path());
+					if (fs::exists(subDir.path() / "mod.json"))
+					{
+						modDirs.push_back(subDir.path());
+					}
 				}
 			}
 		}

--- a/cmake/Findminizip.cmake
+++ b/cmake/Findminizip.cmake
@@ -1,0 +1,8 @@
+
+if(NOT minizip_FOUND)
+	check_init_submodule(${PROJECT_SOURCE_DIR}/thirdparty/minizip)
+
+	add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/minizip minizip)
+	set(minizip_FOUND 1 PARENT_SCOPE)
+endif()
+

--- a/cmake/Findminizip.cmake
+++ b/cmake/Findminizip.cmake
@@ -2,6 +2,8 @@
 if(NOT minizip_FOUND)
 	check_init_submodule(${PROJECT_SOURCE_DIR}/thirdparty/minizip)
 
+	set(MZ_LZMA OFF CACHE BOOL "Disable LZMA & XZ compression")
+
 	add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/minizip minizip)
 	set(minizip_FOUND 1 PARENT_SCOPE)
 endif()


### PR DESCRIPTION
## Description

This branch allows client to download a mod archive from the Thunderstore API, and extract included mods in the remote mods folder of the current game profile.

Not all mods can be automatically downloaded, as it would cause *some* security issues, and Thunderstore mod name cannot be deduced from actual mod name: to be eligible to auto-downloading, a mod must appear in the list of verified mods.

Said list and complete mod verification procedure are described here: https://github.com/R2Northstar/VerifiedMods

This branch exposes two commands to test the feature:
* `fetch_verified_mods` retrieves verified mods list from the GitHub organization, and stores it locally;
* `download_mod` does the actual mod downloading/extraction job.

### What this PR is about

* Downloading a mod archive
* Extracting said archive to mods folder

### What this PR is *NOT* about

* Download progress indicator/messages or UI of any kind
* Mod availability to the game (no `reload_mods` invoked)

## Resources

### How to test

* Download and install DLL file from latest CI build;
* Run the `fetch_verified_mods` command;
* Download a mod with `download_mod [mod_name] [mod_version]` (only `Fifty.mp_frostbite 0.0.1` is listed at the time of writing);
* Check your remote mods directory, the downloaded mod should appear there.

### Media

[autodl-pr-opening.webm](https://github.com/R2Northstar/NorthstarLauncher/assets/11993538/e1ce2f81-3b23-460a-a7c9-5cff60b99751)