### PR TITLE
Check for Console Window before allocating one

### DIFF
--- a/primedev/logging/logging.cpp
+++ b/primedev/logging/logging.cpp
@@ -124,7 +124,7 @@ void CustomSink::custom_log(const custom_log_msg& msg)
 
 void InitialiseConsole()
 {
-	if (AllocConsole() == FALSE)
+	if (GetConsoleWindow() == NULL && AllocConsole() == FALSE)
 	{
 		std::cout << "[*] Failed to create a console window, maybe a console already exists?" << std::endl;
 	}

--- a/primedev/logging/logging.cpp
+++ b/primedev/logging/logging.cpp
@@ -126,7 +126,7 @@ void InitialiseConsole()
 {
 	if (GetConsoleWindow() == NULL && AllocConsole() == FALSE)
 	{
-		std::cout << "[*] Failed to create a console window, maybe a console already exists?" << std::endl;
+		std::cout << "[*] Failed to create a console window" << std::endl;
 	}
 	else
 	{


### PR DESCRIPTION
gets rid of that annoying
`[*] Failed to create a console window, maybe a console already exists?`
when launching via NorthstarLauncher.exe