### PR TITLE
Plugin related log error expecting more args

### DIFF
--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -129,7 +129,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 	if (strcmp(manifestJSON["api_version"].GetString(), std::to_string(ABI_VERSION).c_str()))
 	{
 		NS::log::PLUGINSYS->error(
-			"'{}' has an incompatible API version number '{}' in its manifest. Current ABI version is '{}'", pathstring, ABI_VERSION);
+			"'{}' has an incompatible API version number in its manifest. Current ABI version is '{}'", pathstring, ABI_VERSION);
 		return std::nullopt;
 	}
 	// Passed all checks, going to actually load it now


### PR DESCRIPTION
The related line expected 3 args but only 2 args are passed.

Blocks:

- #472 

### Testing:

The change should be obvious and not need testing. If you still wanna though. Simply replace the current DiscordRPC plugin we ship with the v1 version (grab from a release pre `v1.13`).

Before this PR you'll see something along the lines of "LOG ERROR" in your console output where plugin load happens.
With this PR it should log the error just fine.

