### PR TITLE
Add comment explaining time choice for cron job

### DIFF
--- a/.github/workflows/merge-conflict-auto-label.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "10 21 * * *"
+    - cron: "10 21 * * *" # Runs at 21:10; time was chosen based on contributor activity and low GitHub Actions cron load.
 
 jobs:
   triage:


### PR DESCRIPTION
Just adds a comment to CI file explaining the reasoning for choosing a specific time for the cron job.
