### PR TITLE
Convert primelauncher to GUI Subsystem

### DIFF
--- a/primedev/primelauncher/CMakeLists.txt
+++ b/primedev/primelauncher/CMakeLists.txt
@@ -1,6 +1,6 @@
 # NorthstarLauncher
 
-add_executable(NorthstarLauncher "main.cpp" "resources.rc")
+add_executable(NorthstarLauncher WIN32 "main.cpp" "resources.rc")
 
 target_compile_definitions(NorthstarLauncher PRIVATE UNICODE _UNICODE)
 

--- a/primedev/primelauncher/main.cpp
+++ b/primedev/primelauncher/main.cpp
@@ -476,3 +476,8 @@ int main(int argc, char* argv[])
 	return ((int(/*__fastcall*/*)(HINSTANCE, HINSTANCE, LPSTR, int))LauncherMain)(
 		NULL, NULL, NULL, 0); // the parameters aren't really used anyways
 }
+
+int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, char*, int nShowCmd)
+{
+	return main(__argc, __argv);
+}


### PR DESCRIPTION
Converts primelauncher to GUI subsystem.
Since the GUI subsystem NEEDS the entrypoint to be WinMain I made it call main, since large portions of the code rely on argc and argv handling.

This is practically how Microsoft implements this
`__argc` and `__argv` are available globals
https://learn.microsoft.com/en-us/cpp/c-runtime-library/argc-argv-wargv?view=msvc-170&redirectedfrom=MSDN