### PR TITLE
Remove EXPORT macro from precompiled header

### DIFF
--- a/primedev/pch.h
+++ b/primedev/pch.h
@@ -20,8 +20,6 @@
 
 namespace fs = std::filesystem;
 
-#define EXPORT extern "C" __declspec(dllexport)
-
 typedef void (*callable)();
 typedef void (*callable_v)(void* v);
 

--- a/primedev/plugins/interfaces/interface.h
+++ b/primedev/plugins/interfaces/interface.h
@@ -34,6 +34,6 @@ public:
 	static className __g_##className##_singleton;                                                                                          \
 	EXPOSE_SINGLE_INTERFACE_GLOBALVAR(className, interfaceName, versionName, __g_##className##_singleton)
 
-EXPORT void* CreateInterface(const char* pName, InterfaceStatus* pReturnCode);
+extern "C" __declspec(dllexport) void* CreateInterface(const char* pName, InterfaceStatus* pReturnCode);
 
 #endif


### PR DESCRIPTION
its used once and does not warrant being in the precompiled header
