### PR TITLE
Disable MAD on vanilla

### DIFF
--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -1,5 +1,5 @@
 #include "moddownloader.h"
-#include "core/vanilla.h
+#include "core/vanilla.h"
 #include <rapidjson/fwd.h>
 #include <mz_strm_mem.h>
 #include <mz.h>

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -1,4 +1,5 @@
 #include "moddownloader.h"
+#include "core/vanilla.h
 #include <rapidjson/fwd.h>
 #include <mz_strm_mem.h>
 #include <mz.h>
@@ -587,6 +588,9 @@ void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
+		return;
+	
 	g_pModDownloader = new ModDownloader();
 	g_pModDownloader->FetchModsListFromAPI();
 }


### PR DESCRIPTION
Simply adds a check for the `ON_DLL_LOAD` that runs the mod auto download code for if vanilla compatibility is enabled. 

Although it would never run on vanilla, some people are confused by the `Custom verified mods URL not found in command line arguments, using default URL.` and `Mod downloader initialized` added in logs when loading mod auto download, and, from testing, doesn't break anything to disable in this way. I was able to play a match of vanilla and a match of northstar without issues

No idea if this can be done better, just looked at what Spoon did for the master server auth and put it here
