### PR TITLE
feat(?): Allow Vanilla Compatibility Mode to Auth

### DIFF
--- a/primedev/client/clientauthhooks.cpp
+++ b/primedev/client/clientauthhooks.cpp
@@ -22,7 +22,6 @@ void, __fastcall, (void* a1))
 	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 	{
 		AuthWithStryder(a1);
-		return;
 	}
 
 	// game will call this forever, until it gets a valid auth key

--- a/primedev/client/clientauthhooks.cpp
+++ b/primedev/client/clientauthhooks.cpp
@@ -17,13 +17,6 @@ AUTOHOOK(AuthWithStryder, engine.dll + 0x1843A0,
 void, __fastcall, (void* a1))
 // clang-format on
 {
-	// don't attempt to do Atlas auth if we are in vanilla compatibility mode
-	// this prevents users from joining untrustworthy servers (unless they use a concommand or something)
-	if (g_pVanillaCompatibility->GetVanillaCompatibility())
-	{
-		AuthWithStryder(a1);
-	}
-
 	// game will call this forever, until it gets a valid auth key
 	// so, we need to manually invalidate our key until we're authed with northstar, then we'll allow game to auth with stryder
 	if (!g_pMasterServerManager->m_bOriginAuthWithMasterServerDone && Cvar_ns_has_agreed_to_send_token->GetInt() != DISAGREED_TO_SEND_TOKEN)
@@ -32,9 +25,6 @@ void, __fastcall, (void* a1))
 		if (Cvar_ns_has_agreed_to_send_token->GetInt() == AGREED_TO_SEND_TOKEN &&
 			!g_pMasterServerManager->m_bOriginAuthWithMasterServerInProgress)
 			g_pMasterServerManager->AuthenticateOriginWithMasterServer(g_pLocalPlayerUserID, g_pLocalPlayerOriginToken);
-
-		// invalidate key so auth will fail
-		*g_pLocalPlayerOriginToken = 0;
 	}
 
 	AuthWithStryder(a1);

--- a/primedev/masterserver/masterserver.cpp
+++ b/primedev/masterserver/masterserver.cpp
@@ -90,7 +90,7 @@ size_t CurlWriteToStringBufferCallback(char* contents, size_t size, size_t nmemb
 
 void MasterServerManager::AuthenticateOriginWithMasterServer(const char* uid, const char* originToken)
 {
-	if (m_bOriginAuthWithMasterServerInProgress || g_pVanillaCompatibility->GetVanillaCompatibility())
+	if (m_bOriginAuthWithMasterServerInProgress)
 		return;
 
 	// do this here so it's instantly set
@@ -467,7 +467,7 @@ void MasterServerManager::RequestMainMenuPromos()
 void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char* playerToken)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer || g_pVanillaCompatibility->GetVanillaCompatibility())
+	if (m_bAuthenticatingWithGameServer)
 		return;
 
 	m_bAuthenticatingWithGameServer = true;
@@ -604,7 +604,7 @@ void MasterServerManager::AuthenticateWithOwnServer(const char* uid, const char*
 void MasterServerManager::AuthenticateWithServer(const char* uid, const char* playerToken, RemoteServerInfo server, const char* password)
 {
 	// dont wait, just stop if we're trying to do 2 auth requests at once
-	if (m_bAuthenticatingWithGameServer || g_pVanillaCompatibility->GetVanillaCompatibility())
+	if (m_bAuthenticatingWithGameServer)
 		return;
 
 	m_bAuthenticatingWithGameServer = true;


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

This PR makes some small changes to allow `-vanilla` users to authenticate to MS, because it is really stupid that they cannot frankly. (This is a counterpart to: https://github.com/R2Northstar/NorthstarMods/pull/800)