### PR TITLE
Fix engine error crash caused by language detection hooks

### DIFF
--- a/primedev/client/languagehooks.cpp
+++ b/primedev/client/languagehooks.cpp
@@ -41,7 +41,7 @@ std::vector<std::string> file_list(fs::path dir, std::regex ext_pattern)
 std::string GetAnyInstalledAudioLanguage()
 {
 	for (const auto& lang : file_list("r2\\sound\\", std::regex(".*?general_([a-z]+)_patch_1\\.mstr")))
-		if (lang != "general" || lang != "")
+		if (lang != "general" && lang != "" && lang != "stream")
 			return lang;
 	return "NO LANGUAGE DETECTED";
 }


### PR DESCRIPTION
During my debugging around user's game constantly crashes on startup with file corruption detected, I found this code which does not satisfy the guarding logic and need further detection to guard against files named `general_stream_xxx.mstr`. After applying this code change in my NorthstarCN fork, the crashes are resolved.

The initial debugging procedures:
1. Console logs `Origin detected language "stream", but we do not have audio for it installed, falling back to the next option`
2. Games crashes with engine error: file corruption detected.
3. Found problematic code, applied the code change.
4. The problem is fixed without modifying the environment.

