### PR TITLE
Update build instructions and CI for `build` subfolder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,7 @@ jobs:
       - name: Setup msvc
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure cmake
-        run: |
-          mkdir build/
-          cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="${{ env.BUILD_PROFILE }}"
+        run: cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="${{ env.BUILD_PROFILE }}"
       - name: Setup resource file version
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Setup msvc
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure cmake
-        run: cmake -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="${{ env.BUILD_PROFILE }}"
+        run: |
+          mkdir build/
+          cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="${{ env.BUILD_PROFILE }}"
       - name: Setup resource file version
         shell: bash
         run: |
@@ -33,7 +35,7 @@ jobs:
           FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
           sed -i "s/0,0,0,1/${FILEVERSION}/g" primedev/ns_version.h
       - name: Build
-        run: cmake --build .
+        run: cmake --build build/
       - name: Extract Short Commit Hash
         id: extract
         shell: bash
@@ -43,7 +45,7 @@ jobs:
         with:
           name: NorthstarLauncher-${{ matrix.config.name }}-${{ steps.extract.outputs.commit }}
           path: |
-            game/
+            build/game/
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,7 @@ jobs:
       - name: Setup msvc
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure cmake
-        run: |
-          mkdir build/
-          cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="Release"
+        run: cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="Release"
       - name: Setup resource file version
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Setup msvc
         uses: ilammy/msvc-dev-cmd@v1
       - name: Configure cmake
-        run: cmake -G "Ninja" -DCMAKE_BUILD_TYPE:STRING="Release"
+        run: |
+          mkdir build/
+          cmake -G "Ninja" -B build -DCMAKE_BUILD_TYPE:STRING="Release"
       - name: Setup resource file version
         shell: bash
         run: |
@@ -30,22 +32,22 @@ jobs:
           FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
           sed -i "s/0,0,0,1/${FILEVERSION}/g" primedev/ns_version.h
       - name: Build
-        run: cmake --build .
+        run: cmake --build build/
       - name: Upload launcher build as artifact
         uses: actions/upload-artifact@v3
         with:
           name: northstar-launcher
           path: |
-            game/*.exe
-            game/*.dll
-            game/bin/x64_retail/*.dll
+            build/game/*.exe
+            build/game/*.dll
+            build/game/bin/x64_retail/*.dll
       - name: Upload debug build artifact
         uses: actions/upload-artifact@v3
         with:
           name: launcher-debug-files
           path: |
-            game/*.pdb
-            game/bin/x64_retail/*.pdb
+            build/game/*.pdb
+            build/game/bin/x64_retail/*.pdb
 
   upload-launcher-to-release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ mono_crash.*
 
 # CMake output
 out/
-game/
+build/game/
 build/
 CMakeFiles/
 cmake_install.cmake

--- a/BUILD.md
+++ b/BUILD.md
@@ -37,9 +37,9 @@ Developers who can work a command line may be interested in using [Visual Studio
 
 - Follow the same steps as above for Visual Studio Build Tools, but instead of opening in Visual Studio, run the Command Prompt for VS 2022 and navigate to the NorthstarLauncher.
 
-- Run `cmake . -G "Ninja"` to generate build files.
+- Run `cmake . -G "Ninja" -B build` to generate build files.
 
-- Run `cmake --build .` to build the project.
+- Run `cmake --build build/` to build the project.
 
 ## Linux
 ### Steps
@@ -47,8 +47,8 @@ Developers who can work a command line may be interested in using [Visual Studio
 2. Use `cd` to navigate to the cloned repo's directory
 3. Then, run the following commands in order:
 * `docker build --rm -t northstar-build-fedora .`
-* `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
-* `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake --build .`
+* `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja" -B build`
+* `docker run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build northstar-build-fedora cmake --build build/`
 
 #### Podman
 
@@ -57,5 +57,5 @@ When using [`podman`](https://podman.io/) instead of Docker on an SELinux enable
 As such the corresponding commands are
 
 * `podman build --rm -t northstar-build-fedora .`
-* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja"`
-* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake --build .`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Windows -G "Ninja" -B build`
+* `podman run --rm -it -e CC=cl -e CXX=cl --mount type=bind,source="$(pwd)",destination=/build,z northstar-build-fedora cmake --build build/`


### PR DESCRIPTION
Set up instructions so that compiling from commandline puts the resulting binaries in `/build/game/` to match the folder structure usually generated by Visual Studio.

Supersedes #594 