### PR TITLE
fix: Do not crash on unknown MAD manifesto format

### DIFF
--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -92,6 +92,13 @@ void ModDownloader::FetchModsListFromAPI()
 			verifiedModsJson.Parse(readBuffer);
 			for (auto i = verifiedModsJson.MemberBegin(); i != verifiedModsJson.MemberEnd(); ++i)
 			{
+				// Format testing
+				if (!i->value.HasMember("DependencyPrefix") || !i->value.HasMember("Versions"))
+				{
+					spdlog::warn("Verified mods manifesto format is unrecognized, skipping loading.");
+					return;
+				}
+
 				std::string name = i->name.GetString();
 				std::string dependency = i->value["DependencyPrefix"].GetString();
 
@@ -101,6 +108,13 @@ void ModDownloader::FetchModsListFromAPI()
 				for (auto& attribute : versions.GetArray())
 				{
 					assert(attribute.IsObject());
+					// Format testing
+					if (!attribute.HasMember("Version") || !attribute.HasMember("Checksum"))
+					{
+						spdlog::warn("Verified mods manifesto format is unrecognized, skipping loading.");
+						return;
+					}
+
 					std::string version = attribute["Version"].GetString();
 					std::string checksum = attribute["Checksum"].GetString();
 					modVersions.insert({version, {.checksum = checksum}});


### PR DESCRIPTION
Currently, if something bad happens during MAD manifesto parsing (if its format was updated, *for instance*), the game crashes.

##### Testing

Using an unknown MAD manifesto:
`.\NorthstarLauncher.exe -customverifiedurl=https://raw.githubusercontent.com/R2Northstar/VerifiedMods/refactor/include-mod-source-in-version-links/verified-mods.json`:

1. should crash with `main`;
2. should output a warning message with this branch.