### PR TITLE
remove needless parts out of precompiled header

### DIFF
--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -8,9 +8,6 @@
 #define _WINSOCK_DEPRECATED_NO_WARNINGS // temp because i'm very lazy and want to use inet_addr, remove later
 #define RAPIDJSON_HAS_STDSTRING 1
 
-// add headers that you want to pre-compile here
-#include "core/memalloc.h"
-
 #include <windows.h>
 #include <psapi.h>
 #include <set>
@@ -18,29 +15,10 @@
 #include <filesystem>
 #include <sstream>
 
-namespace fs = std::filesystem;
-
-#define EXPORT extern "C" __declspec(dllexport)
-
-typedef void (*callable)();
-typedef void (*callable_v)(void* v);
-
-// clang-format off
-#define assert_msg(exp, msg) assert((exp, msg))
-//clang-format on
-
-#define NOTE_UNUSED(var) do { (void)var; } while(false)
-
 #include "core/macros.h"
-
 #include "core/math/color.h"
-
-#include "spdlog/spdlog.h"
-#include "logging/logging.h"
-#include "MinHook.h"
-#include "curl/curl.h"
-#include "silver-bun/module.h"
-#include "silver-bun/memaddr.h"
 #include "core/hooks.h"
+#include "core/memalloc.h"
+#include "logging/logging.h"
 
 #endif


### PR DESCRIPTION
needs #732 
lots of things in the precompiled header really do not benefit from being in there since they are rarely used or not that large.

locally this has sped up the compiled by a minimum of 5 seconds