### PR TITLE
Clean up wsock proxy code and move wsock build system logic

### DIFF
--- a/primedev/CMakeLists.txt
+++ b/primedev/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(Northstar.cmake)
 include(Launcher.cmake)
-include(WSockProxy.cmake)
+add_subdirectory(wsockproxy)

--- a/primedev/wsockproxy/CMakeLists.txt
+++ b/primedev/wsockproxy/CMakeLists.txt
@@ -4,11 +4,10 @@ find_package(minhook REQUIRED)
 
 add_library(
     loader_wsock32_proxy SHARED
-    "wsockproxy/dllmain.cpp"
-    "wsockproxy/loader.cpp"
-    "wsockproxy/loader.h"
-    "wsockproxy/wsock32.asm"
-    "wsockproxy/wsock32.def"
+    "dllmain.cpp"
+    "loader.cpp"
+    "loader.h"
+    "wsock32.def"
     )
 
 target_link_libraries(
@@ -36,7 +35,7 @@ target_link_libraries(
 target_precompile_headers(
     loader_wsock32_proxy
     PRIVATE
-    wsockproxy/pch.h
+    pch.h
     )
 
 target_compile_definitions(loader_wsock32_proxy PRIVATE UNICODE _UNICODE)

--- a/primedev/wsockproxy/dllmain.cpp
+++ b/primedev/wsockproxy/dllmain.cpp
@@ -5,7 +5,7 @@
 FARPROC p[73];
 HMODULE hL = 0;
 
-static wchar_t buffer[4096];
+static wchar_t wsockPath[4096];
 
 BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 {
@@ -17,13 +17,13 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 		if (!ProvisionNorthstar()) // does not call InitialiseNorthstar yet, will do it on LauncherMain hook
 			return true;
 
-        GetSystemDirectoryW(buffer, 4096);
-		swprintf_s(buffer, 4096, L"%s\\wsock32.dll", buffer);
+        GetSystemDirectoryW(wsockPath, 4096);
+		swprintf_s(wsockPath, 4096, L"%s\\wsock32.dll", wsockPath);
 
-		hL = LoadLibraryExW(buffer, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+		hL = LoadLibraryExW(wsockPath, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
 		if (!hL)
 		{
-			LibraryLoadError(GetLastError(), L"wsock32.dll", buffer);
+			LibraryLoadError(GetLastError(), L"wsock32.dll", wsockPath);
 			return false;
 		}
 

--- a/primedev/wsockproxy/dllmain.cpp
+++ b/primedev/wsockproxy/dllmain.cpp
@@ -1,90 +1,29 @@
 #include "loader.h"
 
-#include <shlwapi.h>
 #include <filesystem>
 
-HINSTANCE hLThis = 0;
-FARPROC p[857];
-HINSTANCE hL = 0;
+FARPROC p[73];
+HMODULE hL = 0;
 
-bool GetExePathWide(wchar_t* dest, DWORD destSize)
-{
-	if (!dest)
-		return NULL;
-	if (destSize < MAX_PATH)
-		return NULL;
-
-	DWORD length = GetModuleFileNameW(NULL, dest, destSize);
-	return length && PathRemoveFileSpecW(dest);
-}
-
-wchar_t exePath[4096];
-wchar_t buffer1[8192];
-wchar_t buffer2[12288];
+static wchar_t buffer[4096];
 
 BOOL WINAPI DllMain(HINSTANCE hInst, DWORD reason, LPVOID)
 {
 	if (reason == DLL_PROCESS_ATTACH)
 	{
-		hLThis = hInst;
-
-		if (!GetExePathWide(exePath, 4096))
-		{
-			MessageBoxA(
-				GetForegroundWindow(),
-				"Failed getting game directory.\nThe game cannot continue and has to exit.",
-				"Northstar Wsock32 Proxy Error",
-				0);
-			return true;
-		}
-
-		SetCurrentDirectoryW(exePath);
+		// Tell the OS we don't need to know about threads
+        DisableThreadLibraryCalls(hInst);
 
 		if (!ProvisionNorthstar()) // does not call InitialiseNorthstar yet, will do it on LauncherMain hook
 			return true;
 
-		// copy the original library for system to our local directory, with changed name so that we can load it
-		swprintf_s(buffer1, L"%s\\bin\\x64_retail\\wsock32.org.dll", exePath);
-		GetSystemDirectoryW(buffer2, 4096);
-		swprintf_s(buffer2, L"%s\\wsock32.dll", buffer2);
-		try
-		{
-			std::filesystem::copy_file(buffer2, buffer1);
-		}
-		catch (const std::exception& e1)
-		{
-			if (!std::filesystem::exists(buffer1))
-			{
-				// fallback by copying to temp dir...
-				// because apparently games installed by EA Desktop app don't have write permissions in their directories
-				auto temp_dir = std::filesystem::temp_directory_path() / L"wsock32.org.dll";
-				try
-				{
-					std::filesystem::copy_file(buffer2, temp_dir);
-				}
-				catch (const std::exception& e2)
-				{
-					if (!std::filesystem::exists(temp_dir))
-					{
-						swprintf_s(
-							buffer2,
-							L"Failed copying wsock32.dll from system32 to \"%s\"\n\n%S\n\nFurthermore, we failed copying wsock32.dll into "
-							L"temporary directory at \"%s\"\n\n%S",
-							buffer1,
-							e1.what(),
-							temp_dir.c_str(),
-							e2.what());
-						MessageBoxW(GetForegroundWindow(), buffer2, L"Northstar Wsock32 Proxy Error", 0);
-						return false;
-					}
-				}
-				swprintf_s(buffer1, L"%s", temp_dir.c_str());
-			}
-		}
-		hL = LoadLibraryExW(buffer1, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
+        GetSystemDirectoryW(buffer, 4096);
+		swprintf_s(buffer, 4096, L"%s\\wsock32.dll", buffer);
+
+		hL = LoadLibraryExW(buffer, 0, LOAD_WITH_ALTERED_SEARCH_PATH);
 		if (!hL)
 		{
-			LibraryLoadError(GetLastError(), L"wsock32.org.dll", buffer1);
+			LibraryLoadError(GetLastError(), L"wsock32.dll", buffer);
 			return false;
 		}
 
@@ -119,64 +58,16 @@ extern "C"
 	FARPROC PA = NULL;
 	int RunASM();
 
-	void PROXY_EnumProtocolsA()
-	{
-		PA = p[1];
-		RunASM();
-	}
-	void PROXY_EnumProtocolsW()
-	{
-		PA = p[2];
-		RunASM();
-	}
-	void PROXY_GetAddressByNameA()
-	{
-		PA = p[4];
-		RunASM();
-	}
-	void PROXY_GetAddressByNameW()
-	{
-		PA = p[5];
-		RunASM();
-	}
-	void PROXY_WEP()
-	{
-		PA = p[17];
-		RunASM();
-	}
-	void PROXY_WSARecvEx()
-	{
-		PA = p[30];
-		RunASM();
-	}
-	void PROXY___WSAFDIsSet()
-	{
-		PA = p[36];
-		RunASM();
-	}
-	void PROXY_getnetbyname()
-	{
-		PA = p[45];
-		RunASM();
-	}
-	void PROXY_getsockopt()
-	{
-		PA = p[52];
-		RunASM();
-	}
-	void PROXY_inet_network()
-	{
-		PA = p[56];
-		RunASM();
-	}
-	void PROXY_s_perror()
-	{
-		PA = p[67];
-		RunASM();
-	}
-	void PROXY_setsockopt()
-	{
-		PA = p[72];
-		RunASM();
-	}
+	void PROXY_EnumProtocolsA() { p[1](); }
+	void PROXY_EnumProtocolsW() { p[2](); }
+	void PROXY_GetAddressByNameA() { p[4](); }
+	void PROXY_GetAddressByNameW() { p[5](); }
+	void PROXY_WEP() { p[17](); }
+	void PROXY_WSARecvEx() { p[30](); }
+	void PROXY___WSAFDIsSet() { p[36](); }
+	void PROXY_getnetbyname() { p[45](); }
+	void PROXY_getsockopt() { p[52](); }
+	void PROXY_inet_network() { p[56](); }
+	void PROXY_s_perror() { p[67](); }
+	void PROXY_setsockopt() { p[72](); }
 }

--- a/primedev/wsockproxy/loader.cpp
+++ b/primedev/wsockproxy/loader.cpp
@@ -9,7 +9,7 @@
 
 namespace fs = std::filesystem;
 
-static wchar_t buffer[8192];
+static wchar_t northstarPath[8192];
 static wchar_t exePath[4096];
 
 bool GetExePathWide(wchar_t* dest, DWORD destSize)
@@ -102,19 +102,19 @@ bool LoadNorthstar()
 		}
 
 		// Check if "Northstar.dll" exists in profile directory, if it doesnt fall back to root
-		swprintf_s(buffer, L"%s\\%s\\Northstar.dll", exePath, std::wstring(strProfile.begin(), strProfile.end()).c_str());
+		swprintf_s(northstarPath, L"%s\\%s\\Northstar.dll", exePath, std::wstring(strProfile.begin(), strProfile.end()).c_str());
 
-		if (!fs::exists(fs::path(buffer)))
-			swprintf_s(buffer, L"%s\\Northstar.dll", exePath);
+		if (!fs::exists(fs::path(northstarPath)))
+			swprintf_s(northstarPath, L"%s\\Northstar.dll", exePath);
 
-		std::wcout << L"[*] Using: " << buffer << std::endl;
+		std::wcout << L"[*] Using: " << northstarPath << std::endl;
 
-		HMODULE hHookModule = LoadLibraryExW(buffer, 0, 8u);
+		HMODULE hHookModule = LoadLibraryExW(northstarPath, 0, 8u);
 		if (hHookModule)
 			Hook_Init = GetProcAddress(hHookModule, "InitialiseNorthstar");
 		if (!hHookModule || Hook_Init == nullptr)
 		{
-			LibraryLoadError(GetLastError(), L"Northstar.dll", buffer);
+			LibraryLoadError(GetLastError(), L"Northstar.dll", northstarPath);
 			return false;
 		}
 	}

--- a/primedev/wsockproxy/wsock32.asm
+++ b/primedev/wsockproxy/wsock32.asm
@@ -1,7 +1,0 @@
-.data
-extern PA : qword
-.code
-RunASM proc
-jmp qword ptr [PA]
-RunASM endp
-end


### PR DESCRIPTION
- moves `WSockProxy` to `wsockproxy/CmakeLists`
- remove exepath stuff from dllmain
  + its still done in loader.cpp because its used when reporting failure
- Disabled any Thread Library calls
  + we don't need to know about threads at all in the proxy
- yoink `wsock32.asm` into outer space
  + turns out, we can just call the function in a void shim since that wont touch the registers
- stop copying `wsock32.dll` to the game directory
  + this should improve the state of things when using the EA App
