### PR TITLE
Format constructor initializers in a better way

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,5 +35,5 @@ IndentExternBlock: Indent
 PointerAlignment: Left
 SortIncludes: false
 NamespaceIndentation: All
-PackConstructorInitializers: NextLine
-BreakConstructorInitializersBeforeComma: true
+PackConstructorInitializers: Never
+BreakConstructorInitializers: BeforeComma


### PR DESCRIPTION
Old:
![image](https://github.com/user-attachments/assets/e0466a00-4fe6-4908-84e3-1738aeeb2eab)

New:
![image](https://github.com/user-attachments/assets/481aca13-c4f1-4a34-84a6-a6381c99ca5e)
