### PR TITLE
Add dependabot config to check for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Configures dependabot
+
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Adds a dependabot config to check for updates to the GitHub Actions we use and makes a PR with the version bump if a new version is found.

### Code review:

_None_

### Testing:

_None_