### PR TITLE
Give `g_pMemAllocSingleton` a default value

### DIFF
--- a/NorthstarDLL/core/tier0.cpp
+++ b/NorthstarDLL/core/tier0.cpp
@@ -3,7 +3,7 @@
 // use the Tier0 namespace for tier0 funcs
 namespace Tier0
 {
-	IMemAlloc* g_pMemAllocSingleton;
+	IMemAlloc* g_pMemAllocSingleton = nullptr;
 
 	ErrorType Error;
 	CommandLineType CommandLine;


### PR DESCRIPTION
The standard does not guarantee that `g_pMemAllocSingleton` will default to a falsey value, which our `*alloc` implementations demands.

I believe this change is so small and contained that its not worth testing, can you agree with that @GeckoEidechse ?

