### PR TITLE
Update all actions to supported versions

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -13,7 +13,7 @@ jobs:
     name: Add to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.1
         with:
           project-url: "https://github.com/orgs/R2Northstar/projects/3"
           github-token: "${{ secrets.PROJECT_BOARD_TOKEN }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Setup msvc
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: NorthstarLauncher-${{ steps.extract.outputs.commit }}
           path: |
@@ -40,7 +40,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: 'primedev'
@@ -52,7 +52,7 @@ jobs:
   format-check-cmake-files:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: puneetmatharu/cmake-format-lint-action@v1.0.4
       with:
         args: "--in-place"


### PR DESCRIPTION
checkout v3 has been out of date for a while
artifact v1, v2 and v3 will be deprecated this year, so we have to switch.