### PR TITLE
engine: Restore `mat_crosshair_printmaterial` concommand

### DIFF
--- a/primedev/Northstar.cmake
+++ b/primedev/Northstar.cmake
@@ -62,6 +62,7 @@ add_library(
     "dedicated/dedicatedlogtoclient.cpp"
     "dedicated/dedicatedlogtoclient.h"
     "dedicated/dedicatedmaterialsystem.cpp"
+    "engine/gl_matsysiface.cpp"
     "engine/host.cpp"
     "engine/hoststate.cpp"
     "engine/hoststate.h"

--- a/primedev/engine/gl_matsysiface.cpp
+++ b/primedev/engine/gl_matsysiface.cpp
@@ -1,0 +1,50 @@
+#include "materialsystem/cmaterialglue.h"
+
+CMaterialGlue* (*GetMaterialAtCrossHair)();
+
+AUTOHOOK_INIT()
+
+AUTOHOOK(CC_mat_crosshair_printmaterial_f, engine.dll + 0xB3C40, void, __fastcall, (const CCommand& args))
+{
+	CMaterialGlue* pMat = GetMaterialAtCrossHair();
+
+	if (!pMat)
+	{
+		spdlog::error("Not looking at a material!");
+		return;
+	}
+
+	std::function<void(CMaterialGlue * pGlue, const char* szName)> fnPrintGlue = [](CMaterialGlue* pGlue, const char* szName)
+	{
+		spdlog::info("|-----------------------------------------------");
+
+		if (!pGlue)
+		{
+			spdlog::info("|-- {} is NULL", szName);
+			return;
+		}
+
+		spdlog::info("|-- Name: {}", szName);
+		spdlog::info("|-- GUID: {:#x}", pGlue->m_GUID);
+		spdlog::info("|-- Name: {}", pGlue->m_pszName);
+		spdlog::info("|-- Width : {}", pGlue->m_iWidth);
+		spdlog::info("|-- Height: {}", pGlue->m_iHeight);
+	};
+
+	spdlog::info("|- GUID: {:#x}", pMat->m_GUID);
+	spdlog::info("|- Name: {}", pMat->m_pszName);
+	spdlog::info("|- Width : {}", pMat->m_iWidth);
+	spdlog::info("|- Height: {}", pMat->m_iHeight);
+
+	fnPrintGlue(pMat->m_pDepthShadow, "DepthShadow");
+	fnPrintGlue(pMat->m_pDepthPrepass, "DepthPrepass");
+	fnPrintGlue(pMat->m_pDepthVSM, "DepthVSM");
+	fnPrintGlue(pMat->m_pColPass, "ColPass");
+}
+
+ON_DLL_LOAD("engine.dll", GlMatSysIFace, (CModule module))
+{
+	AUTOHOOK_DISPATCH()
+
+	GetMaterialAtCrossHair = module.Offset(0xB37D0).RCast<CMaterialGlue* (*)()>();
+}

--- a/primedev/materialsystem/cmaterialglue.h
+++ b/primedev/materialsystem/cmaterialglue.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "materialsystem/cshaderglue.h"
+
+class CMaterialGlue
+{
+public:
+	void* m_pVFTable;
+	char m_unk[8];
+
+	uint64_t m_GUID;
+
+	const char* m_pszName;
+	const char* m_pszSurfaceProp;
+	const char* m_pszSurfaceProp2;
+
+	CMaterialGlue* m_pDepthShadow;
+	CMaterialGlue* m_pDepthPrepass;
+	CMaterialGlue* m_pDepthVSM;
+	CMaterialGlue* m_pColPass;
+
+	char gap_50[64];
+
+	CShaderGlue* m_pShaderGlue;
+	void** m_pTextureHandles;
+	void** m_pStreamingTextures;
+	int16_t m_iStreamingTextureCount;
+	uint8_t m_iSamplersIndices[4];
+	int16_t m_iUnknown0;
+	char gap_B0[12];
+
+	int16_t aword_BC[2];
+	int32_t flags2;
+	int32_t flags3;
+	int16_t m_iWidth;
+	int16_t m_iHeight;
+	int16_t m_iUnknown1;
+	int16_t m_iUnknown2;
+
+	void** m_pUnkD3D11Ptr;
+	void* m_pD3D11Buffer;
+	void* qword_E0;
+	void* pointer_E8;
+
+	int32_t dword_F0;
+	char gap_F4[12];
+};

--- a/primedev/materialsystem/cshaderglue.h
+++ b/primedev/materialsystem/cshaderglue.h
@@ -1,0 +1,7 @@
+#pragma once
+
+class CShaderGlue
+{
+public:
+	void* vftable;
+};


### PR DESCRIPTION
### Description

Reimplements the `mat_crosshair_printmaterial` concommand. As my poor i3 thinkpad with fedora cant run Titanfall 2 nor visual studio i didnt test this branch. It did however work flawlessly on primedev. 

### Testing

Hop in a map and run the command.