### PR TITLE
Remove uses of Autohook from `hooks.cpp`

### DIFF
--- a/primedev/core/hooks.cpp
+++ b/primedev/core/hooks.cpp
@@ -12,8 +12,6 @@
 
 namespace fs = std::filesystem;
 
-AUTOHOOK_INIT()
-
 // called from the ON_DLL_LOAD macros
 __dllLoadCallback::__dllLoadCallback(
 	eDllLoadCallbackSide side, const std::string dllName, DllLoadCallbackFuncType callback, std::string uniqueStr, std::string reliesOn)
@@ -395,8 +393,7 @@ void HookSys_Init()
 	{
 		spdlog::error("MH_Initialize (minhook initialization) failed");
 	}
-	// todo: remove remaining instances of autohook in this file
-	AUTOHOOK_DISPATCH()
+
 	o_pGetCommandLineA = GetCommandLineA;
 	HookAttach(&(PVOID&)o_pGetCommandLineA, (PVOID)h_GetCommandLineA);
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that arguments from `ns_startup_args.txt` are still loaded
