### PR TITLE
core: Remove unused `CModule` variable

### DIFF
--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -328,8 +328,6 @@ void CallLoadLibraryACallbacks(LPCSTR lpLibFileName, HMODULE moduleAddress)
 
 void CallLoadLibraryWCallbacks(LPCWSTR lpLibFileName, HMODULE moduleAddress)
 {
-	CModule cModule(moduleAddress);
-
 	while (true)
 	{
 		bool bDoneCalling = true;


### PR DESCRIPTION
Removes unused `CModule` var. CModule crashes when you give it a dll tha's been loaded as one of these: `LOAD_LIBRARY_AS_DATAFILE`, `LOAD_LIBRARY_AS_DATAFILE_EXCLUSIVE`, `LOAD_LIBRARY_AS_IMAGE_RESOURCE`. We have guards for this in libsys but not here.

Idk if this'll fix the issue discussed on Discord but well see