### PR TITLE
Formatting: Set short inline functions to be on one line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AccessModifierOffset: -4
 AlignTrailingComments: false
 AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortFunctionsOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: No


### PR DESCRIPTION
I'm losing my mind at clang-format making all my short getters and setters into 4 lines for no good reason