### PR TITLE
Only run `add-to-project` action on issues

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types:
       - opened
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
PRs from forks are triggered from that fork which means that they don't have access to the necessary token causing them to fail for the first commit.