### PR TITLE
Change mod loading location

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -616,7 +616,7 @@ void ModManager::LoadMods()
 	// ensure dirs exist
 	fs::remove_all(GetCompiledAssetsPath());
 	fs::create_directories(GetModFolderPath());
-	fs::create_directories(GetThunderstoreModFolderPath());
+	fs::create_directories(GetThunderstoreLegacyModFolderPath());
 	fs::create_directories(GetRemoteModFolderPath());
 
 	m_DependencyConstants.clear();
@@ -640,7 +640,7 @@ void ModManager::LoadMods()
 	// get mod directories
 	std::filesystem::directory_iterator classicModsDir = fs::directory_iterator(GetModFolderPath());
 	std::filesystem::directory_iterator remoteModsDir = fs::directory_iterator(GetRemoteModFolderPath());
-	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreLegacyModFolderPath());
 
 	for (fs::directory_entry dir : classicModsDir)
 		if (fs::exists(dir.path() / "mod.json"))
@@ -1131,7 +1131,7 @@ fs::path GetModFolderPath()
 {
 	return fs::path(GetNorthstarPrefix() + MOD_FOLDER_SUFFIX);
 }
-fs::path GetThunderstoreModFolderPath()
+fs::path GetThunderstoreLegacyModFolderPath()
 {
 	return fs::path(GetNorthstarPrefix() + THUNDERSTORE_MOD_FOLDER_SUFFIX);
 }

--- a/primedev/mods/modmanager.h
+++ b/primedev/mods/modmanager.h
@@ -9,8 +9,8 @@
 #include <filesystem>
 #include <unordered_set>
 
-const std::string MOD_FOLDER_SUFFIX = "\\mods";
-const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "\\packages";
+const std::string MOD_FOLDER_SUFFIX = "\\mods\\core";
+const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "\\mods\\thunderstore-legacy";
 const std::string REMOTE_MOD_FOLDER_SUFFIX = "\\runtime\\remote\\mods";
 const fs::path MOD_OVERRIDE_DIR = "mod";
 const std::string COMPILED_ASSETS_SUFFIX = "\\runtime\\compiled";
@@ -181,7 +181,7 @@ public:
 
 fs::path GetModFolderPath();
 fs::path GetRemoteModFolderPath();
-fs::path GetThunderstoreModFolderPath();
+fs::path GetThunderstoreLegacyModFolderPath();
 fs::path GetCompiledAssetsPath();
 
 extern ModManager* g_pModManager;

--- a/primedev/plugins/pluginmanager.cpp
+++ b/primedev/plugins/pluginmanager.cpp
@@ -58,7 +58,7 @@ bool PluginManager::LoadPlugins(bool reloaded)
 		return false;
 	}
 
-	fs::create_directories(GetThunderstoreModFolderPath());
+	fs::create_directories(GetThunderstoreLegacyModFolderPath());
 
 	std::vector<fs::path> paths;
 
@@ -71,7 +71,7 @@ bool PluginManager::LoadPlugins(bool reloaded)
 	FindPlugins(pluginPath, paths);
 
 	// Special case for Thunderstore mods dir
-	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreModFolderPath());
+	std::filesystem::directory_iterator thunderstoreModsDir = fs::directory_iterator(GetThunderstoreLegacyModFolderPath());
 	// Set up regex for `AUTHOR-MOD-VERSION` pattern
 	std::regex pattern(R"(.*\\([a-zA-Z0-9_]+)-([a-zA-Z0-9_]+)-(\d+\.\d+\.\d+))");
 	for (fs::directory_entry dir : thunderstoreModsDir)


### PR DESCRIPTION
## What this do?

Basically
- `mods/` gets split into 
  - `mods/core/` for core Northstar mods (only `Northstar.XYZ` named mods allowed)
  - `mods/manual` for manually installed mods
- `packages` is moved into `core/thunderstore-legacy`
- a new folder for non-packages style Thunderstore mods, i.e. all the files are in the root of the zip instead of in `/mods/<mod-name>` (forcing on Northstar mod per Thunderstore mod)

Additionaly `mod.json` should get maybe also get a manifest version number and `0` should be assumed if the version number is missing.

&nbsp;

## What this involved?

Arguably the biggest issue with all of this is getting all the wiki and other sources of information updated, updating GitHub Actions for pushing to Thunderstore, getting helpers informed, somehow getting old YouTube videos updated, getting mod-managers involved, ... it's gonna be a mess at first but it's gonna be worth it.


&nbsp;

## Why?

- Support for other mod sources next to Thunderstore in the future
- No more multiple Northstar mods in a single Thunderstore mod

&nbsp;

## TODO

- [ ] make code look nicer
- [ ] require mods in `mods/core/` to be prefixed with `Northstar.`
- [ ] add `mods/thunderstore/`
  - [ ] Add check for `AUTHOR-MOD-VERSION` folder name and `mod.json` in folder root
- [ ] Figure out how to do plugins. They should be inside a Northstar mod IMO but how exactly? Or are there better approaches?
- [ ] Add manifest version number in `mods.json`
- [ ] Non-PR-related: Literally get everyone informed on this and stuff changed accordingly
  - [ ] Helpers
  - [ ] Wiki
  - [ ] ModdingDocs
  - [ ] Mod-managers
    - [ ] FlightCore
    - [ ] Viper
    - [ ] VTOL
    - [ ] r2modman
    - [ ] Tether
- [ ] ???