### PR TITLE
Define `fs` alias in source file where used

### DIFF
--- a/primedev/client/audio.cpp
+++ b/primedev/client/audio.cpp
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <random>
 
+namespace fs = std::filesystem;
+
 AUTOHOOK_INIT()
 
 static const char* pszAudioEventName;

--- a/primedev/client/audio.h
+++ b/primedev/client/audio.h
@@ -5,6 +5,8 @@
 #include <regex>
 #include <shared_mutex>
 
+namespace fs = std::filesystem;
+
 enum class AudioSelectionStrategy
 {
 	INVALID = -1,

--- a/primedev/client/languagehooks.cpp
+++ b/primedev/client/languagehooks.cpp
@@ -3,6 +3,8 @@
 #include <filesystem>
 #include <regex>
 
+namespace fs = std::filesystem;
+
 AUTOHOOK_INIT()
 
 typedef LANGID (*Tier0_DetectDefaultLanguageType)();

--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -12,6 +12,8 @@
 
 #define XINPUT1_3_DLL "XInput1_3.dll"
 
+namespace fs = std::filesystem;
+
 AUTOHOOK_INIT()
 
 // called from the ON_DLL_LOAD macros

--- a/primedev/mods/autodownload/moddownloader.h
+++ b/primedev/mods/autodownload/moddownloader.h
@@ -1,3 +1,5 @@
+namespace fs = std::filesystem;
+
 class ModDownloader
 {
 private:

--- a/primedev/mods/modmanager.h
+++ b/primedev/mods/modmanager.h
@@ -9,6 +9,8 @@
 #include <filesystem>
 #include <unordered_set>
 
+namespace fs = std::filesystem;
+
 const std::string MOD_FOLDER_SUFFIX = "\\mods";
 const std::string THUNDERSTORE_MOD_FOLDER_SUFFIX = "\\packages";
 const std::string REMOTE_MOD_FOLDER_SUFFIX = "\\runtime\\remote\\mods";

--- a/primedev/plugins/pluginmanager.cpp
+++ b/primedev/plugins/pluginmanager.cpp
@@ -5,6 +5,8 @@
 #include "config/profile.h"
 #include "core/convar/concommand.h"
 
+namespace fs = std::filesystem;
+
 PluginManager* g_pPluginManager;
 
 const std::vector<Plugin>& PluginManager::GetLoadedPlugins() const

--- a/primedev/plugins/pluginmanager.h
+++ b/primedev/plugins/pluginmanager.h
@@ -3,6 +3,8 @@
 
 #include <windows.h>
 
+namespace fs = std::filesystem;
+
 class Plugin;
 
 class PluginManager

--- a/primedev/server/buildainfile.cpp
+++ b/primedev/server/buildainfile.cpp
@@ -5,6 +5,8 @@
 #include <fstream>
 #include <filesystem>
 
+namespace fs = std::filesystem;
+
 AUTOHOOK_INIT()
 
 const int AINET_VERSION_NUMBER = 57;

--- a/primedev/squirrel/squirrel.h
+++ b/primedev/squirrel/squirrel.h
@@ -5,6 +5,8 @@
 #include "core/math/vector.h"
 #include "mods/modmanager.h"
 
+namespace fs = std::filesystem;
+
 /*
 	definitions from hell
 	required to function


### PR DESCRIPTION
Define `fs` alias for filesystem namespace in source file where used instead of relying on implicit includes.

Spliced from #732
