### PR TITLE
Add default case for SquirrelContext switch

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -601,6 +601,8 @@ auto ModConCommandCallback(const CCommand& command)
 	case ScriptContext::UI:
 		ModConCommandCallback_Internal<ScriptContext::UI>(found->Function, command);
 		break;
+	default:
+		spdlog::error("ModConCommandCallback on invalid Context {}", found->Context);
 	};
 }
 


### PR DESCRIPTION
logs errors so we can catch them if they do ever happen.

follow-up to #712