### PR TITLE
Schedule the merge conflict labelling to run daily

### DIFF
--- a/.github/workflows/merge-conflict-auto-label.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: "20 4 * * *"
 
 jobs:
   triage:

--- a/.github/workflows/merge-conflict-auto-label.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "20 4 * * *"
+    - cron: "40 20 * * *"
 
 jobs:
   triage:


### PR DESCRIPTION
Runs at 4:20 UTC every day

It was taking a while for labels to get removed, sometimes