### PR TITLE
warn if mod dependency is found but disabled

### DIFF
--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -173,12 +173,16 @@ template <ScriptContext context> void SquirrelManager<context>::VMCreated(CSquir
 
 		for (Mod& dependency : g_pModManager->m_LoadedMods)
 		{
-			if (!dependency.m_bEnabled)
-				continue;
-
 			if (dependency.Name == pair.second)
 			{
-				bWasFound = true;
+				if (dependency.m_bEnabled)
+				{
+					bWasFound = true;
+				}
+				else
+				{
+					spdlog::warn("dependency '{}' is disabled, some mods may not work correctly", pair.second);
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
Adds a warning if a dependency is installed but disabled.

This may be intentional by the user or be an optional dependency, so we cannot force enable it.

If this is really needed is up to debate because one could derive if a dependency is missing by digging through the log, but I think this may be useful to have.
