### PR TITLE
Fix manual hooks storing their name badly

### DIFF
--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -85,19 +85,9 @@ void __fileAutohook::DispatchForModule(const char* pModuleName)
 			hook->Dispatch();
 }
 
-ManualHook::ManualHook(const char* funcName, LPVOID func) : pHookFunc(func), ppOrigFunc(nullptr)
-{
-	const size_t iFuncNameStrlen = strlen(funcName) + 1;
-	pFuncName = new char[iFuncNameStrlen];
-	memcpy(pFuncName, funcName, iFuncNameStrlen);
-}
+ManualHook::ManualHook(const char* funcName, LPVOID func) : svFuncName(funcName), pHookFunc(func), ppOrigFunc(nullptr) {}
 
-ManualHook::ManualHook(const char* funcName, LPVOID* orig, LPVOID func) : pHookFunc(func), ppOrigFunc(orig)
-{
-	const size_t iFuncNameStrlen = strlen(funcName) + 1;
-	pFuncName = new char[iFuncNameStrlen];
-	memcpy(pFuncName, funcName, iFuncNameStrlen);
-}
+ManualHook::ManualHook(const char* funcName, LPVOID* orig, LPVOID func) : svFuncName(funcName), pHookFunc(func), ppOrigFunc(orig) {}
 
 bool ManualHook::Dispatch(LPVOID addr, LPVOID* orig)
 {
@@ -105,19 +95,19 @@ bool ManualHook::Dispatch(LPVOID addr, LPVOID* orig)
 		ppOrigFunc = orig;
 
 	if (!addr)
-		spdlog::error("Address for hook {} is invalid", pFuncName);
+		spdlog::error("Address for hook {} is invalid", svFuncName);
 	else if (MH_CreateHook(addr, pHookFunc, ppOrigFunc) == MH_OK)
 	{
 		if (MH_EnableHook(addr) == MH_OK)
 		{
-			spdlog::info("Enabling hook {}", pFuncName);
+			spdlog::info("Enabling hook {}", svFuncName);
 			return true;
 		}
 		else
-			spdlog::error("MH_EnableHook failed for function {}", pFuncName);
+			spdlog::error("MH_EnableHook failed for function {}", svFuncName);
 	}
 	else
-		spdlog::error("MH_CreateHook failed for function {}", pFuncName);
+		spdlog::error("MH_CreateHook failed for function {}", svFuncName);
 
 	return false;
 }

--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -87,14 +87,14 @@ void __fileAutohook::DispatchForModule(const char* pModuleName)
 
 ManualHook::ManualHook(const char* funcName, LPVOID func) : pHookFunc(func), ppOrigFunc(nullptr)
 {
-	const size_t iFuncNameStrlen = strlen(funcName);
+	const size_t iFuncNameStrlen = strlen(funcName) + 1;
 	pFuncName = new char[iFuncNameStrlen];
 	memcpy(pFuncName, funcName, iFuncNameStrlen);
 }
 
 ManualHook::ManualHook(const char* funcName, LPVOID* orig, LPVOID func) : pHookFunc(func), ppOrigFunc(orig)
 {
-	const size_t iFuncNameStrlen = strlen(funcName);
+	const size_t iFuncNameStrlen = strlen(funcName) + 1;
 	pFuncName = new char[iFuncNameStrlen];
 	memcpy(pFuncName, funcName, iFuncNameStrlen);
 }

--- a/primedev/core/hooks.h
+++ b/primedev/core/hooks.h
@@ -278,7 +278,7 @@ public:
 class ManualHook
 {
 public:
-	char* pFuncName;
+	std::string svFuncName;
 
 	LPVOID pHookFunc;
 	LPVOID* ppOrigFunc;


### PR DESCRIPTION
They weren't storing the null terminator since `strlen` doesn't include it. This meant that any `ManualHook`s were logging their name blindly and just reading random memory until they hit a null terminator.

I also moved over to just using `std::string` instead of doing manual allocations etc. since we are doing C++ here we have these tools why not use them.

### Testing:
1. Launch the game without the PR and observe `OnCommandSubmittedHook` doesn't log it's own name properly when enabled (there are also others)
2. Launch the game with this PR and observe that this is now fixed.