### PR TITLE
Use static MSVC Runtime Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.15)
+cmake_policy(
+    SET
+    CMP0091
+    NEW
+    )
 
 project(
     Northstar
@@ -20,6 +25,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_VS_PLATFORM_TOOLSET v143)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
 # Deal with MSVC incompatiblity
 add_compile_definitions(_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
 


### PR DESCRIPTION
We tried this already for when MSVC broke Northstar before but didn't merge it since it didn't fix the issue.

I think its best if we use the static runtime anyways to remove more dynamic dependencies that we can't anticipate.