### PR TITLE
Remove uses of Autohook from `rejectconnectionfixes.cpp`

### DIFF
--- a/primedev/client/rejectconnectionfixes.cpp
+++ b/primedev/client/rejectconnectionfixes.cpp
@@ -1,7 +1,5 @@
 #include "engine/r2engine.h"
 
-AUTOHOOK_INIT()
-
 // this is called from  when our connection is rejected, this is the only case we're hooking this for
 static void (*o_pCOM_ExplainDisconnection)(bool a1, const char* fmt, ...) = nullptr;
 static void h_COM_ExplainDisconnection(bool a1, const char* fmt, ...)
@@ -28,7 +26,6 @@ static void h_COM_ExplainDisconnection(bool a1, const char* fmt, ...)
 
 ON_DLL_LOAD_CLIENT("engine.dll", RejectConnectionFixes, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
 	o_pCOM_ExplainDisconnection = module.Offset(0x1342F0).RCast<decltype(o_pCOM_ExplainDisconnection)>();
 	HookAttach(&(PVOID&)o_pCOM_ExplainDisconnection, (PVOID)h_COM_ExplainDisconnection);
 }

--- a/primedev/client/rejectconnectionfixes.cpp
+++ b/primedev/client/rejectconnectionfixes.cpp
@@ -3,10 +3,8 @@
 AUTOHOOK_INIT()
 
 // this is called from  when our connection is rejected, this is the only case we're hooking this for
-// clang-format off
-AUTOHOOK(COM_ExplainDisconnection, engine.dll + 0x1342F0,
-void,, (bool a1, const char* fmt, ...))
-// clang-format on
+static void (*o_pCOM_ExplainDisconnection)(bool a1, const char* fmt, ...) = nullptr;
+static void h_COM_ExplainDisconnection(bool a1, const char* fmt, ...)
 {
 	va_list va;
 	va_start(va, fmt);
@@ -25,10 +23,12 @@ void,, (bool a1, const char* fmt, ...))
 		Cbuf_AddText(Cbuf_GetCurrentPlayer(), "disconnect", cmd_source_t::kCommandSrcCode);
 	}
 
-	return COM_ExplainDisconnection(a1, "%s", buf);
+	return o_pCOM_ExplainDisconnection(a1, "%s", buf);
 }
 
 ON_DLL_LOAD_CLIENT("engine.dll", RejectConnectionFixes, (CModule module))
 {
 	AUTOHOOK_DISPATCH()
+	o_pCOM_ExplainDisconnection = module.Offset(0x1342F0).RCast<decltype(o_pCOM_ExplainDisconnection)>();
+	HookAttach(&(PVOID&)o_pCOM_ExplainDisconnection, (PVOID)h_COM_ExplainDisconnection);
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Honestly, this is a difficult one to test functionality for... I guess the hook being created will have to do?
