### PR TITLE
Rework `-vanilla` to be a vanilla compatibility mode

### DIFF
--- a/NorthstarDLL/client/clientauthhooks.cpp
+++ b/NorthstarDLL/client/clientauthhooks.cpp
@@ -19,7 +19,7 @@ void, __fastcall, (void* a1))
 {
 	// don't attempt to do Atlas auth if we are in vanilla compatibility mode
 	// this prevents users from joining untrustworthy servers (unless they use a concommand or something)
-	if (g_bIsVanillaCompatible)
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 	{
 		AuthWithStryder(a1);
 		return;
@@ -48,7 +48,7 @@ AUTOHOOK(Auth3PToken, engine.dll + 0x183760,
 char*, __fastcall, ())
 // clang-format on
 {
-	if (!g_bIsVanillaCompatible && g_pMasterServerManager->m_sOwnClientAuthToken[0])
+	if (!g_pVanillaCompatibility->GetVanillaCompatibility() && g_pMasterServerManager->m_sOwnClientAuthToken[0])
 	{
 		memset(p3PToken, 0x0, 1024);
 		strcpy(p3PToken, "Protocol 3: Protect the Pilot");

--- a/NorthstarDLL/client/clientauthhooks.cpp
+++ b/NorthstarDLL/client/clientauthhooks.cpp
@@ -1,6 +1,7 @@
 #include "masterserver/masterserver.h"
 #include "core/convar/convar.h"
 #include "client/r2client.h"
+#include "core/vanilla.h"
 
 AUTOHOOK_INIT()
 
@@ -16,6 +17,14 @@ AUTOHOOK(AuthWithStryder, engine.dll + 0x1843A0,
 void, __fastcall, (void* a1))
 // clang-format on
 {
+	// don't attempt to do Atlas auth if we are in vanilla compatibility mode
+	// this prevents users from joining untrustworthy servers (unless they use a concommand or something)
+	if (g_bIsVanillaCompatible)
+	{
+		AuthWithStryder(a1);
+		return;
+	}
+
 	// game will call this forever, until it gets a valid auth key
 	// so, we need to manually invalidate our key until we're authed with northstar, then we'll allow game to auth with stryder
 	if (!g_pMasterServerManager->m_bOriginAuthWithMasterServerDone && Cvar_ns_has_agreed_to_send_token->GetInt() != DISAGREED_TO_SEND_TOKEN)
@@ -39,7 +48,7 @@ AUTOHOOK(Auth3PToken, engine.dll + 0x183760,
 char*, __fastcall, ())
 // clang-format on
 {
-	if (g_pMasterServerManager->m_sOwnClientAuthToken[0])
+	if (!g_bIsVanillaCompatible && g_pMasterServerManager->m_sOwnClientAuthToken[0])
 	{
 		memset(p3PToken, 0x0, 1024);
 		strcpy(p3PToken, "Protocol 3: Protect the Pilot");

--- a/NorthstarDLL/core/vanilla.h
+++ b/NorthstarDLL/core/vanilla.h
@@ -4,4 +4,26 @@
 /// In this mode we shouldn't auth with Atlas, which prevents users from joining a
 /// non-trusted server. This means that we can unrestrict client/server commands
 /// as well as various other small changes for compatibility
-static bool g_bIsVanillaCompatible = false;
+class VanillaCompatibility
+{
+  public:
+	void SetVanillaCompatibility(bool isVanilla)
+	{
+		static bool bInitialised = false;
+		if (bInitialised)
+			return;
+
+		bInitialised = true;
+		m_bIsVanillaCompatible = isVanilla;
+	}
+
+	bool GetVanillaCompatibility()
+	{
+		return m_bIsVanillaCompatible;
+	}
+
+  private:
+	bool m_bIsVanillaCompatible = false;
+};
+
+inline VanillaCompatibility* g_pVanillaCompatibility;

--- a/NorthstarDLL/core/vanilla.h
+++ b/NorthstarDLL/core/vanilla.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/// Determines if we are in vanilla-compatibility mode.
+/// In this mode we shouldn't auth with Atlas, which prevents users from joining a
+/// non-trusted server. This means that we can unrestrict client/server commands
+/// as well as various other small changes for compatibility
+static bool g_bIsVanillaCompatible = false;

--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -55,7 +55,8 @@ bool InitialiseNorthstar()
 	g_pCrashHandler->SetAllFatal(bAllFatal);
 
 	// determine if we are in vanilla-compatibility mode
-	g_bIsVanillaCompatible = strstr(GetCommandLineA(), "-vanilla") != NULL;
+	g_pVanillaCompatibility = new VanillaCompatibility();
+	g_pVanillaCompatibility->SetVanillaCompatibility(strstr(GetCommandLineA(), "-vanilla") != NULL);
 
 	// Write launcher version to log
 	StartupLog();

--- a/NorthstarDLL/dllmain.cpp
+++ b/NorthstarDLL/dllmain.cpp
@@ -2,6 +2,7 @@
 #include "logging/logging.h"
 #include "logging/crashhandler.h"
 #include "core/memalloc.h"
+#include "core/vanilla.h"
 #include "config/profile.h"
 #include "plugins/plugin_abi.h"
 #include "plugins/plugins.h"
@@ -52,6 +53,9 @@ bool InitialiseNorthstar()
 	g_pCrashHandler = new CCrashHandler();
 	bool bAllFatal = strstr(GetCommandLineA(), "-crash_handle_all") != NULL;
 	g_pCrashHandler->SetAllFatal(bAllFatal);
+
+	// determine if we are in vanilla-compatibility mode
+	g_bIsVanillaCompatible = strstr(GetCommandLineA(), "-vanilla") != NULL;
 
 	// Write launcher version to log
 	StartupLog();

--- a/NorthstarDLL/masterserver/masterserver.cpp
+++ b/NorthstarDLL/masterserver/masterserver.cpp
@@ -3,6 +3,7 @@
 #include "shared/playlist.h"
 #include "server/auth/serverauthentication.h"
 #include "core/tier0.h"
+#include "core/vanilla.h"
 #include "engine/r2engine.h"
 #include "mods/modmanager.h"
 #include "shared/misccommands.h"
@@ -87,7 +88,7 @@ size_t CurlWriteToStringBufferCallback(char* contents, size_t size, size_t nmemb
 
 void MasterServerManager::AuthenticateOriginWithMasterServer(const char* uid, const char* originToken)
 {
-	if (m_bOriginAuthWithMasterServerInProgress)
+	if (m_bOriginAuthWithMasterServerInProgress || g_bIsVanillaCompatible)
 		return;
 
 	// do this here so it's instantly set
@@ -465,7 +466,7 @@ void MasterServerManager::RequestMainMenuPromos()
 void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char* playerToken)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer)
+	if (m_bAuthenticatingWithGameServer || g_bIsVanillaCompatible)
 		return;
 
 	m_bAuthenticatingWithGameServer = true;
@@ -600,7 +601,7 @@ void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char*
 void MasterServerManager::AuthenticateWithServer(const char* uid, const char* playerToken, RemoteServerInfo server, const char* password)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer)
+	if (m_bAuthenticatingWithGameServer || g_bIsVanillaCompatible)
 		return;
 
 	m_bAuthenticatingWithGameServer = true;

--- a/NorthstarDLL/masterserver/masterserver.cpp
+++ b/NorthstarDLL/masterserver/masterserver.cpp
@@ -88,7 +88,7 @@ size_t CurlWriteToStringBufferCallback(char* contents, size_t size, size_t nmemb
 
 void MasterServerManager::AuthenticateOriginWithMasterServer(const char* uid, const char* originToken)
 {
-	if (m_bOriginAuthWithMasterServerInProgress || g_bIsVanillaCompatible)
+	if (m_bOriginAuthWithMasterServerInProgress || g_pVanillaCompatibility->GetVanillaCompatibility())
 		return;
 
 	// do this here so it's instantly set
@@ -466,7 +466,7 @@ void MasterServerManager::RequestMainMenuPromos()
 void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char* playerToken)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer || g_bIsVanillaCompatible)
+	if (m_bAuthenticatingWithGameServer || g_pVanillaCompatibility->GetVanillaCompatibility())
 		return;
 
 	m_bAuthenticatingWithGameServer = true;
@@ -601,7 +601,7 @@ void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char*
 void MasterServerManager::AuthenticateWithServer(const char* uid, const char* playerToken, RemoteServerInfo server, const char* password)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer || g_bIsVanillaCompatible)
+	if (m_bAuthenticatingWithGameServer || g_pVanillaCompatibility->GetVanillaCompatibility())
 		return;
 
 	m_bAuthenticatingWithGameServer = true;

--- a/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
@@ -34,7 +34,7 @@ AUTOHOOK(CLC_Screenshot_WriteToBuffer, engine.dll + 0x22AF20,
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 57 48 83 EC 20 8B 42 10
 // clang-format on
 {
-	if (g_bIsVanillaCompatible)
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 		return CLC_Screenshot_WriteToBuffer(thisptr, buffer);
 	return false;
 }
@@ -44,7 +44,7 @@ AUTOHOOK(CLC_Screenshot_ReadFromBuffer, engine.dll + 0x221F00,
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B DA 48 8B 52 38
 // clang-format on
 {
-	if (g_bIsVanillaCompatible)
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 		return CLC_Screenshot_WriteToBuffer(thisptr, buffer);
 	return false;
 }
@@ -261,13 +261,13 @@ AUTOHOOK(IsRespawnMod, engine.dll + 0x1C6360,
 bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 15 ? ? ? ? E8 ? ? ? ? 85 C0 74 63
 // clang-format on
 {
-	if (g_bIsVanillaCompatible)
-		return true;
-
 	// somewhat temp, store the modname here, since we don't have a proper ptr in engine to it rn
 	int iSize = strlen(pModName);
 	R2::g_pModName = new char[iSize + 1];
 	strcpy(R2::g_pModName, pModName);
+
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
+		return false;
 
 	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !Tier0::CommandLine()->CheckParm("-norestrictservercommands");
 }

--- a/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
@@ -45,7 +45,7 @@ bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 48 89 6C 24 ? 
 // clang-format on
 {
 	if (g_pVanillaCompatibility->GetVanillaCompatibility())
-		return CLC_Screenshot_WriteToBuffer(thisptr, buffer);
+		return CLC_Screenshot_ReadFromBuffer(thisptr, buffer);
 	return false;
 }
 

--- a/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
+++ b/NorthstarDLL/shared/exploit_fixes/exploitfixes.cpp
@@ -5,6 +5,7 @@
 #include "engine/r2engine.h"
 #include "client/r2client.h"
 #include "core/math/vector.h"
+#include "core/vanilla.h"
 
 AUTOHOOK_INIT()
 
@@ -33,6 +34,8 @@ AUTOHOOK(CLC_Screenshot_WriteToBuffer, engine.dll + 0x22AF20,
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 57 48 83 EC 20 8B 42 10
 // clang-format on
 {
+	if (g_bIsVanillaCompatible)
+		return CLC_Screenshot_WriteToBuffer(thisptr, buffer);
 	return false;
 }
 
@@ -41,6 +44,8 @@ AUTOHOOK(CLC_Screenshot_ReadFromBuffer, engine.dll + 0x221F00,
 bool, __fastcall, (void* thisptr, void* buffer)) // 48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B DA 48 8B 52 38
 // clang-format on
 {
+	if (g_bIsVanillaCompatible)
+		return CLC_Screenshot_WriteToBuffer(thisptr, buffer);
 	return false;
 }
 
@@ -256,6 +261,9 @@ AUTOHOOK(IsRespawnMod, engine.dll + 0x1C6360,
 bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 15 ? ? ? ? E8 ? ? ? ? 85 C0 74 63
 // clang-format on
 {
+	if (g_bIsVanillaCompatible)
+		return true;
+
 	// somewhat temp, store the modname here, since we don't have a proper ptr in engine to it rn
 	int iSize = strlen(pModName);
 	R2::g_pModName = new char[iSize + 1];

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -9,6 +9,7 @@
 #include "plugins/plugin_abi.h"
 #include "plugins/plugins.h"
 #include "ns_version.h"
+#include "core/vanilla.h"
 
 #include <any>
 
@@ -271,6 +272,9 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 	defconst(m_pSQVM, "NS_VERSION_MINOR", version[1]);
 	defconst(m_pSQVM, "NS_VERSION_PATCH", version[2]);
 	defconst(m_pSQVM, "NS_VERSION_DEV", version[3]);
+
+	// define squirrel constant for if we are in vanilla-compatibility mode
+	defconst(m_pSQVM, "VANILLA", g_bIsVanillaCompatible)
 
 	g_pSquirrel<context>->messageBuffer = new SquirrelMessageBuffer();
 	g_pPluginManager->InformSQVMCreated(context, newSqvm);

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -274,7 +274,7 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 	defconst(m_pSQVM, "NS_VERSION_DEV", version[3]);
 
 	// define squirrel constant for if we are in vanilla-compatibility mode
-	defconst(m_pSQVM, "VANILLA", g_bIsVanillaCompatible)
+	defconst(m_pSQVM, "VANILLA", g_bIsVanillaCompatible);
 
 	g_pSquirrel<context>->messageBuffer = new SquirrelMessageBuffer();
 	g_pPluginManager->InformSQVMCreated(context, newSqvm);

--- a/NorthstarDLL/squirrel/squirrel.cpp
+++ b/NorthstarDLL/squirrel/squirrel.cpp
@@ -274,7 +274,7 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 	defconst(m_pSQVM, "NS_VERSION_DEV", version[3]);
 
 	// define squirrel constant for if we are in vanilla-compatibility mode
-	defconst(m_pSQVM, "VANILLA", g_bIsVanillaCompatible);
+	defconst(m_pSQVM, "VANILLA", g_pVanillaCompatibility->GetVanillaCompatibility());
 
 	g_pSquirrel<context>->messageBuffer = new SquirrelMessageBuffer();
 	g_pPluginManager->InformSQVMCreated(context, newSqvm);

--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -255,7 +255,7 @@ void PrependPath()
 bool ShouldLoadNorthstar(int argc, char* argv[])
 {
 	for (int i = 0; i < argc; i++)
-		if (!strcmp(argv[i], "-vanilla"))
+		if (!strcmp(argv[i], "-noworkerdll"))
 			return false;
 
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");

--- a/NorthstarLauncher/main.cpp
+++ b/NorthstarLauncher/main.cpp
@@ -255,7 +255,7 @@ void PrependPath()
 bool ShouldLoadNorthstar(int argc, char* argv[])
 {
 	for (int i = 0; i < argc; i++)
-		if (!strcmp(argv[i], "-noworkerdll"))
+		if (!strcmp(argv[i], "-nonorthstardll"))
 			return false;
 
 	auto runNorthstarFile = std::ifstream("run_northstar.txt");


### PR DESCRIPTION
Old `-vanilla` behaviour is now handled by `-nonorthstardll`

`VANILLA` is exposed as a squirrel constant, set to true when in vanilla compatibility mode.

Differences when in vanilla compatibility mode:
- Doesn't restrict server commands (same as `-norestrictservercommands`)
- Doesn't block FairFight screenshot functions 
- Doesn't do Atlas-related stuff (except for mainmenupromos)


With this PR various script changes will still be needed for proper vanilla compatibility, but it's a good start.

closes #588