### PR TITLE
Improve replacing `xinput1_3` with `xinput9_1`

### DIFF
--- a/NorthstarDLL/core/hooks.cpp
+++ b/NorthstarDLL/core/hooks.cpp
@@ -398,7 +398,7 @@ HMODULE, WINAPI, (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
 	LPCSTR lpLibName = lpLibFileNameEnd - strlen(XINPUT1_3_DLL);
 
 	// replace xinput dll with one that has ASLR
-	if (!strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL) + 1))
+	if (lpLibFileName <= lpLibName && !strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL) + 1))
 	{
 		moduleAddress = _LoadLibraryExA("XInput9_1_0.dll", hFile, dwFlags);
 

--- a/NorthstarDLL/core/hooks.cpp
+++ b/NorthstarDLL/core/hooks.cpp
@@ -9,6 +9,8 @@
 #include <filesystem>
 #include <Psapi.h>
 
+#define XINPUT1_3_DLL "XInput1_3.dll"
+
 AUTOHOOK_INIT()
 
 // called from the ON_DLL_LOAD macros
@@ -392,8 +394,11 @@ HMODULE, WINAPI, (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
 {
 	HMODULE moduleAddress;
 
+	LPCSTR lpLibFileNameEnd = lpLibFileName + strlen(lpLibFileName);
+	LPCSTR lpLibName = lpLibFileNameEnd - strlen(XINPUT1_3_DLL);
+
 	// replace xinput dll with one that has ASLR
-	if (!strncmp(lpLibFileName, "XInput1_3.dll", 14))
+	if (!strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL)+1))
 	{
 		moduleAddress = _LoadLibraryExA("XInput9_1_0.dll", hFile, dwFlags);
 

--- a/NorthstarDLL/core/hooks.cpp
+++ b/NorthstarDLL/core/hooks.cpp
@@ -398,7 +398,7 @@ HMODULE, WINAPI, (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags))
 	LPCSTR lpLibName = lpLibFileNameEnd - strlen(XINPUT1_3_DLL);
 
 	// replace xinput dll with one that has ASLR
-	if (!strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL)+1))
+	if (!strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL) + 1))
 	{
 		moduleAddress = _LoadLibraryExA("XInput9_1_0.dll", hFile, dwFlags);
 


### PR DESCRIPTION
The previous logic compared the whole argument, which may be a path, to a string literal.
This checks if the argument ends with the string literal instead.

