### PR TITLE
Fix tokens for bots

### DIFF
--- a/NorthstarDLL/server/auth/serverauthentication.h
+++ b/NorthstarDLL/server/auth/serverauthentication.h
@@ -48,9 +48,9 @@ class ServerAuthenticationManager
 
 	bool VerifyPlayerName(const char* pAuthToken, const char* pName, char pOutVerifiedName[64]);
 	bool IsDuplicateAccount(R2::CBaseClient* pPlayer, const char* pUid);
-	bool CheckAuthentication(R2::CBaseClient* pPlayer, uint64_t iUid, char* pAuthToken);
+	bool CheckAuthentication(R2::CBaseClient* pPlayer, uint64_t iUid, const char* pAuthToken);
 
-	void AuthenticatePlayer(R2::CBaseClient* pPlayer, uint64_t iUid, char* pAuthToken);
+	void AuthenticatePlayer(R2::CBaseClient* pPlayer, uint64_t iUid, const char* pAuthToken);
 	bool RemovePlayerAuthData(R2::CBaseClient* pPlayer);
 	void WritePersistentData(R2::CBaseClient* pPlayer);
 };


### PR DESCRIPTION
If bots connect before a player ever connects to the server, a uninit [pointer](https://github.com/R2Northstar/NorthstarLauncher/blob/07e76e3a8e2738dbb7a1d5a6aeaa908a838f5a02/NorthstarDLL/server/auth/serverauthentication.cpp#L207C7-L207C23) will be accessed. this happens because bots skip `CBaseServer__ConnectClient`.

this pr fixes this issue.

