### PR TITLE
Remove uses of Autohook from `filesystem.cpp`

### DIFF
--- a/primedev/core/filesystem/filesystem.cpp
+++ b/primedev/core/filesystem/filesystem.cpp
@@ -42,7 +42,8 @@ std::string ReadVPKOriginalFile(const char* path)
 	return ret;
 }
 
-static void(__fastcall* o_pAddSearchPath)(IFileSystem* fileSystem, const char* pPath, const char* pathID, SearchPathAdd_t addType) = nullptr;
+static void(__fastcall* o_pAddSearchPath)(IFileSystem* fileSystem, const char* pPath, const char* pathID, SearchPathAdd_t addType) =
+	nullptr;
 static void __fastcall h_AddSearchPath(IFileSystem* fileSystem, const char* pPath, const char* pathID, SearchPathAdd_t addType)
 {
 	o_pAddSearchPath(fileSystem, pPath, pathID, addType);
@@ -93,8 +94,8 @@ bool TryReplaceFile(const char* pPath, bool shouldCompile)
 }
 
 // force modded files to be read from mods, not cache
-static bool(__fastcall* o_pReadFromCache)(IFileSystem * filesystem, char* pPath, void* result) = nullptr;
-static bool __fastcall h_ReadFromCache(IFileSystem * filesystem, char* pPath, void* result)
+static bool(__fastcall* o_pReadFromCache)(IFileSystem* filesystem, char* pPath, void* result) = nullptr;
+static bool __fastcall h_ReadFromCache(IFileSystem* filesystem, char* pPath, void* result)
 {
 	if (TryReplaceFile(pPath, true))
 		return false;
@@ -115,8 +116,11 @@ static FileHandle_t __fastcall h_ReadFileFromVPK(VPKData* vpkInfo, uint64_t* b, 
 	return o_pReadFileFromVPK(vpkInfo, b, filename);
 }
 
-static FileHandle_t(__fastcall* o_pCBaseFileSystem__OpenEx)(IFileSystem* filesystem, const char* pPath, const char* pOptions, uint32_t flags, const char* pPathID, char **ppszResolvedFilename) = nullptr;
-static FileHandle_t __fastcall h_CBaseFileSystem__OpenEx(IFileSystem* filesystem, const char* pPath, const char* pOptions, uint32_t flags, const char* pPathID, char **ppszResolvedFilename)
+static FileHandle_t(__fastcall* o_pCBaseFileSystem__OpenEx)(
+	IFileSystem* filesystem, const char* pPath, const char* pOptions, uint32_t flags, const char* pPathID, char** ppszResolvedFilename) =
+	nullptr;
+static FileHandle_t __fastcall h_CBaseFileSystem__OpenEx(
+	IFileSystem* filesystem, const char* pPath, const char* pOptions, uint32_t flags, const char* pPathID, char** ppszResolvedFilename)
 {
 	TryReplaceFile(pPath, true);
 	return o_pCBaseFileSystem__OpenEx(filesystem, pPath, pOptions, flags, pPathID, ppszResolvedFilename);

--- a/primedev/core/filesystem/filesystem.cpp
+++ b/primedev/core/filesystem/filesystem.cpp
@@ -5,8 +5,6 @@
 #include <iostream>
 #include <sstream>
 
-AUTOHOOK_INIT()
-
 bool bReadingOriginalFile = false;
 std::string sCurrentModPath;
 
@@ -159,7 +157,6 @@ static VPKData* h_MountVPK(IFileSystem* fileSystem, const char* pVpkPath)
 
 ON_DLL_LOAD("filesystem_stdio.dll", Filesystem, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
 	o_pReadFileFromVPK = module.Offset(0x5CBA0).RCast<decltype(o_pReadFileFromVPK)>();
 	HookAttach(&(PVOID&)o_pReadFileFromVPK, (PVOID)h_ReadFileFromVPK);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that the loading mod files (scripts etc.) works as normal
