### PR TITLE
Depedency Constant Version Tables

### DIFF
--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -260,11 +260,11 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 		// if mod is not loaded push null instead of a table with all versions
 		if (!bWasFound)
 		{
-			pushstring(m_pSQVM->sqvm, pair.first.c_str(), -1);
-			pushnull(m_pSQVM->sqvm); // this is coerced to SQInteger 0 for some reason in the const table
-			pushinteger(m_pSQVM->sqvm, 0);
-			newslot(m_pSQVM->sqvm, -3, false);
-			// defconst(m_pSQVM, pair.first.c_str(), 0);
+			// pushstring(m_pSQVM->sqvm, pair.first.c_str(), -1);
+			// pushnull(m_pSQVM->sqvm); // TODO null entries get erased for some reason
+			// pushinteger(m_pSQVM->sqvm, 0);
+			// newslot(m_pSQVM->sqvm, -3, false);
+			defconst(m_pSQVM, pair.first.c_str(), 0);
 		}
 	}
 

--- a/primedev/squirrel/squirrel.h
+++ b/primedev/squirrel/squirrel.h
@@ -4,6 +4,7 @@
 #include "squirrelautobind.h"
 #include "core/math/vector.h"
 #include "mods/modmanager.h"
+#include "squirreldatatypes.h"
 
 /*
 	definitions from hell
@@ -119,6 +120,10 @@ public:
 
 	sq_pushnewstructinstanceType __sq_pushnewstructinstance;
 	sq_sealstructslotType __sq_sealstructslot;
+
+	sq_pushconsttableType __sq_pushconsttable;
+	sq_poptopType __sq_poptop;
+	sq_pushnullType __sq_pushnull;
 
 #pragma endregion
 
@@ -252,6 +257,21 @@ public:
 	inline long long sq_stackinfos(HSquirrelVM* sqvm, int level, SQStackInfos& out)
 	{
 		return __sq_stackinfos(sqvm, level, &out, sqvm->_callstacksize);
+	}
+
+	inline void pushconsttable(HSquirrelVM* sqvm)
+	{
+		return __sq_pushconsttable(sqvm);
+	}
+
+	inline void poptop(HSquirrelVM* sqvm)
+	{
+		return __sq_poptop(sqvm);
+	}
+
+	inline void pushnull(HSquirrelVM* sqvm)
+	{
+		return __sq_pushnull(sqvm);
 	}
 
 	inline Mod* getcallingmod(HSquirrelVM* sqvm, int depth = 0)
@@ -407,6 +427,8 @@ public:
 		m_pSQVM = nullptr;
 	}
 
+	SQRESULT CreateSlot(const char* key, SQInteger val);
+	void CreateDependencyConstantsForMod(Mod& mod, const char* dependencyName);
 	void VMCreated(CSquirrelVM* newSqvm);
 	void VMDestroyed();
 	void ExecuteCode(const char* code);

--- a/primedev/squirrel/squirrelclasstypes.h
+++ b/primedev/squirrel/squirrelclasstypes.h
@@ -235,4 +235,8 @@ typedef int (*sq_getfunctionType)(HSquirrelVM* sqvm, const char* name, SQObject*
 typedef SQRESULT (*sq_pushnewstructinstanceType)(HSquirrelVM* sqvm, int fieldCount);
 typedef SQRESULT (*sq_sealstructslotType)(HSquirrelVM* sqvm, int slotIndex);
 
+typedef void (*sq_poptopType)(HSquirrelVM* sqvm);
+typedef void (*sq_pushconsttableType)(HSquirrelVM* sqvm);
+typedef void (*sq_pushnullType)(HSquirrelVM* sqvm);
+
 #pragma endregion


### PR DESCRIPTION
```
#if HAS_UEBERBLICK
// This compiles only if the dependency is loaded. No matter the version of the dependency
#endif

#if HAS_UEBERBLICK && HAS_UEBERBLICK.major == 1
// This compiles ONLY if the dependency version is 1.x.x
#endif

#if HAS_UEBEBLICK && HAS_UEBERBLICK.major == 1 && HAS_UEBERBLICK.minor >= 2 && HAS_UEBERBLICK.minor <= 5
// This compiles only if the dependency's version is between 1.2.x - 1.5.x
#endif
```

- if a dependency is not loaded, the constant is `0`
- otherwise the dependency is a table that holds `major`, `minor` and `patch` keys for the versions of the mod
- only valid versions are inserted in the table. e.g. `1.x.x` would only expose the `major` key
- build & pre-release info is ignored