### PR TITLE
Remove uses of Autohook from `clientchathooks.cpp`

### DIFF
--- a/primedev/scripts/client/clientchathooks.cpp
+++ b/primedev/scripts/client/clientchathooks.cpp
@@ -6,8 +6,6 @@
 
 #include <rapidjson/document.h>
 
-AUTOHOOK_INIT()
-
 static void(__fastcall* o_pCHudChat__AddGameLine)(void* self, const char* message, int inboxId, bool isTeam, bool isDead) = nullptr;
 static void __fastcall h_CHudChat__AddGameLine(void* self, const char* message, int inboxId, bool isTeam, bool isDead)
 {
@@ -66,8 +64,6 @@ ADD_SQFUNC("void", NSChatWriteLine, "int context, string text", "", ScriptContex
 
 ON_DLL_LOAD_CLIENT("client.dll", ClientChatHooks, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
-
 	o_pCHudChat__AddGameLine = module.Offset(0x22E580).RCast<decltype(o_pCHudChat__AddGameLine)>();
 	HookAttach(&(PVOID&)o_pCHudChat__AddGameLine, (PVOID)h_CHudChat__AddGameLine);
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Make sure that `CHudChat_ProcessMessageStartThread` still gets called in the CLIENT squirrel VM (probably easiest to add a debug print there)
