### PR TITLE
Add instructions to build with podman

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -52,10 +52,10 @@ Developers who can work a command line may be interested in using [Visual Studio
 
 #### Podman
 
-When using [`podman`](https://podman.io/) instead of Docker on an SELinux enabled distro, make sure to add the `Z` flag when mounting the directory to keep SELinux happy.
+When using [`podman`](https://podman.io/) instead of Docker on an SELinux enabled distro, make sure to add the `z` flag when mounting the directory to keep SELinux happy.
 
 As such the corresponding commands are
 
 * `podman build --rm -t northstar-build-fedora .`
-* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
-* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake --build .`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake --build .`

--- a/BUILD.md
+++ b/BUILD.md
@@ -52,7 +52,7 @@ Developers who can work a command line may be interested in using [Visual Studio
 
 #### Podman
 
-When using [`podman`](https://podman.io/) instead of Docker on an SELinux enabled distro, make sure to add the `z` flag when mounting the directory to keep SELinux happy.
+When using [`podman`](https://podman.io/) instead of Docker on an SELinux enabled distro, make sure to add the `z` flag when mounting the directory to correctly label it to avoid SELinux denying access.
 
 As such the corresponding commands are
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -49,3 +49,13 @@ Developers who can work a command line may be interested in using [Visual Studio
 * `docker build --rm -t northstar-build-fedora .`
 * `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
 * `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake --build .`
+
+#### Podman
+
+When using [`podman`](https://podman.io/) instead of Docker on an SELinux enabled distro, make sure to add the `Z` flag when mounting the directory to keep SELinux happy.
+
+As such the corresponding commands are
+
+* `podman build --rm -t northstar-build-fedora .`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake --build .`


### PR DESCRIPTION
Add instructions to build NorthstarLauncher with [`podman`](https://podman.io/) (rootless Docker alternative) on Linux when using an SELinux enabled distros.



```
$ podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"
-- NS: Building to /build/game
CMake Deprecation Warning at primedev/thirdparty/minhook/CMakeLists.txt:27 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- curl version=[7.81.0-DEV]
-- Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR) 
-- Enabled features: SSL IPv6 unixsockets AsynchDNS Largefile SSPI alt-svc HSTS SPNEGO Kerberos NTLM
-- Enabled protocols: HTTP HTTPS
-- Enabled SSL backends: Schannel
-- Using CMake version 3.27.7
-- Fetching zlib https://github.com/R2Northstar/zlib fix-things
-- The following features have been enabled:

 * MZ_COMPAT, Enables compatibility layer
 * MZ_ZLIB, Enables ZLIB compression
 * MZ_FETCH_LIBS, Enables fetching third-party libraries if not found

-- The following features have been disabled:

 * MZ_BZIP2, Enables BZIP2 compression
 * MZ_LZMA, Enables LZMA & XZ compression
 * MZ_ZSTD, Enables ZSTD compression
 * MZ_LIBCOMP, Enables Apple compression
 * MZ_FORCE_FETCH_LIBS, Enables fetching third-party libraries always
 * MZ_PKCRYPT, Enables PKWARE traditional encryption
 * MZ_WZAES, Enables WinZIP AES encryption
 * MZ_OPENSSL, Enables OpenSSL for encryption
 * MZ_LIBBSD, Builds with libbsd crypto random
 * MZ_ICONV, Enables iconv string encoding conversion library
 * MZ_COMPRESS_ONLY, Only support compression
 * MZ_DECOMPRESS_ONLY, Only support decompression
 * MZ_FILE32_API, Builds using posix 32-bit file api
 * MZ_BUILD_TESTS, Builds minizip test executable
 * MZ_BUILD_UNIT_TESTS, Builds minizip unit test project
 * MZ_BUILD_FUZZ_TESTS, Builds minizip fuzzer executables
 * MZ_CODE_COVERAGE, Builds with code coverage flags

-- Configuring done (0.8s)
-- Generating done (0.1s)
-- Build files have been written to: /build
```

```
$ podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,Z northstar-build-fedora cmake --build .
[1/99] Building RC object primedev/CMakeFiles/NorthstarLauncher.dir/primelauncher/resources.rc.res
Microsoft (R) Windows (R) Resource Compiler Version 10.0.10011.16384
Copyright (C) Microsoft Corporation.  All rights reserved.

[2/99] Building RC object primedev/CMakeFiles/NorthstarDLL.dir/resources.rc.res
Microsoft (R) Windows (R) Resource Compiler Version 10.0.10011.16384
Copyright (C) Microsoft Corporation.  All rights reserved.

...

[99/99] Linking CXX shared library game/Northstar.dll
```