### PR TITLE
Address C4100 compiler warnings (unused var)

### DIFF
--- a/primedev/core/convar/convar.cpp
+++ b/primedev/core/convar/convar.cpp
@@ -372,6 +372,7 @@ void ConVar::SetValue(Color clValue)
 //-----------------------------------------------------------------------------
 void ConVar::ChangeStringValue(const char* pszTempVal, float flOldValue)
 {
+	NOTE_UNUSED(flOldValue);
 	assert(!(m_ConCommandBase.m_nFlags & FCVAR_NEVER_AS_STRING));
 
 	char* pszOldValue = (char*)_malloca(m_Value.m_iStringLength);

--- a/primedev/dedicated/dedicated.cpp
+++ b/primedev/dedicated/dedicated.cpp
@@ -35,11 +35,14 @@ struct CDedicatedExports
 
 void Sys_Printf(CDedicatedExports* dedicated, const char* msg)
 {
+	NOTE_UNUSED(dedicated);
 	spdlog::info("[DEDICATED SERVER] {}", msg);
 }
 
 void RunServer(CDedicatedExports* dedicated)
 {
+	NOTE_UNUSED(dedicated);
+
 	spdlog::info("CDedicatedExports::RunServer(): starting");
 	spdlog::info(CommandLine()->GetCmdLine());
 
@@ -86,6 +89,8 @@ class DedicatedConsoleServerPresence : public ServerPresenceReporter
 HANDLE consoleInputThreadHandle = NULL;
 DWORD WINAPI ConsoleInputThread(PVOID pThreadParameter)
 {
+	NOTE_UNUSED(pThreadParameter);
+
 	while (!g_pEngine || !g_pHostState || g_pHostState->m_iCurrentState != HostState_t::HS_RUN)
 		Sleep(1000);
 

--- a/primedev/dedicated/dedicatedlogtoclient.cpp
+++ b/primedev/dedicated/dedicatedlogtoclient.cpp
@@ -37,6 +37,7 @@ void DedicatedServerLogToClientSink::custom_sink_it_(const custom_log_msg& msg)
 
 void DedicatedServerLogToClientSink::sink_it_(const spdlog::details::log_msg& msg)
 {
+	NOTE_UNUSED(msg);
 	throw std::runtime_error("sink_it_ called on DedicatedServerLogToClientSink with pure log_msg. This is an error!");
 }
 

--- a/primedev/dllmain.cpp
+++ b/primedev/dllmain.cpp
@@ -20,6 +20,8 @@
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
+	NOTE_UNUSED(hModule);
+	NOTE_UNUSED(lpReserved);
 	switch (ul_reason_for_call)
 	{
 	case DLL_PROCESS_ATTACH:

--- a/primedev/logging/logging.cpp
+++ b/primedev/logging/logging.cpp
@@ -70,6 +70,7 @@ void CreateLogFiles()
 
 void ExternalConsoleSink::sink_it_(const spdlog::details::log_msg& msg)
 {
+	NOTE_UNUSED(msg);
 	throw std::runtime_error("sink_it_ called on SourceConsoleSink with pure log_msg. This is an error!");
 }
 

--- a/primedev/logging/logging.h
+++ b/primedev/logging/logging.h
@@ -25,6 +25,7 @@ public:
 	void custom_log(const custom_log_msg& msg);
 	virtual void custom_sink_it_(const custom_log_msg& msg)
 	{
+		NOTE_UNUSED(msg);
 		throw std::runtime_error("Pure virtual call to CustomSink::custom_sink_it_");
 	}
 };

--- a/primedev/logging/loghooks.cpp
+++ b/primedev/logging/loghooks.cpp
@@ -108,6 +108,8 @@ AUTOHOOK(Hook_fprintf, engine.dll + 0x51B1F0,
 int,, (void* const stream, const char* const format, ...))
 // clang-format on
 {
+	NOTE_UNUSED(stream);
+
 	va_list va;
 	va_start(va, format);
 
@@ -139,6 +141,7 @@ AUTOHOOK(EngineSpewFunc, engine.dll + 0x11CA80,
 void, __fastcall, (void* pEngineServer, SpewType_t type, const char* format, va_list args))
 // clang-format on
 {
+	NOTE_UNUSED(pEngineServer);
 	if (!Cvar_spewlog_enable->GetBool())
 		return;
 
@@ -235,6 +238,8 @@ AUTOHOOK(CClientState_ProcessPrint, engine.dll + 0x1A1530,
 bool,, (void* thisptr, uintptr_t msg))
 // clang-format on
 {
+	NOTE_UNUSED(thisptr);
+
 	char* text = *(char**)(msg + 0x20);
 
 	auto endpos = strlen(text);

--- a/primedev/logging/sourceconsole.cpp
+++ b/primedev/logging/sourceconsole.cpp
@@ -8,6 +8,7 @@ SourceInterface<CGameConsole>* g_pSourceGameConsole;
 
 void ConCommand_toggleconsole(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	if ((*g_pSourceGameConsole)->IsConsoleVisible())
 		(*g_pSourceGameConsole)->Hide();
 	else
@@ -16,11 +17,13 @@ void ConCommand_toggleconsole(const CCommand& arg)
 
 void ConCommand_showconsole(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	(*g_pSourceGameConsole)->Activate();
 }
 
 void ConCommand_hideconsole(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	(*g_pSourceGameConsole)->Hide();
 }
 
@@ -47,6 +50,7 @@ void SourceConsoleSink::custom_sink_it_(const custom_log_msg& msg)
 
 void SourceConsoleSink::sink_it_(const spdlog::details::log_msg& msg)
 {
+	NOTE_UNUSED(msg);
 	throw std::runtime_error("sink_it_ called on SourceConsoleSink with pure log_msg. This is an error!");
 }
 

--- a/primedev/masterserver/masterserver.cpp
+++ b/primedev/masterserver/masterserver.cpp
@@ -988,6 +988,7 @@ void MasterServerManager::ProcessConnectionlessPacketSigreq1(std::string data)
 
 void ConCommand_ns_fetchservers(const CCommand& args)
 {
+	NOTE_UNUSED(args);
 	g_pMasterServerManager->RequestServerList();
 }
 
@@ -1008,6 +1009,7 @@ ON_DLL_LOAD_RELIESON("engine.dll", MasterServer, (ConCommand, ServerPresence), (
 
 void MasterServerPresenceReporter::CreatePresence(const ServerPresence* pServerPresence)
 {
+	NOTE_UNUSED(pServerPresence);
 	m_nNumRegistrationAttempts = 0;
 }
 
@@ -1051,6 +1053,7 @@ void MasterServerPresenceReporter::ReportPresence(const ServerPresence* pServerP
 
 void MasterServerPresenceReporter::DestroyPresence(const ServerPresence* pServerPresence)
 {
+	NOTE_UNUSED(pServerPresence);
 	// Don't call this if we don't have a server id.
 	if (!*g_pMasterServerManager->m_sOwnServerId)
 	{
@@ -1086,6 +1089,8 @@ void MasterServerPresenceReporter::DestroyPresence(const ServerPresence* pServer
 
 void MasterServerPresenceReporter::RunFrame(double flCurrentTime, const ServerPresence* pServerPresence)
 {
+	NOTE_UNUSED(flCurrentTime);
+	NOTE_UNUSED(pServerPresence);
 	// Check if we're already running an InternalAddServer() call in the background.
 	// If so, grab the result if it's ready.
 	if (addServerFuture.valid())

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -126,6 +126,8 @@ size_t WriteData(void* ptr, size_t size, size_t nmemb, FILE* stream)
 int ModDownloader::ModFetchingProgressCallback(
 	void* ptr, curl_off_t totalDownloadSize, curl_off_t finishedDownloadSize, curl_off_t totalToUpload, curl_off_t nowUploaded)
 {
+	NOTE_UNUSED(totalToUpload);
+	NOTE_UNUSED(nowUploaded);
 	if (totalDownloadSize != 0 && finishedDownloadSize != 0)
 	{
 		ModDownloader* instance = static_cast<ModDownloader*>(ptr);

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -1122,6 +1122,7 @@ void ModManager::CompileAssetsForFile(const char* filename)
 
 void ConCommand_reload_mods(const CCommand& args)
 {
+	NOTE_UNUSED(args);
 	g_pModManager->LoadMods();
 }
 

--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -29,6 +29,8 @@ typedef void (*callable_v)(void* v);
 #define assert_msg(exp, msg) assert((exp, msg))
 //clang-format on
 
+#define NOTE_UNUSED(var) do { (void)var; } while(false)
+
 #include "core/macros.h"
 
 #include "core/math/color.h"

--- a/primedev/scripts/client/scriptmainmenupromos.cpp
+++ b/primedev/scripts/client/scriptmainmenupromos.cpp
@@ -23,6 +23,7 @@ enum eMainMenuPromoDataProperty
 };
 ADD_SQFUNC("void", NSRequestCustomMainMenuPromos, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	g_pMasterServerManager->RequestMainMenuPromos();
 	return SQRESULT_NULL;
 }

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -160,6 +160,7 @@ ADD_SQFUNC(
 
 ADD_SQFUNC("void", NSReloadMods, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	g_pModManager->LoadMods();
 	return SQRESULT_NULL;
 }

--- a/primedev/scripts/client/scriptserverbrowser.cpp
+++ b/primedev/scripts/client/scriptserverbrowser.cpp
@@ -8,6 +8,7 @@
 
 ADD_SQFUNC("void", NSRequestServerList, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	g_pMasterServerManager->RequestServerList();
 	return SQRESULT_NULL;
 }
@@ -32,6 +33,7 @@ ADD_SQFUNC("int", NSGetServerCount, "", "", ScriptContext::UI)
 
 ADD_SQFUNC("void", NSClearRecievedServerList, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	g_pMasterServerManager->ClearServerList();
 	return SQRESULT_NULL;
 }
@@ -114,6 +116,7 @@ ADD_SQFUNC("void", NSConnectToAuthedServer, "", "", ScriptContext::UI)
 
 ADD_SQFUNC("void", NSTryAuthWithLocalServer, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	// do auth request
 	g_pMasterServerManager->AuthenticateWithOwnServer(g_pLocalPlayerUserID, g_pMasterServerManager->m_sOwnClientAuthToken);
 
@@ -122,6 +125,7 @@ ADD_SQFUNC("void", NSTryAuthWithLocalServer, "", "", ScriptContext::UI)
 
 ADD_SQFUNC("void", NSCompleteAuthWithLocalServer, "", "", ScriptContext::UI)
 {
+	NOTE_UNUSED(sqvm);
 	// literally just set serverfilter
 	// note: this assumes we have no authdata other than our own
 	if (g_pServerAuthentication->m_RemoteAuthenticationData.size())

--- a/primedev/scripts/scriptdatatables.cpp
+++ b/primedev/scripts/scriptdatatables.cpp
@@ -817,6 +817,7 @@ void ConCommand_dump_datatable(const CCommand& args)
 
 void ConCommand_dump_datatables(const CCommand& args)
 {
+	NOTE_UNUSED(args);
 	// likely not a comprehensive list, might be missing a couple?
 	static const std::vector<const char*> VANILLA_DATATABLE_PATHS = {
 		"datatable/burn_meter_rewards.rpak",

--- a/primedev/server/auth/bansystem.cpp
+++ b/primedev/server/auth/bansystem.cpp
@@ -213,6 +213,7 @@ void ConCommand_unban(const CCommand& args)
 
 void ConCommand_clearbanlist(const CCommand& args)
 {
+	NOTE_UNUSED(args);
 	g_pBanSystem->ClearBanlist();
 }
 

--- a/primedev/server/auth/serverauthentication.cpp
+++ b/primedev/server/auth/serverauthentication.cpp
@@ -333,6 +333,7 @@ void,, (CBaseClient* self, uint32_t unknownButAlways1, const char* pReason, ...)
 
 void ConCommand_ns_resetpersistence(const CCommand& args)
 {
+	NOTE_UNUSED(args);
 	if (*g_pServerState == server_state_t::ss_active)
 	{
 		spdlog::error("ns_resetpersistence must be entered from the main menu");

--- a/primedev/server/serverpresence.cpp
+++ b/primedev/server/serverpresence.cpp
@@ -79,6 +79,9 @@ void ServerPresenceManager::CreateConVars()
 		"ns_server_presence_update_rate", "5000", FCVAR_GAMEDLL, "How often we update our server's presence on server lists in ms");
 
 	Cvar_ns_server_name = new ConVar("ns_server_name", "Unnamed Northstar Server", FCVAR_GAMEDLL, "This server's name", false, 0, false, 0, [](ConVar* cvar, const char* pOldValue, float flOldValue) {
+			NOTE_UNUSED(cvar);
+			NOTE_UNUSED(pOldValue);
+			NOTE_UNUSED(flOldValue);
 			g_pServerPresence->SetName(UnescapeUnicode(g_pServerPresence->Cvar_ns_server_name->GetString()));
 
 			// update engine hostname cvar
@@ -86,10 +89,16 @@ void ServerPresenceManager::CreateConVars()
 		});
 
 	Cvar_ns_server_desc = new ConVar("ns_server_desc", "Default server description", FCVAR_GAMEDLL, "This server's description", false, 0, false, 0, [](ConVar* cvar, const char* pOldValue, float flOldValue) {
+			NOTE_UNUSED(cvar);
+			NOTE_UNUSED(pOldValue);
+			NOTE_UNUSED(flOldValue);
 			g_pServerPresence->SetDescription(UnescapeUnicode(g_pServerPresence->Cvar_ns_server_desc->GetString()));
 		});
 
 	Cvar_ns_server_password = new ConVar("ns_server_password", "", FCVAR_GAMEDLL, "This server's password", false, 0, false, 0, [](ConVar* cvar, const char* pOldValue, float flOldValue) {
+			NOTE_UNUSED(cvar);
+			NOTE_UNUSED(pOldValue);
+			NOTE_UNUSED(flOldValue);
 			g_pServerPresence->SetPassword(g_pServerPresence->Cvar_ns_server_password->GetString());
 		});
 

--- a/primedev/server/serverpresence.h
+++ b/primedev/server/serverpresence.h
@@ -45,10 +45,10 @@ public:
 class ServerPresenceReporter
 {
 public:
-	virtual void CreatePresence(const ServerPresence* pServerPresence) {}
-	virtual void ReportPresence(const ServerPresence* pServerPresence) {}
-	virtual void DestroyPresence(const ServerPresence* pServerPresence) {}
-	virtual void RunFrame(double flCurrentTime, const ServerPresence* pServerPresence) {}
+	virtual void CreatePresence(const ServerPresence* /*pServerPresence*/) {}
+	virtual void ReportPresence(const ServerPresence* /*pServerPresence*/) {}
+	virtual void DestroyPresence(const ServerPresence* /*pServerPresence*/) {}
+	virtual void RunFrame(double /*flCurrentTime*/, const ServerPresence* /*pServerPresence*/) {}
 };
 
 class ServerPresenceManager

--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -55,6 +55,8 @@ AUTOHOOK(Base_CmdKeyValues_ReadFromBuffer, engine.dll + 0x220040,
 bool, __fastcall, (void* thisptr, void* buffer)) // 40 55 48 81 EC ? ? ? ? 48 8D 6C 24 ? 48 89 5D 70
 // clang-format on
 {
+	NOTE_UNUSED(thisptr);
+	NOTE_UNUSED(buffer);
 	return false;
 }
 

--- a/primedev/shared/exploit_fixes/exploitfixes_lzss.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes_lzss.cpp
@@ -16,6 +16,7 @@ AUTOHOOK(CLZSS__SafeDecompress, engine.dll + 0x432A10,
 unsigned int, __fastcall, (void* self, const unsigned char* pInput, unsigned char* pOutput, unsigned int unBufSize))
 // clang-format on
 {
+	NOTE_UNUSED(self);
 	unsigned int totalBytes = 0;
 	int getCmdByte = 0;
 	int cmdByte = 0;

--- a/primedev/shared/exploit_fixes/ns_limits.cpp
+++ b/primedev/shared/exploit_fixes/ns_limits.cpp
@@ -16,6 +16,7 @@ float (*CEngineServer__GetTimescale)();
 // todo: make this work on higher timescales, also possibly disable when sv_cheats is set
 void ServerLimitsManager::RunFrame(double flCurrentTime, float flFrameTime)
 {
+	NOTE_UNUSED(flCurrentTime);
 	if (Cvar_sv_antispeedhack_enable->GetBool())
 	{
 		// for each player, set their usercmd processing budget for the frame to the last frametime for the server

--- a/primedev/shared/misccommands.cpp
+++ b/primedev/shared/misccommands.cpp
@@ -21,6 +21,7 @@ void ConCommand_force_newgame(const CCommand& arg)
 
 void ConCommand_ns_start_reauth_and_leave_to_lobby(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	// hack for special case where we're on a local server, so we erase our own newly created auth data on disconnect
 	g_pMasterServerManager->m_bNewgameAfterSelfAuth = true;
 	g_pMasterServerManager->AuthenticateWithOwnServer(g_pLocalPlayerUserID, g_pMasterServerManager->m_sOwnClientAuthToken);
@@ -28,6 +29,7 @@ void ConCommand_ns_start_reauth_and_leave_to_lobby(const CCommand& arg)
 
 void ConCommand_ns_end_reauth_and_leave_to_lobby(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	if (g_pServerAuthentication->m_RemoteAuthenticationData.size())
 		g_pCVar->FindVar("serverfilter")->SetValue(g_pServerAuthentication->m_RemoteAuthenticationData.begin()->first.c_str());
 

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -389,6 +389,7 @@ template <ScriptContext context> void SquirrelManager<context>::AddFuncOverride(
 // hooks
 bool IsUIVM(ScriptContext context, HSquirrelVM* pSqvm)
 {
+	NOTE_UNUSED(context);
 	return ScriptContext(pSqvm->sharedState->cSquirrelVM->vmContext) == ScriptContext::UI;
 }
 
@@ -407,6 +408,8 @@ template <ScriptContext context> void* __fastcall sq_compiler_createHook(HSquirr
 template <ScriptContext context> SQInteger (*SQPrint)(HSquirrelVM* sqvm, const char* fmt);
 template <ScriptContext context> SQInteger SQPrintHook(HSquirrelVM* sqvm, const char* fmt, ...)
 {
+	NOTE_UNUSED(sqvm);
+
 	va_list va;
 	va_start(va, fmt);
 

--- a/primedev/util/printcommands.cpp
+++ b/primedev/util/printcommands.cpp
@@ -188,6 +188,7 @@ void ConCommand_findflags(const CCommand& arg)
 
 void ConCommand_list(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	ConCommandBase* var;
 	CCVarIteratorInternal* itint = g_pCVar->FactoryInternalIterator();
 	std::map<std::string, ConCommandBase*> sorted;
@@ -210,6 +211,7 @@ void ConCommand_list(const CCommand& arg)
 
 void ConCommand_differences(const CCommand& arg)
 {
+	NOTE_UNUSED(arg);
 	CCVarIteratorInternal* itint = g_pCVar->FactoryInternalIterator();
 	std::map<std::string, ConCommandBase*> sorted;
 


### PR DESCRIPTION
Uses a macro to avoid the warning. I could have gone for just commenting out the parameter name in most cases, but for things like `ADD_SQFUNC` the parameter names aren't available as they are part of the macro.