### PR TITLE
Fixed mixed indentation in utils.cmake

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,19 +1,19 @@
 
 # Check if a dependency exist before trying to init git submodules
 function(check_init_submodule path)
-	file(GLOB DIR_CONTENT path)
-	list(LENGTH RESULT CONTENT_COUNT)
-	if (CONTENT_COUNT EQUAL 0)
-		if (NOT EXISTS "${PROJECT_SOURCE_DIR}/.git")
-			message(FATAL_ERROR "Failed to find third party dependency in '${path}'")			
-		endif()
+    file(GLOB DIR_CONTENT path)
+    list(LENGTH RESULT CONTENT_COUNT)
+    if (CONTENT_COUNT EQUAL 0)
+        if (NOT EXISTS "${PROJECT_SOURCE_DIR}/.git")
+            message(FATAL_ERROR "Failed to find third party dependency in '${path}'")			
+        endif()
 
-		find_package(Git QUIET)
-		if (NOT Git_FOUND)
-			message(FATAL_ERROR "Failed to find Git, third party dependency could not be setup at `${path}")
-		endif()
+        find_package(Git QUIET)
+        if (NOT Git_FOUND)
+            message(FATAL_ERROR "Failed to find Git, third party dependency could not be setup at `${path}")
+        endif()
 
-		message(STATUS "Setting up dependencies as git submodules")
+        message(STATUS "Setting up dependencies as git submodules")
         execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
@@ -21,5 +21,5 @@ function(check_init_submodule path)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")
             message(FATAL_ERROR "Initializing Git submodules failed with ${GIT_SUBMOD_RESULT}")
         endif()
-	endif()
+    endif()
 endfunction()


### PR DESCRIPTION
The file had mixed indentation (spaces and tabs) when really it should've been spaces only from the beginning

I noticed the indentation change in #569 and spliced it out to make the diff of #569 proper on merge.

No testing needed as this only performs a whitespace change in `utils.cmake`. Check the diff with whitespace changes hidden to verify for yourself :P