### PR TITLE
Reduce warnings due to calling conventions

### DIFF
--- a/NorthstarDLL/core/convar/concommand.h
+++ b/NorthstarDLL/core/convar/concommand.h
@@ -83,8 +83,7 @@ typedef void (*FnCommandCallback_t)(const CCommand& command);
 //-----------------------------------------------------------------------------
 // Returns 0 to COMMAND_COMPLETION_MAXITEMS worth of completion strings
 //-----------------------------------------------------------------------------
-typedef int (*FnCommandCompletionCallback)(
-	const char* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
+typedef int (*FnCommandCompletionCallback)(const char* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
 
 // From r5reloaded
 class ConCommandBase

--- a/NorthstarDLL/core/convar/concommand.h
+++ b/NorthstarDLL/core/convar/concommand.h
@@ -83,7 +83,7 @@ typedef void (*FnCommandCallback_t)(const CCommand& command);
 //-----------------------------------------------------------------------------
 // Returns 0 to COMMAND_COMPLETION_MAXITEMS worth of completion strings
 //-----------------------------------------------------------------------------
-typedef int (*__fastcall FnCommandCompletionCallback)(
+typedef int (*FnCommandCompletionCallback)(
 	const char* partial, char commands[COMMAND_COMPLETION_MAXITEMS][COMMAND_COMPLETION_ITEM_LENGTH]);
 
 // From r5reloaded

--- a/NorthstarDLL/core/hooks.h
+++ b/NorthstarDLL/core/hooks.h
@@ -219,7 +219,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*callingConvention name) args;                                                                                                \
+		type(*name) args;                                                                                                \
 		__autohook CONCAT2(__autohook, __LINE__)(                                                                                          \
 			&__FILEAUTOHOOK, __STR(name), __STR(addrString), (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));                       \
 	}                                                                                                                                      \
@@ -230,7 +230,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*callingConvention name) args;                                                                                                \
+		type(*name) args;                                                                                                \
 		__autohook                                                                                                                         \
 			CONCAT2(__autohook, __LINE__)(&__FILEAUTOHOOK, __STR(name), addr, (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));      \
 	}                                                                                                                                      \
@@ -241,7 +241,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*callingConvention name) args;                                                                                                \
+		type(*name) args;                                                                                                \
 		__autohook CONCAT2(__autohook, __LINE__)(                                                                                          \
 			&__FILEAUTOHOOK, __STR(name), __STR(moduleName), __STR(procName), (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));      \
 	}                                                                                                                                      \
@@ -267,7 +267,7 @@ class ManualHook
 #define HOOK(varName, originalFunc, type, callingConvention, args)                                                                         \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*callingConvention originalFunc) args;                                                                                        \
+		type(*originalFunc) args;                                                                                        \
 	}                                                                                                                                      \
 	type callingConvention CONCAT2(__manualhookfunc, varName) args;                                                                        \
 	ManualHook varName = ManualHook(__STR(varName), (LPVOID*)&originalFunc, (LPVOID)CONCAT2(__manualhookfunc, varName));                   \
@@ -316,7 +316,7 @@ class __autovar
 
 // FUNCTION_AT(engine.dll + 0xDEADBEEF, void, __fastcall, SomeFunc, (void* a1))
 #define FUNCTION_AT(addrString, type, callingConvention, name, args)                                                                       \
-	type(*callingConvention name) args;                                                                                                    \
+	type(*name) args;                                                                                                    \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
 		__autovar CONCAT2(__autovar, __LINE__)(&__FILEAUTOHOOK, __STR(addrString), (void**)&name);                                         \

--- a/NorthstarDLL/core/hooks.h
+++ b/NorthstarDLL/core/hooks.h
@@ -219,7 +219,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*name) args;                                                                                                \
+		type(*name) args;                                                                                                                  \
 		__autohook CONCAT2(__autohook, __LINE__)(                                                                                          \
 			&__FILEAUTOHOOK, __STR(name), __STR(addrString), (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));                       \
 	}                                                                                                                                      \
@@ -230,7 +230,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*name) args;                                                                                                \
+		type(*name) args;                                                                                                                  \
 		__autohook                                                                                                                         \
 			CONCAT2(__autohook, __LINE__)(&__FILEAUTOHOOK, __STR(name), addr, (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));      \
 	}                                                                                                                                      \
@@ -241,7 +241,7 @@ class __autohook
 	type callingConvention CONCAT2(__autohookfunc, name) args;                                                                             \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*name) args;                                                                                                \
+		type(*name) args;                                                                                                                  \
 		__autohook CONCAT2(__autohook, __LINE__)(                                                                                          \
 			&__FILEAUTOHOOK, __STR(name), __STR(moduleName), __STR(procName), (LPVOID*)&name, (LPVOID)CONCAT2(__autohookfunc, name));      \
 	}                                                                                                                                      \
@@ -267,7 +267,7 @@ class ManualHook
 #define HOOK(varName, originalFunc, type, callingConvention, args)                                                                         \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
-		type(*originalFunc) args;                                                                                        \
+		type(*originalFunc) args;                                                                                                          \
 	}                                                                                                                                      \
 	type callingConvention CONCAT2(__manualhookfunc, varName) args;                                                                        \
 	ManualHook varName = ManualHook(__STR(varName), (LPVOID*)&originalFunc, (LPVOID)CONCAT2(__manualhookfunc, varName));                   \
@@ -316,7 +316,7 @@ class __autovar
 
 // FUNCTION_AT(engine.dll + 0xDEADBEEF, void, __fastcall, SomeFunc, (void* a1))
 #define FUNCTION_AT(addrString, type, callingConvention, name, args)                                                                       \
-	type(*name) args;                                                                                                    \
+	type(*name) args;                                                                                                                      \
 	namespace                                                                                                                              \
 	{                                                                                                                                      \
 		__autovar CONCAT2(__autovar, __LINE__)(&__FILEAUTOHOOK, __STR(addrString), (void**)&name);                                         \

--- a/NorthstarDLL/shared/maxplayers.cpp
+++ b/NorthstarDLL/shared/maxplayers.cpp
@@ -282,7 +282,7 @@ void,, (bool a1, float a2))
 
 // clang-format off
 AUTOHOOK(SendPropArray2, server.dll + 0x12B130,
-__int64, __fastcall, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn, unsigned char unk1))
+__int64,, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn, unsigned char unk1))
 // clang-format on
 {
 	// Change the amount of elements to account for a bigger player amount
@@ -453,7 +453,7 @@ ON_DLL_LOAD("server.dll", MaxPlayersOverride_Server, (CModule module))
 
 // clang-format off
 AUTOHOOK(RecvPropArray2, client.dll + 0x1CEDA0,
-__int64, __fastcall, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn))
+__int64,, (__int64 recvProp, int elements, int flags, const char* name, __int64 proxyFn))
 // clang-format on
 {
 	// Change the amount of elements to account for a bigger player amount

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -447,8 +447,7 @@ template <ScriptContext context> void __fastcall DestroyVMHook(void* a1, CSquirr
 	spdlog::info("DestroyVM {} {}", GetContextName(realContext), (void*)sqvm);
 }
 
-template <ScriptContext context>
-void (*SQCompileError)(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column);
+template <ScriptContext context> void (*SQCompileError)(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column);
 template <ScriptContext context>
 void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column)
 {
@@ -496,8 +495,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 	// dont call the original function since it kills game lol
 }
 
-template <ScriptContext context>
-int64_t (*RegisterSquirrelFunction)(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown);
+template <ScriptContext context> int64_t (*RegisterSquirrelFunction)(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown);
 template <ScriptContext context>
 int64_t __fastcall RegisterSquirrelFunctionHook(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown)
 {

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -366,7 +366,7 @@ bool IsUIVM(ScriptContext context, HSquirrelVM* pSqvm)
 	return ScriptContext(pSqvm->sharedState->cSquirrelVM->vmContext) == ScriptContext::UI;
 }
 
-template <ScriptContext context> void* (*__fastcall sq_compiler_create)(HSquirrelVM* sqvm, void* a2, void* a3, SQBool bShouldThrowError);
+template <ScriptContext context> void* (*sq_compiler_create)(HSquirrelVM* sqvm, void* a2, void* a3, SQBool bShouldThrowError);
 template <ScriptContext context> void* __fastcall sq_compiler_createHook(HSquirrelVM* sqvm, void* a2, void* a3, SQBool bShouldThrowError)
 {
 	// store whether errors generated from this compile should be fatal
@@ -398,7 +398,7 @@ template <ScriptContext context> SQInteger SQPrintHook(HSquirrelVM* sqvm, const 
 	return 0;
 }
 
-template <ScriptContext context> CSquirrelVM* (*__fastcall CreateNewVM)(void* a1, ScriptContext realContext);
+template <ScriptContext context> CSquirrelVM* (*CreateNewVM)(void* a1, ScriptContext realContext);
 template <ScriptContext context> CSquirrelVM* __fastcall CreateNewVMHook(void* a1, ScriptContext realContext)
 {
 	CSquirrelVM* sqvm = CreateNewVM<context>(a1, realContext);
@@ -411,7 +411,7 @@ template <ScriptContext context> CSquirrelVM* __fastcall CreateNewVMHook(void* a
 	return sqvm;
 }
 
-template <ScriptContext context> bool (*__fastcall CSquirrelVM_init)(CSquirrelVM* vm, ScriptContext realContext, float time);
+template <ScriptContext context> bool (*CSquirrelVM_init)(CSquirrelVM* vm, ScriptContext realContext, float time);
 template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelVM* vm, ScriptContext realContext, float time)
 {
 	bool ret = CSquirrelVM_init<context>(vm, realContext, time);
@@ -428,7 +428,7 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 	return ret;
 }
 
-template <ScriptContext context> void (*__fastcall DestroyVM)(void* a1, CSquirrelVM* sqvm);
+template <ScriptContext context> void (*DestroyVM)(void* a1, CSquirrelVM* sqvm);
 template <ScriptContext context> void __fastcall DestroyVMHook(void* a1, CSquirrelVM* sqvm)
 {
 	ScriptContext realContext = context; // ui and client use the same function so we use this for prints
@@ -448,7 +448,7 @@ template <ScriptContext context> void __fastcall DestroyVMHook(void* a1, CSquirr
 }
 
 template <ScriptContext context>
-void (*__fastcall SQCompileError)(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column);
+void (*SQCompileError)(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column);
 template <ScriptContext context>
 void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, const char* file, int line, int column)
 {
@@ -497,7 +497,7 @@ void __fastcall ScriptCompileErrorHook(HSquirrelVM* sqvm, const char* error, con
 }
 
 template <ScriptContext context>
-int64_t (*__fastcall RegisterSquirrelFunction)(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown);
+int64_t (*RegisterSquirrelFunction)(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown);
 template <ScriptContext context>
 int64_t __fastcall RegisterSquirrelFunctionHook(CSquirrelVM* sqvm, SQFuncRegistration* funcReg, char unknown)
 {
@@ -523,7 +523,7 @@ int64_t __fastcall RegisterSquirrelFunctionHook(CSquirrelVM* sqvm, SQFuncRegistr
 	return g_pSquirrel<context>->RegisterSquirrelFunc(sqvm, funcReg, unknown);
 }
 
-template <ScriptContext context> bool (*__fastcall CallScriptInitCallback)(void* sqvm, const char* callback);
+template <ScriptContext context> bool (*CallScriptInitCallback)(void* sqvm, const char* callback);
 template <ScriptContext context> bool __fastcall CallScriptInitCallbackHook(void* sqvm, const char* callback)
 {
 	ScriptContext realContext = context;


### PR DESCRIPTION
Removes `C4229 "anachronism used: modifiers on data are ignored"` warnings

Reduces warning count from 82 to 6

![image](https://github.com/R2Northstar/NorthstarLauncher/assets/40122905/5c43f11b-c72d-4750-a0a2-fe71e1cf2ef7)

## Testing:
Literally just play the game for a bit, load some mods, see if you notice any new crashes?