### PR TITLE
Allow for changing command restrictions at runtime

### DIFF
--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -119,6 +119,7 @@ add_library(NorthstarDLL SHARED
             "shared/exploit_fixes/exploitfixes_utf8parser.cpp"
             "shared/exploit_fixes/ns_limits.cpp"
             "shared/exploit_fixes/ns_limits.h"
+            "shared/exploit_fixes/servercommands.cpp"
             "shared/gamepresence.cpp"
             "shared/gamepresence.h"
             "shared/keyvalues.cpp"

--- a/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
@@ -1,7 +1,6 @@
 #include "core/convar/cvar.h"
 #include "engine/r2engine.h"
 
-
 typedef void* (*GetBaseLocalClientType)();
 GetBaseLocalClientType GetBaseLocalClient = nullptr;
 

--- a/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
@@ -1,10 +1,6 @@
 #include "core/convar/cvar.h"
-#include "ns_limits.h"
-#include "dedicated/dedicated.h"
-#include "core/tier0.h"
 #include "engine/r2engine.h"
-#include "client/r2client.h"
-#include "core/math/vector.h"
+
 
 typedef void* (*GetBaseLocalClientType)();
 GetBaseLocalClientType GetBaseLocalClient = nullptr;

--- a/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
@@ -20,7 +20,7 @@ ON_DLL_LOAD("engine.dll", ServerCommands, (CModule module))
 		0,
 		false,
 		0,
-		[](ConVar * cvar, const char* pOldValue, float flOldValue)
+		[](ConVar* cvar, const char* pOldValue, float flOldValue)
 		{
 			// this callback runs even if there was no actual change, so filter that out
 			if (!strcmp(pOldValue, Cvar_ns_restrict_commands->GetString()))
@@ -28,7 +28,8 @@ ON_DLL_LOAD("engine.dll", ServerCommands, (CModule module))
 
 			spdlog::info("ns_restrict_commands was changed from {} to {}", pOldValue, Cvar_ns_restrict_commands->GetString());
 
-			R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "disconnect \"Command restrictions were changed\"", R2::cmd_source_t::kCommandSrcCode);
+			R2::Cbuf_AddText(
+				R2::Cbuf_GetCurrentPlayer(), "disconnect \"Command restrictions were changed\"", R2::cmd_source_t::kCommandSrcCode);
 
 			bool shouldRestrict = Cvar_ns_restrict_commands->GetBool();
 			bool* localClientBase = (bool*)(*GetBaseLocalClient)();

--- a/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
@@ -1,0 +1,35 @@
+#include "core/convar/cvar.h"
+#include "ns_limits.h"
+#include "dedicated/dedicated.h"
+#include "core/tier0.h"
+#include "engine/r2engine.h"
+#include "client/r2client.h"
+#include "core/math/vector.h"
+
+typedef void* (*GetBaseLocalClientType)();
+GetBaseLocalClientType GetBaseLocalClient = nullptr;
+
+ConVar* Cvar_ns_restrict_commands;
+
+ON_DLL_LOAD("engine.dll", ServerCommands, (CModule module))
+{
+	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
+
+	Cvar_ns_restrict_commands = new ConVar("ns_restrict_commands", "1", FCVAR_GAMEDLL, "", 0, 0, 0, 0, [](ConVar* cvar, const char* pOldValue, float flOldValue) {
+			// this callback runs even if there was no actual change, so filter that out
+			if (!strcmp(pOldValue, Cvar_ns_restrict_commands->GetString()))
+				return;
+
+			spdlog::info("ns_restrict_commands was changed from {} to {}", pOldValue, Cvar_ns_restrict_commands->GetString());
+
+			R2::Cbuf_AddText(
+				R2::Cbuf_GetCurrentPlayer(),
+				"disconnect \"Command restrictions were changed\"",
+				R2::cmd_source_t::kCommandSrcCode);
+
+			bool shouldRestrict = Cvar_ns_restrict_commands->GetBool();
+			bool* localClientBase = (bool*)(*GetBaseLocalClient)();
+			*(localClientBase + 64228) = shouldRestrict; // m_bRestrictServerCommands
+			*(localClientBase + 64229) = shouldRestrict; // m_bRetrictClientCommands
+		});
+}

--- a/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/servercommands.cpp
@@ -11,17 +11,24 @@ ON_DLL_LOAD("engine.dll", ServerCommands, (CModule module))
 {
 	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
 
-	Cvar_ns_restrict_commands = new ConVar("ns_restrict_commands", "1", FCVAR_GAMEDLL, "", 0, 0, 0, 0, [](ConVar* cvar, const char* pOldValue, float flOldValue) {
+	Cvar_ns_restrict_commands = new ConVar(
+		"ns_restrict_commands",
+		"1",
+		FCVAR_GAMEDLL,
+		"Whether or not server/client commands should be restricted.",
+		false,
+		0,
+		false,
+		0,
+		[](ConVar * cvar, const char* pOldValue, float flOldValue)
+		{
 			// this callback runs even if there was no actual change, so filter that out
 			if (!strcmp(pOldValue, Cvar_ns_restrict_commands->GetString()))
 				return;
 
 			spdlog::info("ns_restrict_commands was changed from {} to {}", pOldValue, Cvar_ns_restrict_commands->GetString());
 
-			R2::Cbuf_AddText(
-				R2::Cbuf_GetCurrentPlayer(),
-				"disconnect \"Command restrictions were changed\"",
-				R2::cmd_source_t::kCommandSrcCode);
+			R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "disconnect \"Command restrictions were changed\"", R2::cmd_source_t::kCommandSrcCode);
 
 			bool shouldRestrict = Cvar_ns_restrict_commands->GetBool();
 			bool* localClientBase = (bool*)(*GetBaseLocalClient)();


### PR DESCRIPTION
This allows for vanilla compat without -norestrictservercommands.

Script is absolutely not set up for this though, so to test:

1. launch a vanilla profile (without -norestrictservercommands)
2. go into multiplayer, and matchmake for everyone's favourite mode: Attrition
3. observe that you cannot connect to a game server, you will stay stuck on the "Connecting to match" bit
4. set `ns_restrict_commands` to 0. This will disconnect you from your server and put you back on the main menu.
5. go back into multiplayer and once again matchmake for everybody's favourite mode.
6. observe that you can connect and play a match just fine.

EDIT: 0 not 1, brain hurt