### PR TITLE
Update `actions/checkout` to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'true'
       - name: Setup msvc
@@ -40,7 +40,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: 'primedev'
@@ -52,7 +52,7 @@ jobs:
   format-check-cmake-files:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: puneetmatharu/cmake-format-lint-action@v1.0.4
       with:
         args: "--in-place"


### PR DESCRIPTION
`actions/checkout@v3` is outdated and will soon be deprecated

Spliced from #722 