### PR TITLE
Bump clang-format-lint-action to v0.18.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DoozyX/clang-format-lint-action@v0.16.2
+    - uses: DoozyX/clang-format-lint-action@v0.18.2
       with:
         source: 'primedev'
         exclude: 'primedev/include primedev/thirdparty primedev/wsockproxy'


### PR DESCRIPTION
Bump clang-format-lint-action to v0.18.2 which is the newest upstream version
Also fixes current formatting issues.

### Code review:

Not much really, this is just a version bump

### Testing:

If CI passes, this is good to merge. No actual code changes.