### PR TITLE
Remove uses of Autohook from `sourceinterface.cpp`

### DIFF
--- a/primedev/core/sourceinterface.cpp
+++ b/primedev/core/sourceinterface.cpp
@@ -1,8 +1,6 @@
 #include "sourceinterface.h"
 #include "logging/sourceconsole.h"
 
-AUTOHOOK_INIT()
-
 // really wanted to do a modular callback system here but honestly couldn't be bothered so hardcoding stuff for now: todo later
 
 static void*(__fastcall* o_pClientCreateInterface)(const char* pName, const int* pReturnCode) = nullptr;
@@ -38,19 +36,16 @@ static void* __fastcall h_EngineCreateInterface(const char* pName, const int* pR
 // clang-format off
 ON_DLL_LOAD("client.dll", ClientInterface, (CModule module))
 {
-	AUTOHOOK_DISPATCH_MODULE(client.dll)
 	o_pClientCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pClientCreateInterface)>();
 	HookAttach(&(PVOID&)o_pClientCreateInterface, (PVOID)h_ClientCreateInterface);
 }
 ON_DLL_LOAD("server.dll", ServerInterface, (CModule module))
 {
-	AUTOHOOK_DISPATCH_MODULE(server.dll)
 	o_pServerCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pServerCreateInterface)>();
 	HookAttach(&(PVOID&)o_pServerCreateInterface, (PVOID)h_ServerCreateInterface);
 }
 ON_DLL_LOAD("engine.dll", EngineInterface, (CModule module))
 {
-	AUTOHOOK_DISPATCH_MODULE(engine.dll)
 	o_pEngineCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pEngineCreateInterface)>();
 	HookAttach(&(PVOID&)o_pEngineCreateInterface, (PVOID)h_EngineCreateInterface);
 }

--- a/primedev/core/sourceinterface.cpp
+++ b/primedev/core/sourceinterface.cpp
@@ -17,12 +17,10 @@ static void* __fastcall h_ClientCreateInterface(const char* pName, const int* pR
 	return ret;
 }
 
-// clang-format off
-AUTOHOOK_PROCADDRESS(ServerCreateInterface, server.dll, CreateInterface, 
-void*, __fastcall, (const char* pName, const int* pReturnCode))
-// clang-format on
+static void*(__fastcall* o_pServerCreateInterface)(const char* pName, const int* pReturnCode) = nullptr;
+static void* __fastcall h_ServerCreateInterface(const char* pName, const int* pReturnCode)
 {
-	void* ret = ServerCreateInterface(pName, pReturnCode);
+	void* ret = o_pServerCreateInterface(pName, pReturnCode);
 	spdlog::info("CreateInterface SERVER {}", pName);
 
 	return ret;
@@ -46,6 +44,11 @@ ON_DLL_LOAD("client.dll", ClientInterface, (CModule module))
 	o_pClientCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pClientCreateInterface)>();
 	HookAttach(&(PVOID&)o_pClientCreateInterface, (PVOID)h_ClientCreateInterface);
 }
-ON_DLL_LOAD("server.dll", ServerInterface, (CModule module)) {AUTOHOOK_DISPATCH_MODULE(server.dll)}
+ON_DLL_LOAD("server.dll", ServerInterface, (CModule module))
+{
+	AUTOHOOK_DISPATCH_MODULE(server.dll)
+	o_pServerCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pServerCreateInterface)>();
+	HookAttach(&(PVOID&)o_pServerCreateInterface, (PVOID)h_ServerCreateInterface);
+}
 ON_DLL_LOAD("engine.dll", EngineInterface, (CModule module)) {AUTOHOOK_DISPATCH_MODULE(engine.dll)}
 // clang-format on

--- a/primedev/core/sourceinterface.cpp
+++ b/primedev/core/sourceinterface.cpp
@@ -5,12 +5,10 @@ AUTOHOOK_INIT()
 
 // really wanted to do a modular callback system here but honestly couldn't be bothered so hardcoding stuff for now: todo later
 
-// clang-format off
-AUTOHOOK_PROCADDRESS(ClientCreateInterface, client.dll, CreateInterface, 
-void*, __fastcall, (const char* pName, const int* pReturnCode))
-// clang-format on
+static void*(__fastcall* o_pClientCreateInterface)(const char* pName, const int* pReturnCode) = nullptr;
+static void* __fastcall h_ClientCreateInterface(const char* pName, const int* pReturnCode)
 {
-	void* ret = ClientCreateInterface(pName, pReturnCode);
+	void* ret = o_pClientCreateInterface(pName, pReturnCode);
 	spdlog::info("CreateInterface CLIENT {}", pName);
 
 	if (!strcmp(pName, "GameClientExports001"))
@@ -42,7 +40,12 @@ void*, __fastcall, (const char* pName, const int* pReturnCode))
 }
 
 // clang-format off
-ON_DLL_LOAD("client.dll", ClientInterface, (CModule module)) {AUTOHOOK_DISPATCH_MODULE(client.dll)}
+ON_DLL_LOAD("client.dll", ClientInterface, (CModule module))
+{
+	AUTOHOOK_DISPATCH_MODULE(client.dll)
+	o_pClientCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pClientCreateInterface)>();
+	HookAttach(&(PVOID&)o_pClientCreateInterface, (PVOID)h_ClientCreateInterface);
+}
 ON_DLL_LOAD("server.dll", ServerInterface, (CModule module)) {AUTOHOOK_DISPATCH_MODULE(server.dll)}
 ON_DLL_LOAD("engine.dll", EngineInterface, (CModule module)) {AUTOHOOK_DISPATCH_MODULE(engine.dll)}
 // clang-format on

--- a/primedev/core/sourceinterface.cpp
+++ b/primedev/core/sourceinterface.cpp
@@ -33,20 +33,20 @@ static void* __fastcall h_EngineCreateInterface(const char* pName, const int* pR
 	return ret;
 }
 
-// clang-format off
 ON_DLL_LOAD("client.dll", ClientInterface, (CModule module))
 {
 	o_pClientCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pClientCreateInterface)>();
 	HookAttach(&(PVOID&)o_pClientCreateInterface, (PVOID)h_ClientCreateInterface);
 }
+
 ON_DLL_LOAD("server.dll", ServerInterface, (CModule module))
 {
 	o_pServerCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pServerCreateInterface)>();
 	HookAttach(&(PVOID&)o_pServerCreateInterface, (PVOID)h_ServerCreateInterface);
 }
+
 ON_DLL_LOAD("engine.dll", EngineInterface, (CModule module))
 {
 	o_pEngineCreateInterface = module.GetExportedFunction("CreateInterface").RCast<decltype(o_pEngineCreateInterface)>();
 	HookAttach(&(PVOID&)o_pEngineCreateInterface, (PVOID)h_EngineCreateInterface);
 }
-// clang-format on


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that `CreateInterface <SERVER/CLIENT/ENGINE>` still get logged
- Make sure that the in-game console still exists (since `InitialiseConsoleOnInterfaceCreation` gets called from `ClientCreateInterface`)
