### PR TITLE
Lowercase all linked libraries for building on Linux

### DIFF
--- a/primedev/Launcher.cmake
+++ b/primedev/Launcher.cmake
@@ -19,7 +19,7 @@ target_link_libraries(
             uuid.lib
             odbc32.lib
             odbccp32.lib
-            WS2_32.lib
+            ws2_32.lib
     )
 
 set_target_properties(

--- a/primedev/Northstar.cmake
+++ b/primedev/Northstar.cmake
@@ -172,13 +172,13 @@ target_link_libraries(
             libcurl
             minizip
             silver-bun
-            WS2_32.lib
-            Crypt32.lib
-            Cryptui.lib
+            ws2_32.lib
+            crypt32.lib
+            cryptui.lib
             dbghelp.lib
-            Wldap32.lib
-            Normaliz.lib
-            Bcrypt.lib
+            wldap32.lib
+            normaliz.lib
+            bcrypt.lib
             version.lib
     )
 

--- a/primedev/wsockproxy/CMakeLists.txt
+++ b/primedev/wsockproxy/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
     PRIVATE minhook
             mswsock.lib
             ws2_32.lib
-            ShLwApi.lib
+            shlwapi.lib
             imagehlp.lib
             dbghelp.lib
             kernel32.lib


### PR DESCRIPTION
Microsoft, in their infinite wisdom, decided to suffix some libraries with `.Lib` instead of `.lib` This causes issues with cmake on Linux because it only looks for `.lib` which it won't be able to resolve because the file system is case sensitive. Microsoft does this for backwards compatibility, in cmake this is a limitation so the best solution is to bite the bullet and lowercase all libraries which setups such as wine-msvc and xwin already do.
