### PR TITLE
fix rpak postload crash if no valid json

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -873,7 +873,7 @@ void ModManager::LoadMods()
 										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
-					if (!bUseRpakJson ||
+					if (bUseRpakJson &&
 						(dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
 						modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
 


### PR DESCRIPTION
Hello frens!

This pr fixes issue #690 

To reproduce the crash on a version without the fix:

1. make a mod with a paks folder
2. put atleast an rpak into it
3. dont make the rpaks.json or make it empty
4. launch the game

this should now crash at line 878 in modmanager.cpp as the original logic tries to set a postload string even tho none exists as the variable `bUseRpakJson` is being inverted in the if statement and doest ask for an && wether the other statements are also true, thus leading to the string being set to a value that doesnt exist making launcher go brrrt

To Test wether it works:
follow the reproduce steps, and notice that it wont crash and still load rpaks properly.


