### PR TITLE
Add check for r2/maps folder

### DIFF
--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -104,6 +104,12 @@ void RefreshMapList()
 	}
 
 	// get maps in game dir
+	if (!std::filesystem::exists(fmt::format("{}/maps", R2::g_pModName)))
+	{
+		spdlog::error("Failed reading maps from game directory.");
+		return;
+	}
+
 	for (fs::directory_entry file : fs::directory_iterator(fmt::format("{}/maps", R2::g_pModName)))
 	{
 		if (file.path().extension() == ".bsp")

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -104,12 +104,13 @@ void RefreshMapList()
 	}
 
 	// get maps in game dir
-	if (!std::filesystem::exists(fmt::format("{}/maps", R2::g_pModName)))
+	char* gameDir = fmt::format("{}/maps", R2::g_pModName);
+	if (!std::filesystem::exists(gameDir))
 	{
 		return;
 	}
 
-	for (fs::directory_entry file : fs::directory_iterator(fmt::format("{}/maps", R2::g_pModName)))
+	for (fs::directory_entry file : fs::directory_iterator(gameDir))
 	{
 		if (file.path().extension() == ".bsp")
 		{

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -104,7 +104,7 @@ void RefreshMapList()
 	}
 
 	// get maps in game dir
-	char* gameDir = fmt::format("{}/maps", R2::g_pModName);
+	std::string gameDir = fmt::format("{}/maps", R2::g_pModName);
 	if (!std::filesystem::exists(gameDir))
 	{
 		return;

--- a/NorthstarDLL/util/printmaps.cpp
+++ b/NorthstarDLL/util/printmaps.cpp
@@ -106,7 +106,6 @@ void RefreshMapList()
 	// get maps in game dir
 	if (!std::filesystem::exists(fmt::format("{}/maps", R2::g_pModName)))
 	{
-		spdlog::error("Failed reading maps from game directory.");
 		return;
 	}
 


### PR DESCRIPTION
Adds a fix so that #564 can be re-merged

# Testing Instructions
1. Rename r2/maps  
2. Run `maps *` in the console 

If the game does not die, :tada:. 
It should just print the maps found from the vpks.

