### PR TITLE
Don't allow too many arguments to be sent to the map command

### DIFF
--- a/primedev/util/printmaps.cpp
+++ b/primedev/util/printmaps.cpp
@@ -205,7 +205,8 @@ AUTOHOOK(Host_Map_f, engine.dll + 0x15B340, void, __fastcall, (const CCommand& a
 		spdlog::warn("Map load failed: too many arguments provided");
 		return;
 	}
-	else if (args.ArgC() == 2 &&
+	else if (
+		args.ArgC() == 2 &&
 		std::find_if(vMapList.begin(), vMapList.end(), [&](MapVPKInfo map) -> bool { return map.name == args.Arg(1); }) == vMapList.end())
 	{
 		spdlog::warn("Map load failed: {} not found or invalid", args.Arg(1));

--- a/primedev/util/printmaps.cpp
+++ b/primedev/util/printmaps.cpp
@@ -200,7 +200,12 @@ AUTOHOOK(Host_Map_f, engine.dll + 0x15B340, void, __fastcall, (const CCommand& a
 {
 	RefreshMapList();
 
-	if (args.ArgC() > 1 &&
+	if (args.ArgC() > 2)
+	{
+		spdlog::warn("Map load failed: too many arguments provided");
+		return;
+	}
+	else if (args.ArgC() == 2 &&
 		std::find_if(vMapList.begin(), vMapList.end(), [&](MapVPKInfo map) -> bool { return map.name == args.Arg(1); }) == vMapList.end())
 	{
 		spdlog::warn("Map load failed: {} not found or invalid", args.Arg(1));


### PR DESCRIPTION
The map command should only take one argument, so any more than that is superfluous.