### PR TITLE
Remove uses of Autohook from `debugoverlay.cpp`

### DIFF
--- a/primedev/client/debugoverlay.cpp
+++ b/primedev/client/debugoverlay.cpp
@@ -201,7 +201,7 @@ static void __fastcall h_DrawOverlay(OverlayBase_t* pOverlay)
 	LeaveCriticalSection(s_OverlayMutex);
 }
 
-static void (__fastcall *o_pDrawAllOverlays)(bool bRender) = nullptr;
+static void(__fastcall* o_pDrawAllOverlays)(bool bRender) = nullptr;
 static void __fastcall h_DrawAllOverlays(bool bRender)
 {
 	EnterCriticalSection(s_OverlayMutex);

--- a/primedev/client/debugoverlay.cpp
+++ b/primedev/client/debugoverlay.cpp
@@ -5,8 +5,6 @@
 #include "core/math/vector.h"
 #include "server/ai_helper.h"
 
-AUTOHOOK_INIT()
-
 enum OverlayType_t
 {
 	OVERLAY_BOX = 0,
@@ -273,8 +271,6 @@ static void __fastcall h_DrawAllOverlays(bool bRender)
 
 ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", DebugOverlay, ConVar, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
-
 	o_pDrawOverlay = module.Offset(0xABCB0).RCast<decltype(o_pDrawOverlay)>();
 	HookAttach(&(PVOID&)o_pDrawOverlay, (PVOID)h_DrawOverlay);
 

--- a/primedev/client/debugoverlay.cpp
+++ b/primedev/client/debugoverlay.cpp
@@ -203,10 +203,8 @@ static void __fastcall h_DrawOverlay(OverlayBase_t* pOverlay)
 	LeaveCriticalSection(s_OverlayMutex);
 }
 
-// clang-format off
-AUTOHOOK(DrawAllOverlays, engine.dll + 0xAB780, 
-void, __fastcall, (bool bRender))
-// clang-format on
+static void (__fastcall *o_pDrawAllOverlays)(bool bRender) = nullptr;
+static void __fastcall h_DrawAllOverlays(bool bRender)
 {
 	EnterCriticalSection(s_OverlayMutex);
 
@@ -279,6 +277,9 @@ ON_DLL_LOAD_CLIENT_RELIESON("engine.dll", DebugOverlay, ConVar, (CModule module)
 
 	o_pDrawOverlay = module.Offset(0xABCB0).RCast<decltype(o_pDrawOverlay)>();
 	HookAttach(&(PVOID&)o_pDrawOverlay, (PVOID)h_DrawOverlay);
+
+	o_pDrawAllOverlays = module.Offset(0xAB780).RCast<decltype(o_pDrawAllOverlays)>();
+	HookAttach(&(PVOID&)o_pDrawAllOverlays, (PVOID)h_DrawAllOverlays);
 
 	OverlayBase_t__IsDead = module.Offset(0xACAC0).RCast<decltype(OverlayBase_t__IsDead)>();
 	OverlayBase_t__DestroyOverlay = module.Offset(0xAB680).RCast<decltype(OverlayBase_t__DestroyOverlay)>();


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that `enable_debug_overlays` still works
