### PR TITLE
Ensure whitespace indentation is consistent in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM registry.fedoraproject.org/fedora-toolbox:38
 RUN dnf update -y && \
     dnf install -y \
-    	git \
-    	wine \
-	wine-mono \
-	python3 \
-	msitools \
-	python3-simplejson \
-	python3-six \
-	cmake \
-	ninja-build \
-	make \
-	samba \
-	libunwind && \
+        git \
+        wine \
+        wine-mono \
+        python3 \
+        msitools \
+        python3-simplejson \
+        python3-six \
+        cmake \
+        ninja-build \
+        make \
+        samba \
+        libunwind && \
     dnf clean all && \
     mkdir /opt/msvc/ /build
 


### PR DESCRIPTION
Just ensures that indentation is consistent and not a mix of tabs and spaces. Styling change, does not affect functionality or anything.