### PR TITLE
Remove uses of Autohook from `host.cpp`

### DIFF
--- a/primedev/engine/host.cpp
+++ b/primedev/engine/host.cpp
@@ -6,8 +6,6 @@
 #include "r2engine.h"
 #include "core/tier0.h"
 
-AUTOHOOK_INIT()
-
 static void(__fastcall* o_pHost_Init)(bool bDedicated) = nullptr;
 static void __fastcall h_Host_Init(bool bDedicated)
 {
@@ -27,8 +25,6 @@ static void __fastcall h_Host_Init(bool bDedicated)
 
 ON_DLL_LOAD("engine.dll", Host_Init, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
-
 	o_pHost_Init = module.Offset(0x155EA0).RCast<decltype(o_pHost_Init)>();
 	HookAttach(&(PVOID&)o_pHost_Init, (PVOID)h_Host_Init);
 }

--- a/primedev/engine/host.cpp
+++ b/primedev/engine/host.cpp
@@ -8,13 +8,11 @@
 
 AUTOHOOK_INIT()
 
-// clang-format off
-AUTOHOOK(Host_Init, engine.dll + 0x155EA0,
-void, __fastcall, (bool bDedicated))
-// clang-format on
+static void(__fastcall* o_pHost_Init)(bool bDedicated) = nullptr;
+static void __fastcall h_Host_Init(bool bDedicated)
 {
 	spdlog::info("Host_Init()");
-	Host_Init(bDedicated);
+	o_pHost_Init(bDedicated);
 	FixupCvarFlags();
 	// need to initialise these after host_init since they do stuff to preexisting concommands/convars without being client/server specific
 	InitialiseCommandPrint();
@@ -30,4 +28,7 @@ void, __fastcall, (bool bDedicated))
 ON_DLL_LOAD("engine.dll", Host_Init, (CModule module))
 {
 	AUTOHOOK_DISPATCH()
+
+	o_pHost_Init = module.Offset(0x155EA0).RCast<decltype(o_pHost_Init)>();
+	HookAttach(&(PVOID&)o_pHost_Init, (PVOID)h_Host_Init);
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly (this one logs `Host_Init()` in the console when it runs so check for that when going into the lobby)
- Make sure that `autoexec_ns_server` and `autoexec_ns_client` are being executed still etc.

