### PR TITLE
Remove uses of Autohook from `hoststate.cpp`

### DIFF
--- a/primedev/engine/hoststate.cpp
+++ b/primedev/engine/hoststate.cpp
@@ -145,12 +145,10 @@ static void __fastcall h_CHostState__State_GameShutdown(CHostState* self)
 	}
 }
 
-// clang-format off
-AUTOHOOK(CHostState__FrameUpdate, engine.dll + 0x16DB00,
-void, __fastcall, (CHostState* self, double flCurrentTime, float flFrameTime))
-// clang-format on
+static void(__fastcall* o_pCHostState__FrameUpdate)(CHostState* self, double flCurrentTime, float flFrameTime) = nullptr;
+static void __fastcall h_CHostState__FrameUpdate(CHostState* self, double flCurrentTime, float flFrameTime)
 {
-	CHostState__FrameUpdate(self, flCurrentTime, flFrameTime);
+	o_pCHostState__FrameUpdate(self, flCurrentTime, flFrameTime);
 
 	if (*g_pServerState == server_state_t::ss_active)
 	{
@@ -188,6 +186,9 @@ ON_DLL_LOAD_RELIESON("engine.dll", HostState, ConVar, (CModule module))
 
 	o_pCHostState__State_GameShutdown = module.Offset(0x16E640).RCast<decltype(o_pCHostState__State_GameShutdown)>();
 	HookAttach(&(PVOID&)o_pCHostState__State_GameShutdown, (PVOID)h_CHostState__State_GameShutdown);
+
+	o_pCHostState__FrameUpdate = module.Offset(0x16DB00).RCast<decltype(o_pCHostState__FrameUpdate)>();
+	HookAttach(&(PVOID&)o_pCHostState__FrameUpdate, (PVOID)h_CHostState__FrameUpdate);
 
 	g_pHostState = module.Offset(0x7CF180).RCast<CHostState*>();
 }

--- a/primedev/engine/hoststate.cpp
+++ b/primedev/engine/hoststate.cpp
@@ -15,8 +15,8 @@ CHostState* g_pHostState;
 
 std::string sLastMode;
 
-VAR_AT(engine.dll + 0x13FA6070, ConVar*, Cvar_hostport);
-FUNCTION_AT(engine.dll + 0x1232C0, void, __fastcall, _Cmd_Exec_f, (const CCommand& arg, bool bOnlyIfExists, bool bUseWhitelists));
+static ConVar* Cvar_hostport = nullptr;
+static void(__fastcall* _Cmd_Exec_f)(const CCommand& arg, bool bOnlyIfExists, bool bUseWhitelists) = nullptr;
 
 void ServerStartingOrChangingMap()
 {
@@ -189,6 +189,9 @@ ON_DLL_LOAD_RELIESON("engine.dll", HostState, ConVar, (CModule module))
 
 	o_pCHostState__FrameUpdate = module.Offset(0x16DB00).RCast<decltype(o_pCHostState__FrameUpdate)>();
 	HookAttach(&(PVOID&)o_pCHostState__FrameUpdate, (PVOID)h_CHostState__FrameUpdate);
+
+	Cvar_hostport = module.Offset(0x13FA6070).RCast<decltype(Cvar_hostport)>();
+	_Cmd_Exec_f = module.Offset(0x1232C0).RCast<decltype(_Cmd_Exec_f)>();
 
 	g_pHostState = module.Offset(0x7CF180).RCast<CHostState*>();
 }

--- a/primedev/engine/hoststate.cpp
+++ b/primedev/engine/hoststate.cpp
@@ -119,16 +119,14 @@ static void __fastcall h_CHostState__State_ChangeLevelMP(CHostState* self)
 	g_pServerPresence->SetMap(g_pHostState->m_levelName);
 }
 
-// clang-format off
-AUTOHOOK(CHostState__State_GameShutdown, engine.dll + 0x16E640,
-void, __fastcall, (CHostState* self))
-// clang-format on
+static void(__fastcall* o_pCHostState__State_GameShutdown)(CHostState* self) = nullptr;
+static void __fastcall h_CHostState__State_GameShutdown(CHostState* self)
 {
 	spdlog::info("HostState: GameShutdown");
 
 	g_pServerPresence->DestroyPresence();
 
-	CHostState__State_GameShutdown(self);
+	o_pCHostState__State_GameShutdown(self);
 
 	// run gamemode cleanup cfg now instead of when we start next map
 	if (sLastMode.length())
@@ -187,6 +185,9 @@ ON_DLL_LOAD_RELIESON("engine.dll", HostState, ConVar, (CModule module))
 
 	o_pCHostState__State_ChangeLevelMP = module.Offset(0x16E520).RCast<decltype(o_pCHostState__State_ChangeLevelMP)>();
 	HookAttach(&(PVOID&)o_pCHostState__State_ChangeLevelMP, (PVOID)h_CHostState__State_ChangeLevelMP);
+
+	o_pCHostState__State_GameShutdown = module.Offset(0x16E640).RCast<decltype(o_pCHostState__State_GameShutdown)>();
+	HookAttach(&(PVOID&)o_pCHostState__State_GameShutdown, (PVOID)h_CHostState__State_GameShutdown);
 
 	g_pHostState = module.Offset(0x7CF180).RCast<CHostState*>();
 }

--- a/primedev/engine/hoststate.cpp
+++ b/primedev/engine/hoststate.cpp
@@ -105,17 +105,15 @@ static void __fastcall h_CHostState__State_LoadGame(CHostState* self)
 	g_pServerAuthentication->m_bNeedLocalAuthForNewgame = false;
 }
 
-// clang-format off
-AUTOHOOK(CHostState__State_ChangeLevelMP, engine.dll + 0x16E520,
-void, __fastcall, (CHostState* self))
-// clang-format on
+static void(__fastcall* o_pCHostState__State_ChangeLevelMP)(CHostState* self) = nullptr;
+static void __fastcall h_CHostState__State_ChangeLevelMP(CHostState* self)
 {
 	spdlog::info("HostState: ChangeLevelMP");
 
 	ServerStartingOrChangingMap();
 
 	double dStartTime = Plat_FloatTime();
-	CHostState__State_ChangeLevelMP(self);
+	o_pCHostState__State_ChangeLevelMP(self);
 	spdlog::info("loading took {}s", Plat_FloatTime() - dStartTime);
 
 	g_pServerPresence->SetMap(g_pHostState->m_levelName);
@@ -186,6 +184,9 @@ ON_DLL_LOAD_RELIESON("engine.dll", HostState, ConVar, (CModule module))
 
 	o_pCHostState__State_LoadGame = module.Offset(0x16E730).RCast<decltype(o_pCHostState__State_LoadGame)>();
 	HookAttach(&(PVOID&)o_pCHostState__State_LoadGame, (PVOID)h_CHostState__State_LoadGame);
+
+	o_pCHostState__State_ChangeLevelMP = module.Offset(0x16E520).RCast<decltype(o_pCHostState__State_ChangeLevelMP)>();
+	HookAttach(&(PVOID&)o_pCHostState__State_ChangeLevelMP, (PVOID)h_CHostState__State_ChangeLevelMP);
 
 	g_pHostState = module.Offset(0x7CF180).RCast<CHostState*>();
 }

--- a/primedev/engine/hoststate.cpp
+++ b/primedev/engine/hoststate.cpp
@@ -9,8 +9,6 @@
 #include "squirrel/squirrel.h"
 #include "plugins/pluginmanager.h"
 
-AUTOHOOK_INIT()
-
 CHostState* g_pHostState;
 
 std::string sLastMode;
@@ -174,7 +172,6 @@ static void __fastcall h_CHostState__FrameUpdate(CHostState* self, double flCurr
 
 ON_DLL_LOAD_RELIESON("engine.dll", HostState, ConVar, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
 	o_pCHostState__State_NewGame = module.Offset(0x16E7D0).RCast<decltype(o_pCHostState__State_NewGame)>();
 	HookAttach(&(PVOID&)o_pCHostState__State_NewGame, (PVOID)h_CHostState__State_NewGame);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly (these ones for the most part log something when they are triggered, so check for that)
- Make sure that server presence is tracking the correct port (honestly easiest to just stick some breakpoints in the code and make sure that it is reading the ConVar properly
