### PR TITLE
Define indent size in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,4 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = tab
+indent_size = 4


### PR DESCRIPTION
Setting indent size in `.editorconfig` means that things like GitHub web preview will default to showing tab indent size as 4 spaces.

By default GitHub uses tabsize 8 for indentation making diffs look weird (cause `clang-format` is doing wrong things)
![image](https://github.com/R2Northstar/NorthstarLauncher/assets/40122905/59deac3c-59b6-412f-b1c0-85fe1894afb2)


See also https://stackoverflow.com/questions/8833953/how-to-change-tab-size-on-github