### PR TITLE
Fix memalloc problems

### DIFF
--- a/primedev/core/memalloc.cpp
+++ b/primedev/core/memalloc.cpp
@@ -3,7 +3,7 @@
 
 // TODO: rename to malloc and free after removing statically compiled .libs
 
-extern "C" void* _malloc_base(size_t n)
+void* _malloc_base(size_t n)
 {
 	// allocate into static buffer if g_pMemAllocSingleton isn't initialised
 	if (!g_pMemAllocSingleton)
@@ -17,7 +17,7 @@ extern "C" void* _malloc_base(size_t n)
 	return _malloc_base(n);
 }*/
 
-extern "C" void _free_base(void* p)
+void _free_base(void* p)
 {
 	if (!g_pMemAllocSingleton)
 		TryCreateGlobalMemAlloc();
@@ -25,7 +25,7 @@ extern "C" void _free_base(void* p)
 	g_pMemAllocSingleton->m_vtable->Free(g_pMemAllocSingleton, p);
 }
 
-extern "C" void* _realloc_base(void* oldPtr, size_t size)
+void* _realloc_base(void* oldPtr, size_t size)
 {
 	if (!g_pMemAllocSingleton)
 		TryCreateGlobalMemAlloc();
@@ -33,7 +33,7 @@ extern "C" void* _realloc_base(void* oldPtr, size_t size)
 	return g_pMemAllocSingleton->m_vtable->Realloc(g_pMemAllocSingleton, oldPtr, size);
 }
 
-extern "C" void* _calloc_base(size_t n, size_t size)
+void* _calloc_base(size_t n, size_t size)
 {
 	size_t bytes = n * size;
 	void* memory = _malloc_base(bytes);
@@ -44,7 +44,7 @@ extern "C" void* _calloc_base(size_t n, size_t size)
 	return memory;
 }
 
-extern "C" char* _strdup_base(const char* src)
+char* _strdup_base(const char* src)
 {
 	char* str;
 	char* p;

--- a/primedev/core/memalloc.cpp
+++ b/primedev/core/memalloc.cpp
@@ -44,6 +44,32 @@ void* _calloc_base(size_t n, size_t size)
 	return memory;
 }
 
+void* _recalloc_base(void* const block, size_t const count, size_t const size)
+{
+	if (!block)
+		return _calloc_base(count, size);
+
+	const size_t new_size = count * size;
+    const size_t old_size = _msize(block);
+
+    void* const memory = _realloc_base(block, new_size);
+
+    if (memory && old_size < new_size)
+    {
+        memset(static_cast<char*>(memory) + old_size, 0, new_size - old_size);
+    }
+
+    return memory;
+}
+
+size_t _msize(void* const block)
+{
+	if (!g_pMemAllocSingleton)
+		TryCreateGlobalMemAlloc();
+
+	return g_pMemAllocSingleton->m_vtable->GetSize(g_pMemAllocSingleton, block);	
+}
+
 char* _strdup_base(const char* src)
 {
 	char* str;

--- a/primedev/core/memalloc.cpp
+++ b/primedev/core/memalloc.cpp
@@ -50,16 +50,16 @@ void* _recalloc_base(void* const block, size_t const count, size_t const size)
 		return _calloc_base(count, size);
 
 	const size_t new_size = count * size;
-    const size_t old_size = _msize(block);
+	const size_t old_size = _msize(block);
 
-    void* const memory = _realloc_base(block, new_size);
+	void* const memory = _realloc_base(block, new_size);
 
-    if (memory && old_size < new_size)
-    {
-        memset(static_cast<char*>(memory) + old_size, 0, new_size - old_size);
-    }
+	if (memory && old_size < new_size)
+	{
+		memset(static_cast<char*>(memory) + old_size, 0, new_size - old_size);
+	}
 
-    return memory;
+	return memory;
 }
 
 size_t _msize(void* const block)
@@ -67,7 +67,7 @@ size_t _msize(void* const block)
 	if (!g_pMemAllocSingleton)
 		TryCreateGlobalMemAlloc();
 
-	return g_pMemAllocSingleton->m_vtable->GetSize(g_pMemAllocSingleton, block);	
+	return g_pMemAllocSingleton->m_vtable->GetSize(g_pMemAllocSingleton, block);
 }
 
 char* _strdup_base(const char* src)

--- a/primedev/core/memalloc.h
+++ b/primedev/core/memalloc.h
@@ -11,6 +11,7 @@ extern "C" __declspec(noinline) void* __cdecl _calloc_base(size_t const count, s
 extern "C" __declspec(noinline) void* __cdecl _realloc_base(void* const block, size_t const size);
 extern "C" __declspec(noinline) void* __cdecl _recalloc_base(void* const block, size_t const count, size_t const size);
 extern "C" __declspec(noinline) void __cdecl _free_base(void* const block);
+extern "C" __declspec(noinline) size_t __cdecl _msize(void* const block);
 extern "C" __declspec(noinline) char* __cdecl _strdup_base(const char* src);
 
 void* operator new(size_t n);

--- a/primedev/core/memalloc.h
+++ b/primedev/core/memalloc.h
@@ -1,14 +1,17 @@
 #pragma once
 
+#include <malloc.h>
+
 #include "rapidjson/document.h"
 // #include "include/rapidjson/allocators.h"
 
-extern "C" void* _malloc_base(size_t size);
-extern "C" void* _calloc_base(size_t const count, size_t const size);
-extern "C" void* _realloc_base(void* block, size_t size);
-extern "C" void* _recalloc_base(void* const block, size_t const count, size_t const size);
-extern "C" void _free_base(void* const block);
-extern "C" char* _strdup_base(const char* src);
+// The prelude is needed for these to be usable by the CRT
+extern "C" __declspec(noinline) void* __cdecl _malloc_base(size_t const size);
+extern "C" __declspec(noinline) void* __cdecl _calloc_base(size_t const count, size_t const size);
+extern "C" __declspec(noinline) void* __cdecl _realloc_base(void* const block, size_t const size);
+extern "C" __declspec(noinline) void* __cdecl _recalloc_base(void* const block, size_t const count, size_t const size);
+extern "C" __declspec(noinline) void __cdecl _free_base(void* const block);
+extern "C" __declspec(noinline) char* __cdecl _strdup_base(const char* src);
 
 void* operator new(size_t n);
 void operator delete(void* p) noexcept;


### PR DESCRIPTION
#718 stopped Northstar from working for two reasons:
- the way the *alloc family was declared was not compatible with how the CRT worked
- _recalloc_base was declared but never defined

Microsofts documentation on _recalloc is a bit bad so I followed the chromium implementation
https://chromium.googlesource.com/chromium/src/+/84db13d2045c3bc2753c4048ec1816373de0c3cc/base/allocator/allocator_shim_override_ucrt_symbols_win.h#102

If the chromium implementation is right and only the new bits are zeroed then the r5sdk implementation is wrong.

Since we need to get the old size for recalloc I also implemented _msize

Tested this myself on Windows but I would love to get another tester for this