### PR TITLE
Write date to logs

### DIFF
--- a/NorthstarDLL/logging/logging.cpp
+++ b/NorthstarDLL/logging/logging.cpp
@@ -52,7 +52,7 @@ void CreateLogFiles()
 
 			stream << std::put_time(&currentTime, (GetNorthstarPrefix() + "/logs/nslog%Y-%m-%d %H-%M-%S.txt").c_str());
 			auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(stream.str(), false);
-			sink->set_pattern("[%H:%M:%S] [%n] [%l] %v");
+			sink->set_pattern("[%Y-%m-%d] [%H:%M:%S] [%n] [%l] %v");
 			for (auto& logger : loggers)
 			{
 				logger->sinks().push_back(sink);


### PR DESCRIPTION
Suggestion from #560 

This PR adds dates to logs in the same format which the file name uses. 

![image](https://github.com/R2Northstar/NorthstarLauncher/assets/97146561/26b74c43-58ab-4ca7-a733-bcdc56f6f889)

Closes #560 