### PR TITLE
Remove uses of Autohook from `latencyflex.cpp`

### DIFF
--- a/primedev/client/latencyflex.cpp
+++ b/primedev/client/latencyflex.cpp
@@ -6,15 +6,13 @@ ConVar* Cvar_r_latencyflex;
 
 void (*m_winelfx_WaitAndBeginFrame)();
 
-// clang-format off
-AUTOHOOK(OnRenderStart, client.dll + 0x1952C0, 
-void, __fastcall, ())
-// clang-format on
+void(__fastcall* o_pOnRenderStart)() = nullptr;
+void __fastcall h_OnRenderStart()
 {
 	if (Cvar_r_latencyflex->GetBool() && m_winelfx_WaitAndBeginFrame)
 		m_winelfx_WaitAndBeginFrame();
 
-	OnRenderStart();
+	o_pOnRenderStart();
 }
 
 ON_DLL_LOAD_CLIENT_RELIESON("client.dll", LatencyFlex, ConVar, (CModule module))
@@ -37,6 +35,8 @@ ON_DLL_LOAD_CLIENT_RELIESON("client.dll", LatencyFlex, ConVar, (CModule module))
 	}
 
 	AUTOHOOK_DISPATCH()
+	o_pOnRenderStart = module.Offset(0x1952C0).RCast<decltype(o_pOnRenderStart)>();
+	HookAttach(&(PVOID&)o_pOnRenderStart, (PVOID)h_OnRenderStart);
 
 	spdlog::info("LatencyFleX initialized.");
 	Cvar_r_latencyflex = new ConVar("r_latencyflex", "1", FCVAR_ARCHIVE, "Whether or not to use LatencyFleX input latency reduction.");

--- a/primedev/client/latencyflex.cpp
+++ b/primedev/client/latencyflex.cpp
@@ -1,7 +1,5 @@
 #include "core/convar/convar.h"
 
-AUTOHOOK_INIT()
-
 ConVar* Cvar_r_latencyflex;
 
 void (*m_winelfx_WaitAndBeginFrame)();
@@ -34,7 +32,6 @@ ON_DLL_LOAD_CLIENT_RELIESON("client.dll", LatencyFlex, ConVar, (CModule module))
 		return;
 	}
 
-	AUTOHOOK_DISPATCH()
 	o_pOnRenderStart = module.Offset(0x1952C0).RCast<decltype(o_pOnRenderStart)>();
 	HookAttach(&(PVOID&)o_pOnRenderStart, (PVOID)h_OnRenderStart);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that the convar `r_latencyflex` works as usual
