### PR TITLE
Add mod versions when logging that a mod has loaded

### DIFF
--- a/NorthstarDLL/mods/modmanager.cpp
+++ b/NorthstarDLL/mods/modmanager.cpp
@@ -696,9 +696,9 @@ void ModManager::LoadMods()
 		if (mod.m_bWasReadSuccessfully)
 		{
 			if (mod.m_bEnabled)
-				spdlog::info("'{}' loaded successfully", mod.Name);
+				spdlog::info("'{}' loaded successfully, version {}", mod.Name, mod.Version);
 			else
-				spdlog::info("'{}' loaded successfully (DISABLED)", mod.Name);
+				spdlog::info("'{}' loaded successfully, version {} (DISABLED)", mod.Name, mod.Version);
 
 			m_LoadedMods.push_back(mod);
 		}


### PR DESCRIPTION
I'm aware of the logging rewrite that is currently open, but that doesn't seem to be entirely active currently and this is something that would be helpful when trying to help users

I'm unsure if the code could be implemented more efficiently, I just followed what was done with the mod name for the mod version and it worked in testing

The version number in the package folder does slightly remedy this, but there are still people that install to `mods`, and I don't see this as hurting anything

A log showing this (enabled and disabled):
Enabled mod:
![image](https://github.com/R2Northstar/NorthstarLauncher/assets/70904206/f55001f6-2a0d-4cff-8b96-e6ce31845b02)
Disabled mod:
![image](https://github.com/R2Northstar/NorthstarLauncher/assets/70904206/739e2004-e730-4345-b2fa-91264e17ef9d)
