### PR TITLE
Replace audio event fetching with hook

### DIFF
--- a/NorthstarDLL/CMakeLists.txt
+++ b/NorthstarDLL/CMakeLists.txt
@@ -148,7 +148,6 @@ add_library(NorthstarDLL SHARED
             "util/version.h"
             "util/wininfo.cpp"
             "util/wininfo.h"
-            "audio_asm.asm"
             "dllmain.cpp"
             "dllmain.h"
             "ns_version.h"

--- a/NorthstarDLL/audio_asm.asm
+++ b/NorthstarDLL/audio_asm.asm
@@ -1,8 +1,0 @@
-public Audio_GetParentEvent
-
-.code
-Audio_GetParentEvent proc
-	mov rax, r12
-	ret
-Audio_GetParentEvent endp
-end


### PR DESCRIPTION
Takes the previous audio event code, which relied on reading out a register using masm, and replaces it with a new hook.


Adapted from NorthstarPrime https://github.com/F1F7Y/NorthstarPrime

