### PR TITLE
ScopeGuard improvements

### DIFF
--- a/primedev/util/utils.h
+++ b/primedev/util/utils.h
@@ -2,22 +2,25 @@
 
 void RemoveAsciiControlSequences(char* str, bool allow_color_codes);
 
+template<typename T>
 class ScopeGuard
 {
 public:
 	auto operator=(ScopeGuard&) = delete;
 	ScopeGuard(ScopeGuard&) = delete;
 
-	ScopeGuard(std::function<void()> callback) : m_callback(callback) {}
+	ScopeGuard(T callback) : m_callback(callback) {}
 	~ScopeGuard()
 	{
-		m_callback();
+		if (!m_dismissed)
+			m_callback();
 	}
 	void Dismiss()
 	{
-		m_callback = [] {};
+		m_dismissed = true;
 	}
 
 private:
-	std::function<void()> m_callback;
+	bool m_dismissed = false;
+	T m_callback;
 };

--- a/primedev/util/utils.h
+++ b/primedev/util/utils.h
@@ -2,8 +2,7 @@
 
 void RemoveAsciiControlSequences(char* str, bool allow_color_codes);
 
-template<typename T>
-class ScopeGuard
+template <typename T> class ScopeGuard
 {
 public:
 	auto operator=(ScopeGuard&) = delete;


### PR DESCRIPTION
`std::function` introduces a layer of indirection that can be removed through templating the class.