### PR TITLE
Only fetch MAD manifesto on server join

### DIFF
--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -63,6 +63,9 @@ void ModDownloader::FetchModsListFromAPI()
 			rapidjson::Document verifiedModsJson;
 			std::string url = modsListUrl;
 
+			// Empty verified mods manifesto
+			verifiedMods = {};
+
 			curl_global_init(CURL_GLOBAL_ALL);
 			easyhandle = curl_easy_init();
 			std::string readBuffer;

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -80,7 +80,12 @@ void ModDownloader::FetchModsListFromAPI()
 			curl_easy_setopt(easyhandle, CURLOPT_WRITEDATA, &readBuffer);
 			curl_easy_setopt(easyhandle, CURLOPT_WRITEFUNCTION, WriteToString);
 			result = curl_easy_perform(easyhandle);
-			ScopeGuard cleanup([&] { curl_easy_cleanup(easyhandle); });
+			ScopeGuard cleanup(
+				[&]
+				{
+					curl_easy_cleanup(easyhandle);
+					modState.state = DOWNLOADING;
+				});
 
 			if (result == CURLcode::CURLE_OK)
 			{

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -55,6 +55,8 @@ size_t WriteToString(void* ptr, size_t size, size_t count, void* stream)
 
 void ModDownloader::FetchModsListFromAPI()
 {
+	modState.state = MANIFESTO_FETCHING;
+
 	std::thread requestThread(
 		[this]()
 		{

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -617,7 +617,6 @@ void ModDownloader::DownloadMod(std::string modName, std::string modVersion)
 ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module))
 {
 	g_pModDownloader = new ModDownloader();
-	g_pModDownloader->FetchModsListFromAPI();
 }
 
 ADD_SQFUNC(

--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -619,6 +619,12 @@ ON_DLL_LOAD_RELIESON("engine.dll", ModDownloader, (ConCommand), (CModule module)
 	g_pModDownloader = new ModDownloader();
 }
 
+ADD_SQFUNC("void", NSFetchVerifiedModsManifesto, "", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+{
+	g_pModDownloader->FetchModsListFromAPI();
+	return SQRESULT_NULL;
+}
+
 ADD_SQFUNC(
 	"bool", NSIsModDownloadable, "string name, string version", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {

--- a/primedev/mods/autodownload/moddownloader.h
+++ b/primedev/mods/autodownload/moddownloader.h
@@ -116,6 +116,8 @@ public:
 
 	enum ModInstallState
 	{
+		MANIFESTO_FETCHING,
+
 		// Normal installation process
 		DOWNLOADING,
 		CHECKSUMING,


### PR DESCRIPTION
Previously, the verified mods manifesto was fetched on game start without checking if the verified mod feature is enabled Squirrel
-side; with this, the manifesto is only fetched when the user wants to download a mod (meaning they enabled the feature beforehand).

**(must be merged with the mods PR!)**

#### Launcher changes

* Expose `FetchModsListFromAPI` method to Squirrel VM
* Do not invoke `FetchModsListFromAPI` method on client start
* Add `ModInstallState.MANIFESTO_FETCHING` enum value to better track mod install progress

#### TODOs

- [x] Mods counterpart PR (https://github.com/R2Northstar/NorthstarMods/pull/821)

#### Testing

*Without PRs:*

1. Launch game;
2. Check the logs: they should display verified mods manifesto was fetched close to game launch;

*With PRs:*

1. Install both launcher and mods PRs;
2. Launch game, reach MP lobby and enable MAD (`allow_mod_auto_download 1`);
3. Try and connect to a server requiring verified mods (`Space battle` or `Parkour` server should be up at the time of writing);
4. Check the logs: manifesto should be fetched when trying to join the server.

##### Media

[delayed_manifesto_fetching.webm](https://github.com/user-attachments/assets/a6b24f62-3964-4251-b6a0-10b118d0614d)

(if you look closely, you can see verified mods manifesto is fetched *WHEN* joining the server, around `0:12` in the video)