### PR TITLE
Add `_deps` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -373,3 +373,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# CMake deps folder?
+_deps/


### PR DESCRIPTION
Add `_deps` to `.gitignore`.

That folder gets created by CMake I think? Just noticed it getting added when I did `cmake . -G "Ninja" && cmake --build .`