### PR TITLE
Bump clang format action to 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: 'NorthstarDLL NorthstarLauncher'
         exclude: 'NorthstarDLL/include loader_launcher_proxy loader_wsock32_proxy'


### PR DESCRIPTION
Current is [`0.13` which was released October 2021](https://github.com/DoozyX/clang-format-lint-action/releases/tag/v0.13). This bumps it latest at the time of writing, i.e. `0.16.2`