### PR TITLE
Check if hook target is non `null` before calling MinHook

### DIFF
--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -104,7 +104,9 @@ bool ManualHook::Dispatch(LPVOID addr, LPVOID* orig)
 	if (orig)
 		ppOrigFunc = orig;
 
-	if (MH_CreateHook(addr, pHookFunc, ppOrigFunc) == MH_OK)
+	if (!addr)
+		spdlog::error("Address for hook {} is invalid", pFuncName);
+	else if (MH_CreateHook(addr, pHookFunc, ppOrigFunc) == MH_OK)
 	{
 		if (MH_EnableHook(addr) == MH_OK)
 		{

--- a/primedev/core/hooks.h
+++ b/primedev/core/hooks.h
@@ -201,7 +201,9 @@ public:
 		}
 		}
 
-		if (MH_CreateHook(targetAddr, pHookFunc, ppOrigFunc) == MH_OK)
+		if (!targetAddr)
+			spdlog::error("Address for hook {} is invalid", pFuncName);
+		else if (MH_CreateHook(targetAddr, pHookFunc, ppOrigFunc) == MH_OK)
 		{
 			if (MH_EnableHook(targetAddr) == MH_OK)
 				spdlog::info("Enabling hook {}", pFuncName);


### PR DESCRIPTION
MinHook doesn't check this either so it would also be found out when a Winapi function fails.

Lets fail earlier with an error message.