### PR TITLE
Turn dependency constant into table

### DIFF
--- a/primedev/squirrel/squirrel.h
+++ b/primedev/squirrel/squirrel.h
@@ -120,6 +120,9 @@ public:
 	sq_pushnewstructinstanceType __sq_pushnewstructinstance;
 	sq_sealstructslotType __sq_sealstructslot;
 
+	sq_pushconsttableType __sq_pushconsttable;
+	sq_poptopType __sq_poptop;
+
 #pragma endregion
 
 #pragma region SQVM func wrappers
@@ -311,6 +314,16 @@ public:
 	{
 		return __sq_sealstructslot(sqvm, fieldIndex);
 	}
+
+	inline void pushconsttable(HSquirrelVM* sqvm)
+	{
+		return __sq_pushconsttable(sqvm);
+	}
+
+	inline void poptop(HSquirrelVM* sqvm)
+	{
+		return __sq_poptop(sqvm);
+	}
 #pragma endregion
 };
 
@@ -409,6 +422,7 @@ public:
 
 	void VMCreated(CSquirrelVM* newSqvm);
 	void VMDestroyed();
+	void InjectDependencyConstants(Mod& dependency, std::string name);
 	void ExecuteCode(const char* code);
 	void AddFuncRegistration(std::string returnType, std::string name, std::string argTypes, std::string helpText, SQFunction func);
 	SQRESULT setupfunc(const SQChar* funcname);

--- a/primedev/squirrel/squirrelclasstypes.h
+++ b/primedev/squirrel/squirrelclasstypes.h
@@ -235,4 +235,7 @@ typedef int (*sq_getfunctionType)(HSquirrelVM* sqvm, const char* name, SQObject*
 typedef SQRESULT (*sq_pushnewstructinstanceType)(HSquirrelVM* sqvm, int fieldCount);
 typedef SQRESULT (*sq_sealstructslotType)(HSquirrelVM* sqvm, int slotIndex);
 
+typedef void (*sq_poptopType)(HSquirrelVM* sqvm);
+typedef void (*sq_pushconsttableType)(HSquirrelVM* sqvm);
+
 #pragma endregion


### PR DESCRIPTION
based on #685
credits to @uniboi for the original implementation

turns dependency constant from a plain boolean value to an optional table with the following attributes:
- `version` contains the raw version string of the dependency
- `major`, `minor`, `patch` contains an attempt at parsing the above version string naively as semver.
    - if the relevant segment is empty or not a number it will default to `-1`

reworked from scratch to add fewer functions and fix some bugs all around.


