### PR TITLE
Remove uses of Autohook from `dedicated.cpp`

### DIFF
--- a/primedev/dedicated/dedicated.cpp
+++ b/primedev/dedicated/dedicated.cpp
@@ -8,8 +8,6 @@
 #include "masterserver/masterserver.h"
 #include "util/printcommands.h"
 
-AUTOHOOK_INIT()
-
 bool IsDedicatedServer()
 {
 	static bool result = strstr(GetCommandLineA(), "-dedicated");
@@ -123,8 +121,6 @@ static bool h_IsGameActiveWindow()
 ON_DLL_LOAD_DEDI_RELIESON("engine.dll", DedicatedServer, ServerPresence, (CModule module))
 {
 	spdlog::info("InitialiseDedicated");
-
-	AUTOHOOK_DISPATCH_MODULE(engine.dll)
 
 	o_pIsGameActiveWindow = module.Offset(0x1CDC80).RCast<decltype(o_pIsGameActiveWindow)>();
 	HookAttach(&(PVOID&)o_pIsGameActiveWindow, (PVOID)h_IsGameActiveWindow);
@@ -288,8 +284,6 @@ static void __fastcall h_PrintSquirrelError(void* sqvm)
 
 ON_DLL_LOAD_DEDI("server.dll", DedicatedServerGameDLL, (CModule module))
 {
-	AUTOHOOK_DISPATCH_MODULE(server.dll)
-
 	o_pPrintSquirrelError = module.Offset(0x794D0).RCast<decltype(o_pPrintSquirrelError)>();
 	HookAttach(&(PVOID&)o_pPrintSquirrelError, (PVOID)h_PrintSquirrelError);
 

--- a/primedev/dedicated/dedicated.cpp
+++ b/primedev/dedicated/dedicated.cpp
@@ -114,10 +114,8 @@ DWORD WINAPI ConsoleInputThread(PVOID pThreadParameter)
 	return 0;
 }
 
-// clang-format off
-AUTOHOOK(IsGameActiveWindow, engine.dll + 0x1CDC80,
-bool,, ())
-// clang-format on
+static bool (*o_pIsGameActiveWindow)() = nullptr;
+static bool h_IsGameActiveWindow()
 {
 	return true;
 }
@@ -127,6 +125,9 @@ ON_DLL_LOAD_DEDI_RELIESON("engine.dll", DedicatedServer, ServerPresence, (CModul
 	spdlog::info("InitialiseDedicated");
 
 	AUTOHOOK_DISPATCH_MODULE(engine.dll)
+
+	o_pIsGameActiveWindow = module.Offset(0x1CDC80).RCast<decltype(o_pIsGameActiveWindow)>();
+	HookAttach(&(PVOID&)o_pIsGameActiveWindow, (PVOID)h_IsGameActiveWindow);
 
 	// Host_Init
 	// prevent a particle init that relies on client dll


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that dedicated servers still gracefully close on script error instead of hard crashing.
