### PR TITLE
remove useless log

### DIFF
--- a/primedev/plugins/plugins.cpp
+++ b/primedev/plugins/plugins.cpp
@@ -219,7 +219,6 @@ void Plugin::OnSqvmCreated(CSquirrelVM* sqvm) const
 
 void Plugin::OnSqvmDestroying(CSquirrelVM* sqvm) const
 {
-	NS::log::PLUGINSYS->info("destroying sqvm {}", sqvm->vmContext);
 	m_callbacks->OnSqvmDestroying(sqvm);
 }
 


### PR DESCRIPTION
It's logged in server.dll somewhere already I believe and doesn't make sense to repeat this for every loaded plugin