### PR TITLE
Move plugin communication handler init out of plugin manager init

### DIFF
--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -5,6 +5,7 @@
 #include "config/profile.h"
 #include "plugins/plugin_abi.h"
 #include "plugins/plugins.h"
+#include "plugins/pluginbackend.h"
 #include "util/version.h"
 #include "squirrel/squirrel.h"
 #include "shared/gamepresence.h"
@@ -62,6 +63,7 @@ bool InitialiseNorthstar()
 
 	g_pGameStatePresence = new GameStatePresence();
 	g_pPluginManager = new PluginManager();
+	g_pPluginCommunicationhandler = new PluginCommunicationHandler();
 	g_pPluginManager->LoadPlugins();
 
 	InitialiseSquirrelManagers();

--- a/NorthstarDLL/plugins/pluginbackend.cpp
+++ b/NorthstarDLL/plugins/pluginbackend.cpp
@@ -15,12 +15,6 @@ PluginCommunicationHandler* g_pPluginCommunicationhandler;
 
 static PluginDataRequest storedRequest {PluginDataRequestType::END, (PluginRespondDataCallable) nullptr};
 
-void init_plugincommunicationhandler()
-{
-	g_pPluginCommunicationhandler = new PluginCommunicationHandler;
-	g_pPluginCommunicationhandler->requestQueue = {};
-}
-
 void PluginCommunicationHandler::RunFrame()
 {
 	std::lock_guard<std::mutex> lock(requestMutex);

--- a/NorthstarDLL/plugins/pluginbackend.h
+++ b/NorthstarDLL/plugins/pluginbackend.h
@@ -39,6 +39,4 @@ class PluginCommunicationHandler
 	PluginEngineData m_sEngineData {};
 };
 
-void init_plugincommunicationhandler();
-
 extern PluginCommunicationHandler* g_pPluginCommunicationhandler;

--- a/NorthstarDLL/plugins/pluginbackend.h
+++ b/NorthstarDLL/plugins/pluginbackend.h
@@ -33,7 +33,7 @@ class PluginCommunicationHandler
 	void GeneratePresenceObjects();
 
   public:
-	std::queue<PluginDataRequest> requestQueue;
+	std::queue<PluginDataRequest> requestQueue = {};
 	std::mutex requestMutex;
 
 	PluginEngineData m_sEngineData {};

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -226,8 +226,6 @@ bool PluginManager::LoadPlugins()
 	funcs.relayInviteFunc = nullptr;
 	funcs.createObject = CreateObject;
 
-	init_plugincommunicationhandler();
-
 	data.version = ns_version.c_str();
 	data.northstarModule = g_NorthstarModule;
 


### PR DESCRIPTION
Plugin state requires this to be initialised even if `-noplugins` is passed, but if `-noplugins` is passed, it doesn't get initialised.

Moving this to `dllmain` guarantees that it is initialised properly and prevents #580 

closes #580 