### PR TITLE
Update default mods list URL

### DIFF
--- a/primedev/mods/autodownload/moddownloader.h
+++ b/primedev/mods/autodownload/moddownloader.h
@@ -4,7 +4,7 @@ private:
 	const char* VERIFICATION_FLAG = "-disablemodverification";
 	const char* CUSTOM_MODS_URL_FLAG = "-customverifiedurl=";
 	const char* STORE_URL = "https://gcdn.thunderstore.io/live/repository/packages/";
-	const char* DEFAULT_MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/verified-mods.json";
+	const char* DEFAULT_MODS_LIST_URL = "https://raw.githubusercontent.com/R2Northstar/VerifiedMods/main/verified-mods.json";
 	char* modsListUrl;
 
 	struct VerifiedModVersion
@@ -79,7 +79,7 @@ public:
 	 * The Northstar auto-downloading feature does NOT allow automatically installing
 	 * all mods for various (notably security) reasons; mods that are candidate to
 	 * auto-downloading are rather listed on a GitHub repository
-	 * (https://raw.githubusercontent.com/R2Northstar/VerifiedMods/master/verified-mods.json),
+	 * (https://raw.githubusercontent.com/R2Northstar/VerifiedMods/main/verified-mods.json),
 	 * which this method gets via a HTTP call to load into local state.
 	 *
 	 * If list fetching fails, local mods list will be initialized as empty, thus


### PR DESCRIPTION
The default branch for the VerifiedMods repo was renamed from `master` to `main`. See https://github.com/R2Northstar/VerifiedMods/issues/28 for more info.

**Testing:**

Simply enable MAD by setting `allow_mod_auto_download` to `1` and join any server that requires some verified mod.