### PR TITLE
Add clang CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ env:
 jobs:
   build:
     runs-on: windows-2022
-    needs: [format-check, format-check-cmake-files]
     strategy:
       matrix:
         config:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ env:
 jobs:
   build:
     runs-on: windows-2022
+    needs: [format-check, format-check-cmake-files]
+    strategy:
+      matrix:
+        config:
+          - { name: "MSVC", cc: cl }
+          - { name: "LLVM", cc: clang-cl  }
+    env:
+      CC: ${{ matrix.config.cc }}
+      CXX: ${{ matrix.config.cc }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -33,7 +42,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: NorthstarLauncher-${{ steps.extract.outputs.commit }}
+          name: NorthstarLauncher-${{ matrix.config.name }}-${{ steps.extract.outputs.commit }}
           path: |
             game/
 


### PR DESCRIPTION
THIS ONLY APPLIES TO THE CI, NOT RELEASES

Builds Northstar with the Microsoft provided clang-cl build.

Anything that downloads GH Actions artifacts like FlightCore (@GeckoEidechse) will need to be updated.

Alternative I could check for a way of only having a `LLVM` suffix for clang builds.