### PR TITLE
Fix typo in class member function

### DIFF
--- a/primedev/squirrel/squirrel.h
+++ b/primedev/squirrel/squirrel.h
@@ -447,7 +447,7 @@ inline VoidFunction SQMessageBufferPushArg(Vector3& arg) {
 // Vectors
 template <ScriptContext context>
 inline VoidFunction SQMessageBufferPushArg(SQObject* arg) {
-	return [arg]{ g_pSquirrel<context>->pushSQObject(g_pSquirrel<context>->m_pSQVM->sqvm, arg); };
+	return [arg]{ g_pSquirrel<context>->pushobject(g_pSquirrel<context>->m_pSQVM->sqvm, arg); };
 }
 // Ints
 template <ScriptContext context, typename T>


### PR DESCRIPTION
`pushSQObject` does not exist. Spliced from #692 as per https://github.com/R2Northstar/NorthstarLauncher/pull/692#discussion_r1591169750