### PR TITLE
Add missing object check in mod manager

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -748,7 +748,7 @@ void ModManager::LoadMods()
 			continue;
 
 		// Add mod entry to enabledmods.json if it doesn't exist
-		if (!mod.m_bIsRemote && !m_EnabledModsCfg.HasMember(mod.Name.c_str()))
+		if (!mod.m_bIsRemote && m_bHasEnabledModsCfg && !m_EnabledModsCfg.HasMember(mod.Name.c_str()))
 		{
 			m_EnabledModsCfg.AddMember(rapidjson_document::StringRefType(mod.Name.c_str()), true, m_EnabledModsCfg.GetAllocator());
 			newModsDetected = true;


### PR DESCRIPTION
`HasMember` asserts `IsObject()` internally.
In release builds this is not an issue but this does not work on Debug builds.

`m_bHasEnabledModsCfg` is the output of `m_EnabledModsCfg.IsObject()` and this pattern exists in other places, so I think this is a "good enough" solution at the moment (though I consider this file to smell a bit)