### PR TITLE
Fix rpak aliasing not working when trying to alias towards a vanilla rpak

### DIFF
--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -342,7 +342,7 @@ void PakLoadManager::UnloadDependentPaks(PakHandle handle)
 static void HandlePakAliases(std::string& originalPath)
 {
 	// convert the pak being loaded to its aliased one, e.g. aliasing mp_hub_timeshift => sp_hub_timeshift
-	for (int64_t i = g_pModManager->m_LoadedMods.size() - 1; i > PakHandle::INVALID; i--)
+	for (int64_t i = g_pModManager->m_LoadedMods.size() - 1; i > -1; i--)
 	{
 		Mod* mod = &g_pModManager->m_LoadedMods[i];
 		if (!mod->m_bEnabled)

--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -350,7 +350,7 @@ static void HandlePakAliases(std::string& originalPath)
 
 		if (mod->RpakAliases.find(originalPath) != mod->RpakAliases.end())
 		{
-			originalPath = (mod->m_ModDirectory / "paks" / mod->RpakAliases[originalPath]).string();
+			originalPath = mod->RpakAliases[originalPath];
 			return;
 		}
 	}


### PR DESCRIPTION
Fixing stuff described by @Alystrasz on discord. I don't really like this behaviour as it behaves a bit differently for vanilla rpak loads and modded rpak loads, but aliasing is hacky already so meh.