### PR TITLE
Remove duplicate wsock32 export

### DIFF
--- a/primedev/wsockproxy/wsock32.def
+++ b/primedev/wsockproxy/wsock32.def
@@ -69,7 +69,6 @@ EXPORTS
 	rresvport=ws2_32.rresvport
 	s_perror=PROXY_s_perror
 	select=ws2_32.select @18
-	select=ws2_32.select @18
 	send=ws2_32.send @19
 	sendto=ws2_32.sendto @20
 	sethostname=ws2_32.sethostname


### PR DESCRIPTION
Newer versions of lld check for duplicate export and error accordingly

```
lld-link: error: duplicate export ordinal: select
```