### PR TITLE
Make link to BUILD.md relative to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Launcher used to modify Titanfall 2 to allow Northstar mods and custom content t
 
 ## Build
 
-Check [BUILD.md](https://github.com/R2Northstar/NorthstarLauncher/blob/main/BUILD.md) for instructions on how to compile, you can also download [binaries built by GitHub Actions](https://github.com/R2Northstar/NorthstarLauncher/actions).
+Check [BUILD.md](BUILD.md) for instructions on how to compile, you can also download [binaries built by GitHub Actions](https://github.com/R2Northstar/NorthstarLauncher/actions).
 
 ## Format
 


### PR DESCRIPTION
Make link to `BUILD.md` relative to `README.md` instead of a hardcoded link to relevant GitHub page

No testing needed as it only modifies `README.md`.