### PR TITLE
Restructure primelauncher cmake logic

### DIFF
--- a/primedev/CMakeLists.txt
+++ b/primedev/CMakeLists.txt
@@ -1,3 +1,3 @@
 include(Northstar.cmake)
-include(Launcher.cmake)
+add_subdirectory(primelauncher)
 add_subdirectory(wsockproxy)

--- a/primedev/primelauncher/CMakeLists.txt
+++ b/primedev/primelauncher/CMakeLists.txt
@@ -1,6 +1,6 @@
 # NorthstarLauncher
 
-add_executable(NorthstarLauncher "primelauncher/main.cpp" "primelauncher/resources.rc")
+add_executable(NorthstarLauncher "main.cpp" "resources.rc")
 
 target_compile_definitions(NorthstarLauncher PRIVATE UNICODE _UNICODE)
 


### PR DESCRIPTION
- moves the primelauncher cmake logic into its subdirectory allowing everything related to it to be self contained
