### PR TITLE
replace assert_msg macro with plain assert

### DIFF
--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -25,10 +25,6 @@ namespace fs = std::filesystem;
 typedef void (*callable)();
 typedef void (*callable_v)(void* v);
 
-// clang-format off
-#define assert_msg(exp, msg) assert((exp, msg))
-//clang-format on
-
 #define NOTE_UNUSED(var) do { (void)var; } while(false)
 
 #include "core/macros.h"

--- a/primedev/shared/keyvalues.cpp
+++ b/primedev/shared/keyvalues.cpp
@@ -204,7 +204,7 @@ void KeyValues::RemoveEverything(void)
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::FindKey(const char* pszKeyName, bool bCreate)
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 
 	if (!pszKeyName || !*pszKeyName)
 		return this;
@@ -510,7 +510,7 @@ bool KeyValues::IsEmpty(const char* pszKeyName)
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetFirstTrueSubKey(void) const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	KeyValues* pRet = m_pSub;
 	while (pRet && pRet->m_iDataType != TYPE_NONE)
 		pRet = pRet->m_pPeer;
@@ -524,7 +524,7 @@ KeyValues* KeyValues::GetFirstTrueSubKey(void) const
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetNextTrueSubKey(void) const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	KeyValues* pRet = m_pPeer;
 	while (pRet && pRet->m_iDataType != TYPE_NONE)
 		pRet = pRet->m_pPeer;
@@ -538,7 +538,7 @@ KeyValues* KeyValues::GetNextTrueSubKey(void) const
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetFirstValue(void) const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	KeyValues* pRet = m_pSub;
 	while (pRet && pRet->m_iDataType == TYPE_NONE)
 		pRet = pRet->m_pPeer;
@@ -552,7 +552,7 @@ KeyValues* KeyValues::GetFirstValue(void) const
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetNextValue(void) const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	KeyValues* pRet = m_pPeer;
 	while (pRet && pRet->m_iDataType == TYPE_NONE)
 		pRet = pRet->m_pPeer;
@@ -565,7 +565,7 @@ KeyValues* KeyValues::GetNextValue(void) const
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetFirstSubKey() const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	return m_pSub;
 }
 
@@ -574,7 +574,7 @@ KeyValues* KeyValues::GetFirstSubKey() const
 //-----------------------------------------------------------------------------
 KeyValues* KeyValues::GetNextKey() const
 {
-	assert_msg(this, "Member function called on NULL KeyValues");
+	assert((this, "Member function called on NULL KeyValues"));
 	return m_pPeer;
 }
 


### PR DESCRIPTION
the `assert_msg` macro really didn't do a lot and was only used in one place so..... yeah.
Less code smell!