### PR TITLE
core: Remove use of `SourceInterface` for `CCvar`

### DIFF
--- a/primedev/core/convar/convar.cpp
+++ b/primedev/core/convar/convar.cpp
@@ -1,7 +1,7 @@
 #include "bits.h"
 #include "cvar.h"
 #include "convar.h"
-#include "core/sourceinterface.h"
+#include "core/tier1.h"
 
 #include <float.h>
 
@@ -35,8 +35,7 @@ ON_DLL_LOAD("engine.dll", ConVar, (CModule module))
 	g_pConVar_Vtable = module.Offset(0x67FD28);
 	g_pIConVar_Vtable = module.Offset(0x67FDC8);
 
-	g_pCVarInterface = new SourceInterface<CCvar>("vstdlib.dll", "VEngineCvar007");
-	g_pCVar = *g_pCVarInterface;
+	g_pCVar = Sys_GetFactoryPtr("vstdlib.dll", "VEngineCvar007");
 }
 
 //-----------------------------------------------------------------------------

--- a/primedev/core/convar/convar.cpp
+++ b/primedev/core/convar/convar.cpp
@@ -35,7 +35,7 @@ ON_DLL_LOAD("engine.dll", ConVar, (CModule module))
 	g_pConVar_Vtable = module.Offset(0x67FD28);
 	g_pIConVar_Vtable = module.Offset(0x67FDC8);
 
-	g_pCVar = Sys_GetFactoryPtr("vstdlib.dll", "VEngineCvar007").RCast<CCVar*>();
+	g_pCVar = Sys_GetFactoryPtr("vstdlib.dll", "VEngineCvar007").RCast<CCvar*>();
 }
 
 //-----------------------------------------------------------------------------

--- a/primedev/core/convar/convar.cpp
+++ b/primedev/core/convar/convar.cpp
@@ -35,7 +35,7 @@ ON_DLL_LOAD("engine.dll", ConVar, (CModule module))
 	g_pConVar_Vtable = module.Offset(0x67FD28);
 	g_pIConVar_Vtable = module.Offset(0x67FDC8);
 
-	g_pCVar = Sys_GetFactoryPtr("vstdlib.dll", "VEngineCvar007");
+	g_pCVar = Sys_GetFactoryPtr("vstdlib.dll", "VEngineCvar007").RCast<CCVar*>();
 }
 
 //-----------------------------------------------------------------------------

--- a/primedev/core/convar/cvar.cpp
+++ b/primedev/core/convar/cvar.cpp
@@ -22,5 +22,4 @@ std::unordered_map<std::string, ConCommandBase*> CCvar::DumpToMap()
 	return allConVars;
 }
 
-SourceInterface<CCvar>* g_pCVarInterface;
 CCvar* g_pCVar;

--- a/primedev/core/convar/cvar.h
+++ b/primedev/core/convar/cvar.h
@@ -34,5 +34,4 @@ public:
 	std::unordered_map<std::string, ConCommandBase*> DumpToMap();
 };
 
-extern SourceInterface<CCvar>* g_pCVarInterface;
 extern CCvar* g_pCVar;


### PR DESCRIPTION
### Code review:

Look at code

### Testing:

Run commands like `help` or `find` that use `g_pCVar`.