### PR TITLE
Fix postload crash from missing `rpak.json`

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -872,7 +872,7 @@ void ModManager::LoadMods()
 
 					if (!bUseRpakJson)
 					{
-						spdlog::warn("Mod {} contains rpaks without valid rpaks.json, rpaks might not be loaded", mod.Name);
+						spdlog::warn("Mod {} contains rpaks without valid rpak.json, rpaks might not be loaded", mod.Name);
 					}
 					else
 					{

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -863,19 +863,27 @@ void ModManager::LoadMods()
 			for (fs::directory_entry file : fs::directory_iterator(mod.m_ModDirectory / "paks"))
 			{
 				// ensure we're only loading rpaks
-				if (fs::is_regular_file(file) && file.path().extension() == ".rpak" && bUseRpakJson)
+				if (fs::is_regular_file(file) && file.path().extension() == ".rpak")
 				{
+
+
 					std::string pakName(file.path().filename().string());
-
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
-					modPak.m_bAutoLoad =
-						!bUseRpakJson || (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
-										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
-					// postload things
-					if (bUseRpakJson &&
-						(dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
-						modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
+					if (!bUseRpakJson)
+					{
+						spdlog::warn("Mod {} contains rpak(s) without a valid rpaks.json, rpak(s) might not be loaded", mod.Name);
+					}
+					else
+					{
+						modPak.m_bAutoLoad = (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
+							dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+
+						// postload things
+						if (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() &&
+							dRpakJson["Postload"].HasMember(pakName))
+							modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
+					}
 
 					modPak.m_sPakName = pakName;
 

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -863,7 +863,7 @@ void ModManager::LoadMods()
 			for (fs::directory_entry file : fs::directory_iterator(mod.m_ModDirectory / "paks"))
 			{
 				// ensure we're only loading rpaks
-				if (fs::is_regular_file(file) && file.path().extension() == ".rpak")
+				if (fs::is_regular_file(file) && file.path().extension() == ".rpak" && bUseRpakJson)
 				{
 					std::string pakName(file.path().filename().string());
 

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -882,7 +882,9 @@ void ModManager::LoadMods()
 						// postload things
 						if (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() &&
 							dRpakJson["Postload"].HasMember(pakName))
+						{
 							modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
+						}
 					}
 
 					modPak.m_sPakName = pakName;

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -873,7 +873,8 @@ void ModManager::LoadMods()
 										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
-					if (bUseRpakJson && (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
+					if (bUseRpakJson &&
+						(dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
 						modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
 
 					modPak.m_sPakName = pakName;

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -865,8 +865,6 @@ void ModManager::LoadMods()
 				// ensure we're only loading rpaks
 				if (fs::is_regular_file(file) && file.path().extension() == ".rpak")
 				{
-
-
 					std::string pakName(file.path().filename().string());
 					ModRpakEntry& modPak = mod.Rpaks.emplace_back();
 
@@ -876,12 +874,12 @@ void ModManager::LoadMods()
 					}
 					else
 					{
-						modPak.m_bAutoLoad = (dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() &&
-							dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
+						modPak.m_bAutoLoad =
+							(dRpakJson.HasMember("Preload") && dRpakJson["Preload"].IsObject() && dRpakJson["Preload"].HasMember(pakName) &&
+							 dRpakJson["Preload"][pakName].IsTrue());
 
 						// postload things
-						if (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() &&
-							dRpakJson["Postload"].HasMember(pakName))
+						if (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName))
 						{
 							modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
 						}

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -872,7 +872,7 @@ void ModManager::LoadMods()
 
 					if (!bUseRpakJson)
 					{
-						spdlog::warn("Mod {} contains rpak(s) without a valid rpaks.json, rpak(s) might not be loaded", mod.Name);
+						spdlog::warn("Mod {} contains rpaks without valid rpaks.json, rpaks might not be loaded", mod.Name);
 					}
 					else
 					{

--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -873,8 +873,7 @@ void ModManager::LoadMods()
 										  dRpakJson["Preload"].HasMember(pakName) && dRpakJson["Preload"][pakName].IsTrue());
 
 					// postload things
-					if (!bUseRpakJson ||
-						(dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
+					if (bUseRpakJson && (dRpakJson.HasMember("Postload") && dRpakJson["Postload"].IsObject() && dRpakJson["Postload"].HasMember(pakName)))
 						modPak.m_sLoadAfterPak = dRpakJson["Postload"][pakName].GetString();
 
 					modPak.m_sPakName = pakName;


### PR DESCRIPTION
Hello frens!

This pr fixes issue #690 

To reproduce the crash on a version without the fix:


1. make a mod with a paks folder
2. put atleast an rpak into it
3. dont make the rpaks.json or make it empty
4. launch the game

this should now crash at line 878 in modmanager.cpp as the original logic tries to set a postload string even tho none exists as the variable bUseRpakJson is being inverted in the if statement and doest ask for an && wether the other statements are also true, thus leading to the string being set to a value that doesnt exist making launcher go brrrt

To Test wether it works:
follow the reproduce steps, and notice that it wont crash and still load rpaks properly.