### PR TITLE
Remove uses of Autohook from `modlocalisation.cpp`

### DIFF
--- a/primedev/client/modlocalisation.cpp
+++ b/primedev/client/modlocalisation.cpp
@@ -1,7 +1,5 @@
 #include "mods/modmanager.h"
 
-AUTOHOOK_INIT()
-
 void* g_pVguiLocalize;
 
 static bool(__fastcall* o_pCLocalise__AddFile)(
@@ -52,7 +50,6 @@ ON_DLL_LOAD_CLIENT("engine.dll", VGuiInit, (CModule module))
 
 ON_DLL_LOAD_CLIENT("localize.dll", Localize, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
 	o_pCLocalise__AddFile = module.Offset(0x6D80).RCast<decltype(o_pCLocalise__AddFile)>();
 	HookAttach(&(PVOID&)o_pCLocalise__AddFile, (PVOID)h_CLocalise__AddFile);
 

--- a/primedev/client/modlocalisation.cpp
+++ b/primedev/client/modlocalisation.cpp
@@ -18,10 +18,8 @@ static bool __fastcall h_CLocalise__AddFile(void* pVguiLocalize, const char* pat
 	return true;
 }
 
-// clang-format off
-AUTOHOOK(CLocalize__ReloadLocalizationFiles, localize.dll + 0xB830,
-void, __fastcall, (void* pVguiLocalize))
-// clang-format on
+static void(__fastcall* o_pCLocalize__ReloadLocalizationFiles)(void* pVguiLocalize) = nullptr;
+static void __fastcall h_CLocalize__ReloadLocalizationFiles(void* pVguiLocalize)
 {
 	// load all mod localization manually, so we keep track of all files, not just previously loaded ones
 	for (Mod mod : g_pModManager->m_LoadedMods)
@@ -30,7 +28,7 @@ void, __fastcall, (void* pVguiLocalize))
 				o_pCLocalise__AddFile(g_pVguiLocalize, localisationFile.c_str(), nullptr, false);
 
 	spdlog::info("reloading localization...");
-	CLocalize__ReloadLocalizationFiles(pVguiLocalize);
+	o_pCLocalize__ReloadLocalizationFiles(pVguiLocalize);
 }
 
 // clang-format off
@@ -53,4 +51,7 @@ ON_DLL_LOAD_CLIENT("localize.dll", Localize, (CModule module))
 	AUTOHOOK_DISPATCH()
 	o_pCLocalise__AddFile = module.Offset(0x6D80).RCast<decltype(o_pCLocalise__AddFile)>();
 	HookAttach(&(PVOID&)o_pCLocalise__AddFile, (PVOID)h_CLocalise__AddFile);
+
+	o_pCLocalize__ReloadLocalizationFiles = module.Offset(0xB830).RCast<decltype(o_pCLocalize__ReloadLocalizationFiles)>();
+	HookAttach(&(PVOID&)o_pCLocalize__ReloadLocalizationFiles, (PVOID)h_CLocalize__ReloadLocalizationFiles);
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that loading localisation files from mods still works as expected.