### PR TITLE
Remove uses of Autohook from `clientruihooks.cpp`

### DIFF
--- a/primedev/client/clientruihooks.cpp
+++ b/primedev/client/clientruihooks.cpp
@@ -4,20 +4,21 @@ AUTOHOOK_INIT()
 
 ConVar* Cvar_rui_drawEnable;
 
-// clang-format off
-AUTOHOOK(DrawRUIFunc, engine.dll + 0xFC500,
-bool, __fastcall, (void* a1, float* a2))
-// clang-format on
+static bool (*__fastcall o_pDrawRUIFunc)(void* a1, float* a2) = nullptr;
+static bool __fastcall h_DrawRUIFunc(void* a1, float* a2)
 {
 	if (!Cvar_rui_drawEnable->GetBool())
 		return 0;
 
-	return DrawRUIFunc(a1, a2);
+	return o_pDrawRUIFunc(a1, a2);
 }
 
 ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", RUI, ConVar, (CModule module))
 {
 	AUTOHOOK_DISPATCH()
+
+	o_pDrawRUIFunc = module.Offset(0xFC500).RCast<decltype(o_pDrawRUIFunc)>();
+	HookAttach(&(PVOID&)o_pDrawRUIFunc, (PVOID)h_DrawRUIFunc);
 
 	Cvar_rui_drawEnable = new ConVar("rui_drawEnable", "1", FCVAR_CLIENTDLL, "Controls whether RUI should be drawn");
 }

--- a/primedev/client/clientruihooks.cpp
+++ b/primedev/client/clientruihooks.cpp
@@ -1,7 +1,5 @@
 #include "core/convar/convar.h"
 
-AUTOHOOK_INIT()
-
 ConVar* Cvar_rui_drawEnable;
 
 static bool (*__fastcall o_pDrawRUIFunc)(void* a1, float* a2) = nullptr;
@@ -15,8 +13,6 @@ static bool __fastcall h_DrawRUIFunc(void* a1, float* a2)
 
 ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", RUI, ConVar, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
-
 	o_pDrawRUIFunc = module.Offset(0xFC500).RCast<decltype(o_pDrawRUIFunc)>();
 	HookAttach(&(PVOID&)o_pDrawRUIFunc, (PVOID)h_DrawRUIFunc);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Test that `rui_drawEnable` still functions properly (`0` stops drawing all RUI, `1` draw RUI as per usual)
