### PR TITLE
Disable more compression methods for minizip

### DIFF
--- a/cmake/Findminizip.cmake
+++ b/cmake/Findminizip.cmake
@@ -2,7 +2,13 @@
 if(NOT minizip_FOUND)
 	check_init_submodule(${PROJECT_SOURCE_DIR}/thirdparty/minizip)
 
+	set(MZ_ZLIB ON CACHE BOOL "Enable ZLIB compression, needed for DEFLATE")
+	set(MZ_BZIP2 OFF CACHE BOOL "Disable BZIP2 compression")
 	set(MZ_LZMA OFF CACHE BOOL "Disable LZMA & XZ compression")
+	set(MZ_PKCRYPT OFF CACHE BOOL "Disable PKWARE traditional encryption")
+	set(MZ_WZAES OFF CACHE BOOL "Disable WinZIP AES encryption")
+	set(MZ_ZSTD OFF CACHE BOOL "Disable ZSTD compression")
+	set(MZ_SIGNING OFF CACHE BOOL "Disable zip signing support")
 
 	add_subdirectory(${PROJECT_SOURCE_DIR}/thirdparty/minizip minizip)
 	set(minizip_FOUND 1 PARENT_SCOPE)


### PR DESCRIPTION
Doing this because I ran into the following error while compiling with msvc-wine
```
z:/home/sentry/git/NorthstarLauncher/thirdparty/minizip/mz_strm_zstd.c(17): fatal error C1083: Cannot open include file: 'zstd.h': No such file or directory
```

What is actually needed from minizip?
This was likely not an issue on windows because of `MZ_FETCH_LIBS`. Should we turn that off to ensure no extra dependencies get in without our knowledge?