### PR TITLE
Remove unused typedefs from precompiled header

### DIFF
--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -20,7 +20,6 @@
 
 namespace fs = std::filesystem;
 
-
 // clang-format off
 #define assert_msg(exp, msg) assert((exp, msg))
 //clang-format on

--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -22,9 +22,6 @@ namespace fs = std::filesystem;
 
 #define EXPORT extern "C" __declspec(dllexport)
 
-typedef void (*callable)();
-typedef void (*callable_v)(void* v);
-
 // clang-format off
 #define assert_msg(exp, msg) assert((exp, msg))
 //clang-format on


### PR DESCRIPTION
These go completely unused
