### PR TITLE
Fix debug overlay not rendering script function stuff

### DIFF
--- a/primedev/client/debugoverlay.cpp
+++ b/primedev/client/debugoverlay.cpp
@@ -170,7 +170,7 @@ int* g_nRenderTickCount;
 int* g_nOverlayTickCount;
 
 // clang-format off
-AUTOHOOK(DrawOverlay, engine.dll + 0xABCB0,
+AUTOHOOK(DrawOverlay, engine.dll + 0xABCB0, 
 void, __fastcall, (OverlayBase_t * pOverlay))
 // clang-format on
 {

--- a/primedev/client/debugoverlay.cpp
+++ b/primedev/client/debugoverlay.cpp
@@ -306,7 +306,10 @@ void, __fastcall, (bool bRender))
 
 			if (bShouldDraw && bRender && (Cvar_enable_debug_overlays->GetBool() || pCurrOverlay->m_Type == OVERLAY_SMARTAMMO))
 			{
-				DrawOverlay(pCurrOverlay);
+				// call the new function, not the original
+				// note: if there is a beter way to call the hooked version of an
+				// autohook func then that would be better than this
+				__autohookfuncDrawOverlay(pCurrOverlay);
 			}
 
 			pPrevOverlay = pCurrOverlay;


### PR DESCRIPTION
Basically when i integrated some debug overlay stuff from `primedev`, I mistakenly called the original version of the hooked function, instead of the new version. The reason for this was because `primedev` doesn't use `AUTOHOOK`, but we do, and the name of the new function on `primedev` is the same as the original function on main. fun.

Offending commit (i think) https://github.com/R2Northstar/NorthstarLauncher/commit/6e32a584804158daec2f57cfe3fa058f1ce3d0a7