### PR TITLE
Replace Plugin manifest JSON with symbols in the lib binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
         source: 'NorthstarDLL NorthstarLauncher'
         exclude: 'NorthstarDLL/include loader_launcher_proxy loader_wsock32_proxy'
         extensions: 'h,cpp'
-        clangFormatVersion: 13
+        clangFormatVersion: 15
         style: file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
         source: 'NorthstarDLL NorthstarLauncher'
         exclude: 'NorthstarDLL/include loader_launcher_proxy loader_wsock32_proxy'
         extensions: 'h,cpp'
-        clangFormatVersion: 15
+        clangFormatVersion: 13
         style: file

--- a/NorthstarDLL/plugins/plugin_abi.h
+++ b/NorthstarDLL/plugins/plugin_abi.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "squirrel/squirrelclasstypes.h"
 
-#define ABI_VERSION 3
+#define ABI_VERSION 4
 
 enum PluginLoadDLL
 {

--- a/NorthstarDLL/plugins/plugin_abi.h
+++ b/NorthstarDLL/plugins/plugin_abi.h
@@ -5,12 +5,13 @@
 #define ABI_VERSION 4
 
 // can't use bitwise ops on enum classes
-namespace PluginContext {
-	enum: uint8_t
-		  {
-			  DEDICATED = 0x1,
-			  CLIENT = 0x2,
-		  };
+namespace PluginContext
+{
+	enum : uint8_t
+	{
+		DEDICATED = 0x1,
+		CLIENT = 0x2,
+	};
 }
 
 enum PluginLoadDLL

--- a/NorthstarDLL/plugins/plugin_abi.h
+++ b/NorthstarDLL/plugins/plugin_abi.h
@@ -1,7 +1,17 @@
 #pragma once
 #include "squirrel/squirrelclasstypes.h"
+#include <stdint.h>
 
 #define ABI_VERSION 4
+
+// can't use bitwise ops on enum classes
+namespace PluginContext {
+	enum: uint8_t
+		  {
+			  DEDICATED = 0x1,
+			  CLIENT = 0x2,
+		  };
+}
 
 enum PluginLoadDLL
 {

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -125,7 +125,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 
 	Plugin plugin = Plugin(pluginLib, m_vLoadedPlugins.size(), pathstring);
 
-	if (!plugin.valid || (!plugin.run_on_server && IsDedicatedServer())
+	if (!plugin.valid || (!plugin.run_on_server && IsDedicatedServer()))
 	{
 		freeLibrary(pluginLib);
 		return std::nullopt;
@@ -135,7 +135,6 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 	// NS::log::PLUGINSYS->info("Succesfully loaded {}", pathstring); // we log the same thing 20 lines later why is this here
 
 	plugin.logger = std::make_shared<ColoredLogger>(plugin.logName, NS::Colors::PLUGIN);
-	d
 	RegisterLogger(plugin.logger);
 	NS::log::PLUGINSYS->info("Loading plugin {} version {}", plugin.logName, plugin.version);
 	m_vLoadedPlugins.push_back(plugin);

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -16,7 +16,8 @@
 #include "logging/logging.h"
 #include "dedicated/dedicated.h"
 
-namespace Symbol {
+namespace Symbol
+{
 	static const char* REQUIRED_ABI_VERSION = "PLUGIN_ABI_VERSION";
 	static const char* NAME = "PLUGIN_NAME";
 	static const char* DESCRIPTION = "PLUGIN_DESCRIPTION";
@@ -31,46 +32,43 @@ namespace Symbol {
 	static const char* SQVM_DESTROYED = "PLUGIN_INFORM_SQVM_CREATED";
 	static const char* LIB_LOAD = "PLUGIN_INFORM_DLL_LOAD";
 	static const char* RUN_FRAME = "PLUGIN_RUNFRAME";
-};
+}; // namespace Symbol
 
 PluginManager* g_pPluginManager;
 
-template<typename T> T GetSymbolValue(HMODULE lib, const char* symbol)
+template <typename T> T GetSymbolValue(HMODULE lib, const char* symbol)
 {
 	const T* addr = (T*)GetProcAddress(lib, symbol);
 	return addr ? *addr : NULL;
 }
 
 Plugin::Plugin(HMODULE lib, int handle, std::string path)
-		: name(GetSymbolValue<char*>(lib, Symbol::NAME)),
-		logName(GetSymbolValue<char*>(lib, Symbol::LOG_NAME)),
-		dependencyName(GetSymbolValue<char*>(lib, Symbol::DEPENDENCY_NAME)),
-		description(GetSymbolValue<char*>(lib, Symbol::DESCRIPTION)),
-		api_version(GetSymbolValue<uint32_t>(lib, Symbol::REQUIRED_ABI_VERSION)),
-		  version(GetSymbolValue<char*>(lib, Symbol::VERSION)),
-		  handle(handle),
-		  runOnContext(GetSymbolValue<uint8_t>(lib, Symbol::CONTEXT)),
-		  run_on_client(runOnContext & PluginContext::CLIENT),
-		  run_on_server(runOnContext & PluginContext::DEDICATED),
-		  init(GetSymbolValue<PLUGIN_INIT_TYPE>(lib, Symbol::INIT)),
-		  init_sqvm_client(GetSymbolValue<PLUGIN_INIT_SQVM_TYPE>(lib, Symbol::CLIENT_SQVM_INIT)),
-		  init_sqvm_server(GetSymbolValue<PLUGIN_INIT_SQVM_TYPE>(lib, Symbol::SERVER_SQVM_INIT)),
-		  inform_sqvm_created(GetSymbolValue<PLUGIN_INFORM_SQVM_CREATED_TYPE>(lib,Symbol::SQVM_CREATED)),
-		  inform_sqvm_destroyed(GetSymbolValue<PLUGIN_INFORM_SQVM_DESTROYED_TYPE>(lib, Symbol::SQVM_DESTROYED)),
-		  inform_dll_load(GetSymbolValue<PLUGIN_INFORM_DLL_LOAD_TYPE>(lib, Symbol::LIB_LOAD)),
-		  run_frame(GetSymbolValue<PLUGIN_RUNFRAME>(lib, Symbol::RUN_FRAME)),
-		  valid(api_version && name && description && version && init && logName && runOnContext) {
-			#define LOG_MISSING_SYMBOL(e, symbol) if(!e) NS::log::PLUGINSYS->error("'{} does not export required symbol '{}'", path, symbol);
-			  LOG_MISSING_SYMBOL(api_version, Symbol::REQUIRED_ABI_VERSION)
-				LOG_MISSING_SYMBOL(name, Symbol::NAME)
-				LOG_MISSING_SYMBOL(description, Symbol::DESCRIPTION)
-				LOG_MISSING_SYMBOL(version, Symbol::VERSION)
-				LOG_MISSING_SYMBOL(logName, Symbol::LOG_NAME)
-				LOG_MISSING_SYMBOL(runOnContext, Symbol::CONTEXT)
-				LOG_MISSING_SYMBOL(init, Symbol::INIT)
+	: name(GetSymbolValue<char*>(lib, Symbol::NAME)), logName(GetSymbolValue<char*>(lib, Symbol::LOG_NAME)),
+	  dependencyName(GetSymbolValue<char*>(lib, Symbol::DEPENDENCY_NAME)), description(GetSymbolValue<char*>(lib, Symbol::DESCRIPTION)),
+	  api_version(GetSymbolValue<uint32_t>(lib, Symbol::REQUIRED_ABI_VERSION)), version(GetSymbolValue<char*>(lib, Symbol::VERSION)),
+	  handle(handle), runOnContext(GetSymbolValue<uint8_t>(lib, Symbol::CONTEXT)), run_on_client(runOnContext & PluginContext::CLIENT),
+	  run_on_server(runOnContext & PluginContext::DEDICATED), init(GetSymbolValue<PLUGIN_INIT_TYPE>(lib, Symbol::INIT)),
+	  init_sqvm_client(GetSymbolValue<PLUGIN_INIT_SQVM_TYPE>(lib, Symbol::CLIENT_SQVM_INIT)),
+	  init_sqvm_server(GetSymbolValue<PLUGIN_INIT_SQVM_TYPE>(lib, Symbol::SERVER_SQVM_INIT)),
+	  inform_sqvm_created(GetSymbolValue<PLUGIN_INFORM_SQVM_CREATED_TYPE>(lib, Symbol::SQVM_CREATED)),
+	  inform_sqvm_destroyed(GetSymbolValue<PLUGIN_INFORM_SQVM_DESTROYED_TYPE>(lib, Symbol::SQVM_DESTROYED)),
+	  inform_dll_load(GetSymbolValue<PLUGIN_INFORM_DLL_LOAD_TYPE>(lib, Symbol::LIB_LOAD)),
+	  run_frame(GetSymbolValue<PLUGIN_RUNFRAME>(lib, Symbol::RUN_FRAME)),
+	  valid(api_version && name && description && version && init && logName && runOnContext)
+{
+#define LOG_MISSING_SYMBOL(e, symbol)                                                                                                      \
+	if (!e)                                                                                                                                \
+		NS::log::PLUGINSYS->error("'{} does not export required symbol '{}'", path, symbol);
+	LOG_MISSING_SYMBOL(api_version, Symbol::REQUIRED_ABI_VERSION)
+	LOG_MISSING_SYMBOL(name, Symbol::NAME)
+	LOG_MISSING_SYMBOL(description, Symbol::DESCRIPTION)
+	LOG_MISSING_SYMBOL(version, Symbol::VERSION)
+	LOG_MISSING_SYMBOL(logName, Symbol::LOG_NAME)
+	LOG_MISSING_SYMBOL(runOnContext, Symbol::CONTEXT)
+	LOG_MISSING_SYMBOL(init, Symbol::INIT)
 #undef LOG_MISSING_SYMBOL
 
-		  	if (ABI_VERSION != api_version)
+	if (ABI_VERSION != api_version)
 	{
 		NS::log::PLUGINSYS->error(
 			"'{}' has an incompatible API version number ('{}') in its manifest. Current ABI version is '{}'",

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -125,7 +125,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 
 	Plugin plugin = Plugin(pluginLib, m_vLoadedPlugins.size(), pathstring);
 
-	if (!plugin.run_on_server && IsDedicatedServer())
+	if (!plugin.valid || (!plugin.run_on_server && IsDedicatedServer())
 	{
 		freeLibrary(pluginLib);
 		return std::nullopt;
@@ -135,6 +135,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 	// NS::log::PLUGINSYS->info("Succesfully loaded {}", pathstring); // we log the same thing 20 lines later why is this here
 
 	plugin.logger = std::make_shared<ColoredLogger>(plugin.logName, NS::Colors::PLUGIN);
+	d
 	RegisterLogger(plugin.logger);
 	NS::log::PLUGINSYS->info("Loading plugin {} version {}", plugin.logName, plugin.version);
 	m_vLoadedPlugins.push_back(plugin);

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -68,23 +68,23 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 		return std::nullopt;
 	}
 
-	uint32_t* abiVersion = (uint32_t*)GetProcAddress(pluginLib, "ABI_VERSION");
-	char** name = (char**)GetProcAddress(pluginLib, "NAME");
-	char** description = (char**)GetProcAddress(pluginLib, "DESCRIPTION");
-	char** abbreviation = (char**)GetProcAddress(pluginLib, "ABBREVIATION");
-	char** version = (char**)GetProcAddress(pluginLib, "VERSION");
-	char** dependencyName = (char**)GetProcAddress(pluginLib, "DEPENDENCY_NAME");
-	uint8_t* context = (uint8_t*)GetProcAddress(pluginLib, "CONTEXT");
+	uint32_t* abiVersion = (uint32_t*)GetProcAddress(pluginLib, "PLUGIN_ABI_VERSION");
+	char** name = (char**)GetProcAddress(pluginLib, "PLUGIN_NAME");
+	char** description = (char**)GetProcAddress(pluginLib, "PLUGIN_DESCRIPTION");
+	char** abbreviation = (char**)GetProcAddress(pluginLib, "PLUGIN_ABBREVIATION");
+	char** version = (char**)GetProcAddress(pluginLib, "PLUGIN_VERSION");
+	char** dependencyName = (char**)GetProcAddress(pluginLib, "PLUGIN_DEPENDENCY_NAME");
+	uint8_t* context = (uint8_t*)GetProcAddress(pluginLib, "PLUGIN_CONTEXT");
 	PLUGIN_INIT_TYPE plugin_init = (PLUGIN_INIT_TYPE)GetProcAddress(pluginLib, "PLUGIN_INIT");
 
 	// ensure all required values are found
 #define ASSERT_HAS_PROP(e, prop) if (!e) { NS::log::PLUGINSYS->error("'{}' is not exporting it's {}", pathstring, prop); freeLibrary(pluginLib); return std::nullopt;; }
-		ASSERT_HAS_PROP(abiVersion, "ABI_VERSION")
-		ASSERT_HAS_PROP(name, "NAME");
-		ASSERT_HAS_PROP(description, "DESCRIPTION");
-		ASSERT_HAS_PROP(abbreviation, "ABBREVIATION");
-		ASSERT_HAS_PROP(version, "VERSION");
-		ASSERT_HAS_PROP(context, "CONTEXT");
+		ASSERT_HAS_PROP(abiVersion, "PLUGIN_ABI_VERSION")
+		ASSERT_HAS_PROP(name, "PLUGIN_NAME");
+		ASSERT_HAS_PROP(description, "PLUGIN_DESCRIPTION");
+		ASSERT_HAS_PROP(abbreviation, "PLUGIN_ABBREVIATION");
+		ASSERT_HAS_PROP(version, "PLUGIN_VERSION");
+		ASSERT_HAS_PROP(context, "PLUGIN_CONTEXT");
 		ASSERT_HAS_PROP(plugin_init, "PLUGIN_INIT");
 #undef ASSERT_HAS_PROP
 

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -68,18 +68,18 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 		return std::nullopt;
 	}
 
-	uint32_t* abi_version = (uint32_t*)GetProcAddress(pluginLib, "ABI_VERSION");
+	uint32_t* abiVersion = (uint32_t*)GetProcAddress(pluginLib, "ABI_VERSION");
 	char** name = (char**)GetProcAddress(pluginLib, "NAME");
 	char** description = (char**)GetProcAddress(pluginLib, "DESCRIPTION");
 	char** abbreviation = (char**)GetProcAddress(pluginLib, "ABBREVIATION");
 	char** version = (char**)GetProcAddress(pluginLib, "VERSION");
-	char** dependency_name = (char**)GetProcAddress(pluginLib, "DEPENDENCY_NAME");
+	char** dependencyName = (char**)GetProcAddress(pluginLib, "DEPENDENCY_NAME");
 	uint8_t* context = (uint8_t*)GetProcAddress(pluginLib, "CONTEXT");
 	PLUGIN_INIT_TYPE plugin_init = (PLUGIN_INIT_TYPE)GetProcAddress(pluginLib, "PLUGIN_INIT");
 
 	// ensure all required values are found
 #define ASSERT_HAS_PROP(e, prop) if (!e) { NS::log::PLUGINSYS->error("'{}' is not exporting it's {}", pathstring, prop); freeLibrary(pluginLib); return std::nullopt;; }
-		ASSERT_HAS_PROP(abi_version, "ABI_VERSION")
+		ASSERT_HAS_PROP(abiVersion, "ABI_VERSION")
 		ASSERT_HAS_PROP(name, "NAME");
 		ASSERT_HAS_PROP(description, "DESCRIPTION");
 		ASSERT_HAS_PROP(abbreviation, "ABBREVIATION");
@@ -88,10 +88,10 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 		ASSERT_HAS_PROP(plugin_init, "PLUGIN_INIT");
 #undef ASSERT_HAS_PROP
 
-		if (ABI_VERSION != *abi_version)
+		if (ABI_VERSION != *abiVersion)
 		{
 			NS::log::PLUGINSYS->error(
-				"'{}' has an incompatible API version number ('{}') in its manifest. Current ABI version is '{}'", pathstring, *abi_version, ABI_VERSION);
+				"'{}' has an incompatible API version number ('{}') in its manifest. Current ABI version is '{}'", pathstring, *abiVersion, ABI_VERSION);
 			freeLibrary(pluginLib);
 			return std::nullopt;
 		}
@@ -102,7 +102,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 	plugin.name = *name;
 	plugin.displayName = *abbreviation;
 	plugin.description = *description;
-	plugin.api_version = *abi_version;
+	plugin.api_version = *abiVersion;
 	plugin.version = *version;
 	plugin.init = *plugin_init;
 
@@ -115,9 +115,9 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 		return std::nullopt;
 	}
 
-	if (dependency_name)
+	if (dependencyName)
 	{
-		plugin.dependencyName = *dependency_name;
+		plugin.dependencyName = *dependencyName;
 	}
 	else
 	{

--- a/NorthstarDLL/plugins/plugins.cpp
+++ b/NorthstarDLL/plugins/plugins.cpp
@@ -117,9 +117,7 @@ std::optional<Plugin> PluginManager::LoadPlugin(fs::path path, PluginInitFuncs* 
 
 	if (!pluginLib)
 	{
-		NS::log::PLUGINSYS->error(
-			"'Failed to load library '{}'",
-			std::system_category().message(GetLastError()));
+		NS::log::PLUGINSYS->error("'Failed to load library '{}'", std::system_category().message(GetLastError()));
 		return std::nullopt;
 	}
 

--- a/NorthstarDLL/plugins/plugins.h
+++ b/NorthstarDLL/plugins/plugins.h
@@ -7,6 +7,8 @@ const int IDR_RCDATA1 = 101;
 class Plugin
 {
   public:
+	const bool valid;
+
 	const char* name;
 	const char* logName;
 	const char* dependencyName;
@@ -21,44 +23,37 @@ class Plugin
 
 	std::shared_ptr<ColoredLogger> logger;
 
+	const uint8_t runOnContext; // bitfield that gets resolved to run_on_client and run_on_server
 	const bool run_on_client = false;
 	const bool run_on_server = false;
 
   public:
+	Plugin(HMODULE lib, int handle, std::string path);
+	/*
 	Plugin(
-			const char* name,
-			const char* logName,
-			const char* dependencyName,
-			const char* description,
-			uint32_t api_version,
-			const char* version,
-			int handle,
-			bool runOnServer,
-			bool runOnClient,
-			const PLUGIN_INIT_TYPE init,
-			const PLUGIN_INIT_SQVM_TYPE initClientSqvm,
-			const PLUGIN_INIT_SQVM_TYPE initServerSqvm,
-			const PLUGIN_INFORM_SQVM_CREATED_TYPE sqvmCreated,
-			const PLUGIN_INFORM_SQVM_DESTROYED_TYPE sqvmDestroyed,
-			const PLUGIN_INFORM_DLL_LOAD_TYPE informLibLoad,
-			const PLUGIN_RUNFRAME runFrame)
-		: name(name)
-		, logName(logName)
-		, dependencyName(dependencyName)
-		, description(description)
-		, api_version(api_version)
-		, version(version)
-		, handle(handle)
-		, run_on_client(runOnClient)
-		, run_on_server(runOnServer)
-		, init(init)
-		, init_sqvm_client(initClientSqvm)
-		, init_sqvm_server(initServerSqvm)
-		, inform_sqvm_created(sqvmCreated)
-		, inform_sqvm_destroyed(sqvmDestroyed)
-		, inform_dll_load(informLibLoad)
-		, run_frame(runFrame)
-	{};
+		const bool valid, // true if all required values are not null
+
+		const char* name,
+		const char* logName,
+		const char* dependencyName,
+		const char* description,
+		uint32_t api_version,
+		const char* version,
+		int handle,
+		bool runOnServer,
+		bool runOnClient,
+		const PLUGIN_INIT_TYPE init,
+		const PLUGIN_INIT_SQVM_TYPE initClientSqvm,
+		const PLUGIN_INIT_SQVM_TYPE initServerSqvm,
+		const PLUGIN_INFORM_SQVM_CREATED_TYPE sqvmCreated,
+		const PLUGIN_INFORM_SQVM_DESTROYED_TYPE sqvmDestroyed,
+		const PLUGIN_INFORM_DLL_LOAD_TYPE informLibLoad,
+		const PLUGIN_RUNFRAME runFrame)
+		: name(name), logName(logName), dependencyName(dependencyName), description(description), api_version(api_version),
+		  version(version), handle(handle), run_on_client(runOnClient), run_on_server(runOnServer), init(init),
+		  init_sqvm_client(initClientSqvm), init_sqvm_server(initServerSqvm), inform_sqvm_created(sqvmCreated),
+		  inform_sqvm_destroyed(sqvmDestroyed), inform_dll_load(informLibLoad), run_frame(runFrame) {};
+		  */
 
 	const PLUGIN_INIT_TYPE init;
 

--- a/NorthstarDLL/plugins/plugins.h
+++ b/NorthstarDLL/plugins/plugins.h
@@ -29,31 +29,6 @@ class Plugin
 
   public:
 	Plugin(HMODULE lib, int handle, std::string path);
-	/*
-	Plugin(
-		const bool valid, // true if all required values are not null
-
-		const char* name,
-		const char* logName,
-		const char* dependencyName,
-		const char* description,
-		uint32_t api_version,
-		const char* version,
-		int handle,
-		bool runOnServer,
-		bool runOnClient,
-		const PLUGIN_INIT_TYPE init,
-		const PLUGIN_INIT_SQVM_TYPE initClientSqvm,
-		const PLUGIN_INIT_SQVM_TYPE initServerSqvm,
-		const PLUGIN_INFORM_SQVM_CREATED_TYPE sqvmCreated,
-		const PLUGIN_INFORM_SQVM_DESTROYED_TYPE sqvmDestroyed,
-		const PLUGIN_INFORM_DLL_LOAD_TYPE informLibLoad,
-		const PLUGIN_RUNFRAME runFrame)
-		: name(name), logName(logName), dependencyName(dependencyName), description(description), api_version(api_version),
-		  version(version), handle(handle), run_on_client(runOnClient), run_on_server(runOnServer), init(init),
-		  init_sqvm_client(initClientSqvm), init_sqvm_server(initServerSqvm), inform_sqvm_created(sqvmCreated),
-		  inform_sqvm_destroyed(sqvmDestroyed), inform_dll_load(informLibLoad), run_frame(runFrame) {};
-		  */
 
 	const PLUGIN_INIT_TYPE init;
 

--- a/NorthstarDLL/plugins/plugins.h
+++ b/NorthstarDLL/plugins/plugins.h
@@ -4,45 +4,73 @@
 
 const int IDR_RCDATA1 = 101;
 
-// can't use bitwise ops on enum classes
-namespace PluginContext {
-	enum: uint8_t
-		  {
-			  DEDICATED = 0x1,
-			  CLIENT = 0x2,
-		  };
-}
-
 class Plugin
 {
   public:
-	char* name;
-	char* displayName;
-	char* dependencyName;
-	char* description;
+	const char* name;
+	const char* logName;
+	const char* dependencyName;
+	const char* description;
 
-	uint32_t api_version;
-	char* version;
+	const uint32_t api_version;
+	const char* version;
 
 	// For now this is just implemented as the index into the plugins array
 	// Maybe a bit shit but it works
-	int handle;
+	const int handle;
 
 	std::shared_ptr<ColoredLogger> logger;
 
-	bool run_on_client = false;
-	bool run_on_server = false;
+	const bool run_on_client = false;
+	const bool run_on_server = false;
 
   public:
-	PLUGIN_INIT_TYPE init;
-	PLUGIN_INIT_SQVM_TYPE init_sqvm_client;
-	PLUGIN_INIT_SQVM_TYPE init_sqvm_server;
-	PLUGIN_INFORM_SQVM_CREATED_TYPE inform_sqvm_created;
-	PLUGIN_INFORM_SQVM_DESTROYED_TYPE inform_sqvm_destroyed;
+	Plugin(
+			const char* name,
+			const char* logName,
+			const char* dependencyName,
+			const char* description,
+			uint32_t api_version,
+			const char* version,
+			int handle,
+			bool runOnServer,
+			bool runOnClient,
+			const PLUGIN_INIT_TYPE init,
+			const PLUGIN_INIT_SQVM_TYPE initClientSqvm,
+			const PLUGIN_INIT_SQVM_TYPE initServerSqvm,
+			const PLUGIN_INFORM_SQVM_CREATED_TYPE sqvmCreated,
+			const PLUGIN_INFORM_SQVM_DESTROYED_TYPE sqvmDestroyed,
+			const PLUGIN_INFORM_DLL_LOAD_TYPE informLibLoad,
+			const PLUGIN_RUNFRAME runFrame)
+		: name(name)
+		, logName(logName)
+		, dependencyName(dependencyName)
+		, description(description)
+		, api_version(api_version)
+		, version(version)
+		, handle(handle)
+		, run_on_client(runOnClient)
+		, run_on_server(runOnServer)
+		, init(init)
+		, init_sqvm_client(initClientSqvm)
+		, init_sqvm_server(initServerSqvm)
+		, inform_sqvm_created(sqvmCreated)
+		, inform_sqvm_destroyed(sqvmDestroyed)
+		, inform_dll_load(informLibLoad)
+		, run_frame(runFrame)
+	{};
 
-	PLUGIN_INFORM_DLL_LOAD_TYPE inform_dll_load;
+	const PLUGIN_INIT_TYPE init;
 
-	PLUGIN_RUNFRAME run_frame;
+	// all following functions are optional. Maybe should be std::optional in the future
+	const PLUGIN_INIT_SQVM_TYPE init_sqvm_client;
+	const PLUGIN_INIT_SQVM_TYPE init_sqvm_server;
+	const PLUGIN_INFORM_SQVM_CREATED_TYPE inform_sqvm_created;
+	const PLUGIN_INFORM_SQVM_DESTROYED_TYPE inform_sqvm_destroyed;
+
+	const PLUGIN_INFORM_DLL_LOAD_TYPE inform_dll_load;
+
+	const PLUGIN_RUNFRAME run_frame;
 };
 
 class PluginManager

--- a/NorthstarDLL/plugins/plugins.h
+++ b/NorthstarDLL/plugins/plugins.h
@@ -17,8 +17,8 @@ class Plugin
 {
   public:
 	char* name;
-	char* displayName; // used somewhere
-	char* dependencyName; // used somewhere
+	char* displayName;
+	char* dependencyName;
 	char* description;
 
 	uint32_t api_version;

--- a/NorthstarDLL/plugins/plugins.h
+++ b/NorthstarDLL/plugins/plugins.h
@@ -1,18 +1,28 @@
 #pragma once
+#include <stdint.h>
 #include "plugin_abi.h"
 
 const int IDR_RCDATA1 = 101;
 
+// can't use bitwise ops on enum classes
+namespace PluginContext {
+	enum: uint8_t
+		  {
+			  DEDICATED = 0x1,
+			  CLIENT = 0x2,
+		  };
+}
+
 class Plugin
 {
   public:
-	std::string name;
-	std::string displayName;
-	std::string dependencyName;
-	std::string description;
+	char* name;
+	char* displayName; // used somewhere
+	char* dependencyName; // used somewhere
+	char* description;
 
-	std::string api_version;
-	std::string version;
+	uint32_t api_version;
+	char* version;
 
 	// For now this is just implemented as the index into the plugins array
 	// Maybe a bit shit but it works


### PR DESCRIPTION
For some reason only known to greater minds, Emma decided to store info about plugins in a json file, compiled into the binary itself.
This PR just changes the behaviour to symbols in the binary making them easier to compile, write and load.

For example, this is now a valid plugin in C
```c
#include <stdint.h>

enum PluginContext {
  PCTX_DEDICATED = 0x1, // load on dedicated servers
  PCTX_CLIENT // unused atm
};

const char* PLUGIN_NAME = "P4_TEST"; // unused atm
const char* PLUGIN_LOG_NAME = "P4"; // used for logging (and I think it's a good idea if the dependency constant would look like 'NSPLUG_${ABBREVIATION}'
const char* PLUGIN_DESCRIPTION = "a plugin that does things"; // unused atm
const char* PLUGIN_VERSION = "0.0.1"; // unused atm
const char* PLUGIN_DEPENDENCY_NAME = "P4_TEST"; // unused atm
const uint32_t PLUGIN_ABI_VERSION = 4; // this has to exactly match the one from Northstar. This sucks and should be changed in the future.

const uint8_t PLUGIN_CONTEXT = PCTX_DEDICATED | PCTX_CLIENT;

void PLUGIN_INIT(void* _1, void* _2) {}
```