### PR TITLE
Add overrides to `custom_sink_it_` methods

### DIFF
--- a/primedev/dedicated/dedicatedlogtoclient.h
+++ b/primedev/dedicated/dedicatedlogtoclient.h
@@ -5,7 +5,7 @@
 class DedicatedServerLogToClientSink : public CustomSink
 {
 protected:
-	void custom_sink_it_(const custom_log_msg& msg);
+	void custom_sink_it_(const custom_log_msg& msg) override;
 	void sink_it_(const spdlog::details::log_msg& msg) override;
 	void flush_() override;
 };

--- a/primedev/logging/sourceconsole.h
+++ b/primedev/logging/sourceconsole.h
@@ -77,7 +77,7 @@ private:
 		{spdlog::level::off, NS::Colors::OFF.ToSourceColor()}};
 
 protected:
-	void custom_sink_it_(const custom_log_msg& msg);
+	void custom_sink_it_(const custom_log_msg& msg) override;
 	void sink_it_(const spdlog::details::log_msg& msg) override;
 	void flush_() override;
 };


### PR DESCRIPTION
the compiler knows we want to override here, since the original `custom_sink_it_` is virtual but we should be explicit to prevent any mistakes.