### PR TITLE
add flag to disable crash handler

### DIFF
--- a/NorthstarDLL/logging/crashhandler.cpp
+++ b/NorthstarDLL/logging/crashhandler.cpp
@@ -366,6 +366,9 @@ BOOL WINAPI ConsoleHandlerRoutine(DWORD eventCode)
 
 void InitialiseCrashHandler()
 {
+	if (strstr(GetCommandLineA(), "-disablecrashhandler"))
+		return;
+
 	hExceptionFilter = AddVectoredExceptionHandler(TRUE, ExceptionFilter);
 	SetConsoleCtrlHandler(ConsoleHandlerRoutine, true);
 	std::set_terminate(RuntimeExceptionHandler);


### PR DESCRIPTION
Skips Crash Handler init when `-disablecrashhandler` is passed

Tier0::CommandLine cannot be used because we are too early for the hook.

On Linux the crash handler has a tendency to loop, shitting out dmp's over and over again.
Debuggers, including winedbg, don't make `IsDebuggerPresent` return true.

