### PR TITLE
Fix crash when running `disconnect %%s`

### DIFF
--- a/NorthstarDLL/client/rejectconnectionfixes.cpp
+++ b/NorthstarDLL/client/rejectconnectionfixes.cpp
@@ -25,7 +25,7 @@ void,, (bool a1, const char* fmt, ...))
 		R2::Cbuf_AddText(R2::Cbuf_GetCurrentPlayer(), "disconnect", R2::cmd_source_t::kCommandSrcCode);
 	}
 
-	return COM_ExplainDisconnection(a1, buf);
+	return COM_ExplainDisconnection(a1, "%s", buf);
 }
 
 ON_DLL_LOAD_CLIENT("engine.dll", RejectConnectionFixes, (CModule module))


### PR DESCRIPTION
Closes #552 

Basically we were running a string format and then passing the string to the original function, which would then try and format it again (and get bad args). By passing `"%s"` and then our formatted string we basically just protect the vanilla string format
