### PR TITLE
Adds -nojoy and -nosteamcontroller to dedicated cmdline args

### DIFF
--- a/primedev/dedicated/dedicated.cpp
+++ b/primedev/dedicated/dedicated.cpp
@@ -222,6 +222,8 @@ ON_DLL_LOAD_DEDI_RELIESON("engine.dll", DedicatedServer, ServerPresence, (CModul
 	CommandLine()->AppendParm("-nosound", 0);
 	CommandLine()->AppendParm("-windowed", 0);
 	CommandLine()->AppendParm("-nomessagebox", 0);
+	CommandLine()->AppendParm("-nojoy", 0);
+	CommandLine()->AppendParm("-nosteamcontroller", 0);
 	CommandLine()->AppendParm("+host_preload_shaders", "0");
 	CommandLine()->AppendParm("+net_usesocketsforloopback", "1");
 	CommandLine()->AppendParm("+community_frame_run", "0");


### PR DESCRIPTION
Closes https://github.com/R2Northstar/NorthstarLauncher/issues/634

Adds `-nojoy` (joystick inputs) and `-nosteamcontroller` (steam controller inputs) to the dedicated server's default args. This is supposed to stop the loading of the XInput DLLs, but at the moment does not. This PR is drafted while I try to figure out if there's something more that I need to do.

![image](https://github.com/R2Northstar/NorthstarLauncher/assets/41448081/5876725a-1e82-48dd-b345-a8f3224a406a)
