### PR TITLE
Don't build when format check failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   build:
     runs-on: windows-2022
+    needs: [format-check, format-check-cmake-files]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This will prevent needless CI running when the format is all wack
