### PR TITLE
Use double brackets to let compiler know assignment is intentional

### DIFF
--- a/primedev/client/latencyflex.cpp
+++ b/primedev/client/latencyflex.cpp
@@ -24,10 +24,10 @@ ON_DLL_LOAD_CLIENT_RELIESON("client.dll", LatencyFlex, ConVar, (CModule module))
 	// https://ishitatsuyuki.github.io/post/latencyflex/
 	HMODULE pLfxModule;
 
-	if (pLfxModule = LoadLibraryA("latencyflex_layer.dll"))
+	if ((pLfxModule = LoadLibraryA("latencyflex_layer.dll")))
 		m_winelfx_WaitAndBeginFrame =
 			reinterpret_cast<void (*)()>(reinterpret_cast<void*>(GetProcAddress(pLfxModule, "lfx_WaitAndBeginFrame")));
-	else if (pLfxModule = LoadLibraryA("latencyflex_wine.dll"))
+	else if ((pLfxModule = LoadLibraryA("latencyflex_wine.dll")))
 		m_winelfx_WaitAndBeginFrame =
 			reinterpret_cast<void (*)()>(reinterpret_cast<void*>(GetProcAddress(pLfxModule, "winelfx_WaitAndBeginFrame")));
 	else


### PR DESCRIPTION
some compilers (most notably clang) gets a bit worried that we may be assigning unintentionally.
Using double brackets silences it and lets it know that this is correct.