### PR TITLE
Remove invalid memset in ServerPresence

### DIFF
--- a/primedev/server/serverpresence.h
+++ b/primedev/server/serverpresence.h
@@ -19,10 +19,7 @@ public:
 	int m_iPlayerCount;
 	int m_iMaxPlayers;
 
-	ServerPresence()
-	{
-		memset(this, 0, sizeof(this));
-	}
+	ServerPresence() {}
 
 	ServerPresence(const ServerPresence* obj)
 	{


### PR DESCRIPTION
The use of sizeof is incorrect here since `this` is a pointer and sizeof is used on the pointer directly, instead of what the pointer points to. It seems to work without issue due to padding but could cause issues if an instanced class like std::string gets nulled.
