### PR TITLE
Remove uses of Autohook from `gl_matsysiface.cpp`

### DIFF
--- a/primedev/engine/gl_matsysiface.cpp
+++ b/primedev/engine/gl_matsysiface.cpp
@@ -4,7 +4,8 @@ CMaterialGlue* (*GetMaterialAtCrossHair)();
 
 AUTOHOOK_INIT()
 
-AUTOHOOK(CC_mat_crosshair_printmaterial_f, engine.dll + 0xB3C40, void, __fastcall, (const CCommand& args))
+static void(__fastcall* o_pCC_mat_crosshair_printmaterial_f)(const CCommand& args) = nullptr;
+static void __fastcall h_CC_mat_crosshair_printmaterial_f(const CCommand& args)
 {
 	CMaterialGlue* pMat = GetMaterialAtCrossHair();
 
@@ -45,6 +46,8 @@ AUTOHOOK(CC_mat_crosshair_printmaterial_f, engine.dll + 0xB3C40, void, __fastcal
 ON_DLL_LOAD("engine.dll", GlMatSysIFace, (CModule module))
 {
 	AUTOHOOK_DISPATCH()
+	o_pCC_mat_crosshair_printmaterial_f = module.Offset(0xB3C40).RCast<decltype(o_pCC_mat_crosshair_printmaterial_f)>();
+	HookAttach(&(PVOID&)o_pCC_mat_crosshair_printmaterial_f, (PVOID)h_CC_mat_crosshair_printmaterial_f);
 
 	GetMaterialAtCrossHair = module.Offset(0xB37D0).RCast<CMaterialGlue* (*)()>();
 }

--- a/primedev/engine/gl_matsysiface.cpp
+++ b/primedev/engine/gl_matsysiface.cpp
@@ -2,8 +2,6 @@
 
 CMaterialGlue* (*GetMaterialAtCrossHair)();
 
-AUTOHOOK_INIT()
-
 static void(__fastcall* o_pCC_mat_crosshair_printmaterial_f)(const CCommand& args) = nullptr;
 static void __fastcall h_CC_mat_crosshair_printmaterial_f(const CCommand& args)
 {
@@ -45,7 +43,6 @@ static void __fastcall h_CC_mat_crosshair_printmaterial_f(const CCommand& args)
 
 ON_DLL_LOAD("engine.dll", GlMatSysIFace, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
 	o_pCC_mat_crosshair_printmaterial_f = module.Offset(0xB3C40).RCast<decltype(o_pCC_mat_crosshair_printmaterial_f)>();
 	HookAttach(&(PVOID&)o_pCC_mat_crosshair_printmaterial_f, (PVOID)h_CC_mat_crosshair_printmaterial_f);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that `mat_crosshair_printmaterial` still works as expected. (#763)
