### PR TITLE
add flag to disable in-game overlay

### DIFF
--- a/NorthstarDLL/core/hooks.cpp
+++ b/NorthstarDLL/core/hooks.cpp
@@ -451,10 +451,10 @@ HMODULE, WINAPI, (LPCWSTR lpLibFileName))
 {
 	if (disable_igo)
 	{
-		LPCWSTR LibFileNameEnd = lpLibFileName + wcslen(lpLibFileName);
-		LPCWSTR LibName = LibFileNameEnd - wcslen(IGO_DLL);
+		LPCWSTR lpLibFileNameEnd = lpLibFileName + wcslen(lpLibFileName);
+		LPCWSTR lpLibName = lpLibFileNameEnd - wcslen(IGO_DLL);
 
-		if (!wcsncmp(LibName, IGO_DLL, wcslen(IGO_DLL) + sizeof(*LPCWSTR)))
+		if (!wcsncmp(lpLibName, IGO_DLL, wcslen(IGO_DLL) + sizeof(wchar_t)))
 			return nullptr;
 	}
 

--- a/NorthstarDLL/core/hooks.cpp
+++ b/NorthstarDLL/core/hooks.cpp
@@ -454,7 +454,7 @@ HMODULE, WINAPI, (LPCWSTR lpLibFileName))
 		LPCWSTR LibFileNameEnd = lpLibFileName + wcslen(lpLibFileName);
 		LPCWSTR LibName = LibFileNameEnd - wcslen(IGO_DLL);
 
-		if (!wcsncmp(LibName, IGO_DLL, wcslen(IGO_DLL)))
+		if (!wcsncmp(LibName, IGO_DLL, wcslen(IGO_DLL) + sizeof(*LPCWSTR)))
 			return nullptr;
 	}
 


### PR DESCRIPTION
The Origin / EA Desktop in-game overlay is known to be quite shit.

Here are a few sources that talk about it and EA's unwillingness to fix it (at least in the past)
- https://www.reddit.com/r/origin/comments/ho3ed5/overlay_wont_go_away/
- https://steamcommunity.com/sharedfiles/filedetails/?id=2664686758
- https://www.reddit.com/r/origin/comments/h7qoni/origin_overlay_is_permanently_enabled_for_games/
(the last one is important because ea games launched over steam are put into a special Link2Ea state)

Code is simple:
- after hook dispatch check if `-disable_igo` is on the command line and store if it was
- if igo was disabled check if the `lpLibFileName` ends with `L"IGO64.dll"`
  - if it does return nullptr
