### PR TITLE
Try loading XInput 1.4 before trying to load 9.1.0

### DIFF
--- a/primedev/windows/libsys.cpp
+++ b/primedev/windows/libsys.cpp
@@ -56,15 +56,30 @@ HMODULE WINAPI WLoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags
 	// replace xinput dll with one that has ASLR
 	if (lpLibFileName <= lpLibName && !strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL) + 1))
 	{
-		hModule = o_LoadLibraryExA("XInput9_1_0.dll", hFile, dwFlags);
+		const char* replacementDll = "XInput1_4.dll";
+		hModule = o_LoadLibraryExA(replacementDll, hFile, dwFlags);
 
 		if (!hModule)
 		{
-			MessageBoxA(0, "Could not find XInput9_1_0.dll", "Northstar", MB_ICONERROR);
+			replacementDll = "XInput9_1_0.dll";
+			spdlog::warn("Couldn't load XInput1_4.dll. Will try XInput9_1_0.dll. If on Windows 7 this is expected");
+			hModule = o_LoadLibraryExA(replacementDll, hFile, dwFlags);
+		}
+
+		if (!hModule)
+		{
+			spdlog::error("Couldn't load XInput9_1_0.dll");
+			MessageBoxA(
+				0,
+				"Could not load a replacement for XInput1_3.dll\nTried: XInput1_4.dll and XInput9_1_0.dll",
+				"Northstar",
+				MB_ICONERROR);
 			exit(EXIT_FAILURE);
 
 			return nullptr;
 		}
+
+		spdlog::info("Successfully loaded {} as a replacement for XInput1_3.dll", replacementDll);
 	}
 	else
 	{

--- a/primedev/windows/libsys.cpp
+++ b/primedev/windows/libsys.cpp
@@ -70,10 +70,7 @@ HMODULE WINAPI WLoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags
 		{
 			spdlog::error("Couldn't load XInput9_1_0.dll");
 			MessageBoxA(
-				0,
-				"Could not load a replacement for XInput1_3.dll\nTried: XInput1_4.dll and XInput9_1_0.dll",
-				"Northstar",
-				MB_ICONERROR);
+				0, "Could not load a replacement for XInput1_3.dll\nTried: XInput1_4.dll and XInput9_1_0.dll", "Northstar", MB_ICONERROR);
 			exit(EXIT_FAILURE);
 
 			return nullptr;

--- a/primedev/windows/libsys.cpp
+++ b/primedev/windows/libsys.cpp
@@ -56,14 +56,14 @@ HMODULE WINAPI WLoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags
 	// replace xinput dll with one that has ASLR
 	if (lpLibFileName <= lpLibName && !strncmp(lpLibName, XINPUT1_3_DLL, strlen(XINPUT1_3_DLL) + 1))
 	{
-		const char* replacementDll = "XInput1_4.dll";
-		hModule = o_LoadLibraryExA(replacementDll, hFile, dwFlags);
+		const char* pszReplacementDll = "XInput1_4.dll";
+		hModule = o_LoadLibraryExA(pszReplacementDll, hFile, dwFlags);
 
 		if (!hModule)
 		{
-			replacementDll = "XInput9_1_0.dll";
+			pszReplacementDll = "XInput9_1_0.dll";
 			spdlog::warn("Couldn't load XInput1_4.dll. Will try XInput9_1_0.dll. If on Windows 7 this is expected");
-			hModule = o_LoadLibraryExA(replacementDll, hFile, dwFlags);
+			hModule = o_LoadLibraryExA(pszReplacementDll, hFile, dwFlags);
 		}
 
 		if (!hModule)
@@ -76,7 +76,7 @@ HMODULE WINAPI WLoadLibraryExA(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags
 			return nullptr;
 		}
 
-		spdlog::info("Successfully loaded {} as a replacement for XInput1_3.dll", replacementDll);
+		spdlog::info("Successfully loaded {} as a replacement for XInput1_3.dll", pszReplacementDll);
 	}
 	else
 	{


### PR DESCRIPTION
XInput 9.1.0 has [some limitations to do with `XInputGetCapabilities`](https://learn.microsoft.com/en-us/windows/win32/xinput/xinput-versions) that may make the game behave differently when we use it as a replacement for XInput 1.3
XInput 1.4 doesn't have this issue, which means that if it works correctly we should always prioritise using this version over 9.1.0

XInputGetCapabilities is called by the game in at least two places: `inputsystem.dll + 0xCE4C` & `inputsystem.dll + 0xE2DF` (function pointer set at `inputsystem.dll + 0xCF0B`)

I have checked and 1.4 does have the `/DYNAMICBASE` option enabled so it supports ASLR just like 9.1.0.
Since `XInput1_4.dll` is only included stock on Windows 8 and newer, this PR makes it fall back to `XInput9_1_0.dll` if the former couldn't be loaded, as to maintain the current state of compatibility with Windows 7.

I have personally tested this, and saw no changes in behaviour compared to using XInput 9.1.0, however with this change the game should now handle non-gamepad controllers as it originally was intended to.

**Note: I tested that gamepad input worked fine using an Xbox One S controller. I do not own any non-gamepad controllers so it may be worth investigating what difference is actually made, if any, when something which does not list itself as a gamepad is used in game.**

XInput 1.4 loaded successfully:
![image](https://github.com/user-attachments/assets/43c93d44-c13f-46da-b32f-348b05cb1fd5)

XInput 1.4 failed to load but 9.1.0 loaded fine:
![image](https://github.com/user-attachments/assets/b59e2c0e-0e97-4fb7-895e-8ed749ad1091)

Neither XInput 1.4 or XInput 9.1.0 succeeded in loading:
![image-1](https://github.com/user-attachments/assets/d54ba845-031a-43f0-8e3f-a570517bfaf9)
