### PR TITLE
refactor: Mod information

### DIFF
--- a/primedev/mods/compiled/modkeyvalues.cpp
+++ b/primedev/mods/compiled/modkeyvalues.cpp
@@ -3,8 +3,6 @@
 
 #include <fstream>
 
-AUTOHOOK_INIT()
-
 void ModManager::TryBuildKeyValues(const char* filename)
 {
 	spdlog::info("Building KeyValues for file {}", filename);

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -57,6 +57,68 @@ ADD_SQFUNC("array<ModInfo>", NSGetModsInformation, "", "", ScriptContext::SERVER
 	return SQRESULT_NOTNULL;
 }
 
+ADD_SQFUNC("array<ModInfo>", NSGetModInformation, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+{
+	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
+	g_pSquirrel<context>->newarray(sqvm, 0);
+
+	for (Mod& mod : g_pModManager->m_LoadedMods)
+	{
+		if (mod.Name.compare(modName) != 0)
+		{
+			continue;
+		}
+
+		g_pSquirrel<context>->pushnewstructinstance(sqvm, 9);
+
+		// name
+		g_pSquirrel<context>->pushstring(sqvm, mod.Name.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 0);
+
+		// description
+		g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 1);
+
+		// version
+		g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 2);
+
+		// download link
+		g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 3);
+
+		// load priority
+		g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
+		g_pSquirrel<context>->sealstructslot(sqvm, 4);
+
+		// enabled
+		g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
+		g_pSquirrel<context>->sealstructslot(sqvm, 5);
+
+		// required on client
+		g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
+		g_pSquirrel<context>->sealstructslot(sqvm, 6);
+
+		// is remote
+		g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
+		g_pSquirrel<context>->sealstructslot(sqvm, 7);
+
+		// convars
+		g_pSquirrel<context>->newarray(sqvm);
+		for (ModConVar* cvar : mod.ConVars)
+		{
+			g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
+			g_pSquirrel<context>->arrayappend(sqvm, -2);
+		}
+		g_pSquirrel<context>->sealstructslot(sqvm, 8);
+
+		// add current object to squirrel array
+		g_pSquirrel<context>->arrayappend(sqvm, -2);
+	}
+
+	return SQRESULT_NOTNULL;
+}
+
 ADD_SQFUNC("array<string>", NSGetModNames, "", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	g_pSquirrel<context>->newarray(sqvm, 0);
@@ -99,23 +161,6 @@ ADD_SQFUNC("void", NSSetModEnabled, "string modName, bool enabled", "", ScriptCo
 		{
 			mod.m_bEnabled = enabled;
 			return SQRESULT_NULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC("bool", NSIsModRequiredOnClient, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
-			return SQRESULT_NOTNULL;
 		}
 	}
 

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -132,23 +132,6 @@ ADD_SQFUNC("array<string>", NSGetModNames, "", "", ScriptContext::SERVER | Scrip
 	return SQRESULT_NOTNULL;
 }
 
-ADD_SQFUNC("bool", NSIsModEnabled, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
 ADD_SQFUNC("void", NSSetModEnabled, "string modName, bool enabled", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -1,57 +1,62 @@
 #include "mods/modmanager.h"
 #include "squirrel/squirrel.h"
 
+template <ScriptContext context> void ModToSquirrel(HSQUIRRELVM sqvm, Mod& mod)
+{
+	g_pSquirrel<context>->pushnewstructinstance(sqvm, 9);
+
+	// name
+	g_pSquirrel<context>->pushstring(sqvm, mod.Name.c_str(), -1);
+	g_pSquirrel<context>->sealstructslot(sqvm, 0);
+
+	// description
+	g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str(), -1);
+	g_pSquirrel<context>->sealstructslot(sqvm, 1);
+
+	// version
+	g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str(), -1);
+	g_pSquirrel<context>->sealstructslot(sqvm, 2);
+
+	// download link
+	g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str(), -1);
+	g_pSquirrel<context>->sealstructslot(sqvm, 3);
+
+	// load priority
+	g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
+	g_pSquirrel<context>->sealstructslot(sqvm, 4);
+
+	// enabled
+	g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
+	g_pSquirrel<context>->sealstructslot(sqvm, 5);
+
+	// required on client
+	g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
+	g_pSquirrel<context>->sealstructslot(sqvm, 6);
+
+	// is remote
+	g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
+	g_pSquirrel<context>->sealstructslot(sqvm, 7);
+
+	// convars
+	g_pSquirrel<context>->newarray(sqvm);
+	for (ModConVar* cvar : mod.ConVars)
+	{
+		g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
+		g_pSquirrel<context>->arrayappend(sqvm, -2);
+	}
+	g_pSquirrel<context>->sealstructslot(sqvm, 8);
+
+	// add current object to squirrel array
+	g_pSquirrel<context>->arrayappend(sqvm, -2);
+}
+
 ADD_SQFUNC("array<ModInfo>", NSGetModsInformation, "", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	g_pSquirrel<context>->newarray(sqvm, 0);
 
 	for (Mod& mod : g_pModManager->m_LoadedMods)
 	{
-		g_pSquirrel<context>->pushnewstructinstance(sqvm, 9);
-
-		// name
-		g_pSquirrel<context>->pushstring(sqvm, mod.Name.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 0);
-
-		// description
-		g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 1);
-
-		// version
-		g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 2);
-
-		// download link
-		g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 3);
-
-		// load priority
-		g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
-		g_pSquirrel<context>->sealstructslot(sqvm, 4);
-
-		// enabled
-		g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
-		g_pSquirrel<context>->sealstructslot(sqvm, 5);
-
-		// required on client
-		g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
-		g_pSquirrel<context>->sealstructslot(sqvm, 6);
-
-		// is remote
-		g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
-		g_pSquirrel<context>->sealstructslot(sqvm, 7);
-
-		// convars
-		g_pSquirrel<context>->newarray(sqvm);
-		for (ModConVar* cvar : mod.ConVars)
-		{
-			g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
-			g_pSquirrel<context>->arrayappend(sqvm, -2);
-		}
-		g_pSquirrel<context>->sealstructslot(sqvm, 8);
-
-		// add current object to squirrel array
-		g_pSquirrel<context>->arrayappend(sqvm, -2);
+		ModToSquirrel<context>(sqvm, mod);
 	}
 
 	return SQRESULT_NOTNULL;
@@ -68,52 +73,7 @@ ADD_SQFUNC("array<ModInfo>", NSGetModInformation, "string modName", "", ScriptCo
 		{
 			continue;
 		}
-
-		g_pSquirrel<context>->pushnewstructinstance(sqvm, 9);
-
-		// name
-		g_pSquirrel<context>->pushstring(sqvm, mod.Name.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 0);
-
-		// description
-		g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 1);
-
-		// version
-		g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 2);
-
-		// download link
-		g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str(), -1);
-		g_pSquirrel<context>->sealstructslot(sqvm, 3);
-
-		// load priority
-		g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
-		g_pSquirrel<context>->sealstructslot(sqvm, 4);
-
-		// enabled
-		g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
-		g_pSquirrel<context>->sealstructslot(sqvm, 5);
-
-		// required on client
-		g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
-		g_pSquirrel<context>->sealstructslot(sqvm, 6);
-
-		// is remote
-		g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
-		g_pSquirrel<context>->sealstructslot(sqvm, 7);
-
-		// convars
-		g_pSquirrel<context>->newarray(sqvm);
-		for (ModConVar* cvar : mod.ConVars)
-		{
-			g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
-			g_pSquirrel<context>->arrayappend(sqvm, -2);
-		}
-		g_pSquirrel<context>->sealstructslot(sqvm, 8);
-
-		// add current object to squirrel array
-		g_pSquirrel<context>->arrayappend(sqvm, -2);
+		ModToSquirrel<context>(sqvm, mod);
 	}
 
 	return SQRESULT_NOTNULL;

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -122,6 +122,24 @@ ADD_SQFUNC("bool", NSIsModRequiredOnClient, "string modName", "", ScriptContext:
 	return SQRESULT_NULL;
 }
 
+ADD_SQFUNC("array<string>", NSGetModVersions, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+{
+	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
+	g_pSquirrel<context>->newarray(sqvm, 0);
+
+	// manual lookup, not super performant but eh not a big deal
+	for (Mod& mod : g_pModManager->m_LoadedMods)
+	{
+		if (!mod.Name.compare(modName))
+		{
+			g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str());
+			g_pSquirrel<context>->arrayappend(sqvm, -2);
+		}
+	}
+
+	return SQRESULT_NOTNULL;
+}
+
 ADD_SQFUNC("void", NSReloadMods, "", "", ScriptContext::UI)
 {
 	NOTE_UNUSED(sqvm);

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -105,91 +105,6 @@ ADD_SQFUNC("void", NSSetModEnabled, "string modName, bool enabled", "", ScriptCo
 	return SQRESULT_NULL;
 }
 
-ADD_SQFUNC("bool", NSIsModRemote, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC("string", NSGetModDescriptionByModName, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str());
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC("string", NSGetModVersionByModName, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str());
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC("string", NSGetModDownloadLinkByModName, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str());
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC("int", NSGetModLoadPriority, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NULL;
-}
-
 ADD_SQFUNC("bool", NSIsModRequiredOnClient, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
@@ -205,30 +120,6 @@ ADD_SQFUNC("bool", NSIsModRequiredOnClient, "string modName", "", ScriptContext:
 	}
 
 	return SQRESULT_NULL;
-}
-
-ADD_SQFUNC(
-	"array<string>", NSGetModConvarsByModName, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-	g_pSquirrel<context>->newarray(sqvm, 0);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			for (ModConVar* cvar : mod.ConVars)
-			{
-				g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
-				g_pSquirrel<context>->arrayappend(sqvm, -2);
-			}
-
-			return SQRESULT_NOTNULL;
-		}
-	}
-
-	return SQRESULT_NOTNULL; // return empty array
 }
 
 ADD_SQFUNC("void", NSReloadMods, "", "", ScriptContext::UI)

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -167,24 +167,6 @@ ADD_SQFUNC("void", NSSetModEnabled, "string modName, bool enabled", "", ScriptCo
 	return SQRESULT_NULL;
 }
 
-ADD_SQFUNC("array<string>", NSGetModVersions, "string modName", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
-{
-	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-	g_pSquirrel<context>->newarray(sqvm, 0);
-
-	// manual lookup, not super performant but eh not a big deal
-	for (Mod& mod : g_pModManager->m_LoadedMods)
-	{
-		if (!mod.Name.compare(modName))
-		{
-			g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str());
-			g_pSquirrel<context>->arrayappend(sqvm, -2);
-		}
-	}
-
-	return SQRESULT_NOTNULL;
-}
-
 ADD_SQFUNC("void", NSReloadMods, "", "", ScriptContext::UI)
 {
 	NOTE_UNUSED(sqvm);

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -1,6 +1,62 @@
 #include "mods/modmanager.h"
 #include "squirrel/squirrel.h"
 
+ADD_SQFUNC("array<ModInfo>", NSGetModsInformation, "", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+{
+	g_pSquirrel<context>->newarray(sqvm, 0);
+
+	for (Mod& mod : g_pModManager->m_LoadedMods)
+	{
+		g_pSquirrel<context>->pushnewstructinstance(sqvm, 9);
+
+		// name
+		g_pSquirrel<context>->pushstring(sqvm, mod.Name.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 0);
+
+		// description
+		g_pSquirrel<context>->pushstring(sqvm, mod.Description.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 1);
+
+		// version
+		g_pSquirrel<context>->pushstring(sqvm, mod.Version.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 2);
+
+		// download link
+		g_pSquirrel<context>->pushstring(sqvm, mod.DownloadLink.c_str(), -1);
+		g_pSquirrel<context>->sealstructslot(sqvm, 3);
+
+		// load priority
+		g_pSquirrel<context>->pushinteger(sqvm, mod.LoadPriority);
+		g_pSquirrel<context>->sealstructslot(sqvm, 4);
+
+		// enabled
+		g_pSquirrel<context>->pushbool(sqvm, mod.m_bEnabled);
+		g_pSquirrel<context>->sealstructslot(sqvm, 5);
+
+		// required on client
+		g_pSquirrel<context>->pushbool(sqvm, mod.RequiredOnClient);
+		g_pSquirrel<context>->sealstructslot(sqvm, 6);
+
+		// is remote
+		g_pSquirrel<context>->pushbool(sqvm, mod.m_bIsRemote);
+		g_pSquirrel<context>->sealstructslot(sqvm, 7);
+
+		// convars
+		g_pSquirrel<context>->newarray(sqvm);
+		for (ModConVar* cvar : mod.ConVars)
+		{
+			g_pSquirrel<context>->pushstring(sqvm, cvar->Name.c_str());
+			g_pSquirrel<context>->arrayappend(sqvm, -2);
+		}
+		g_pSquirrel<context>->sealstructslot(sqvm, 8);
+
+		// add current object to squirrel array
+		g_pSquirrel<context>->arrayappend(sqvm, -2);
+	}
+
+	return SQRESULT_NOTNULL;
+}
+
 ADD_SQFUNC("array<string>", NSGetModNames, "", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	g_pSquirrel<context>->newarray(sqvm, 0);


### PR DESCRIPTION
Currently, to retrieve mod information from launcher, Squirrel VM must summon methods such as `NSGetModDescriptionByModName`, `NSGetModDownloadLinkByModName`, `NSGetModLoadPriority` etc, which all loop over the list of mods until they find the correct one (using mod name as key), which is highly ineffective: this means we need as many iterations over mods list as we need information about the mod.

To solve this problem, this PR introduces a `NSGetModsInformation`, which exposes all mod information to Squirrel VM at once, using a new `ModInfo` structure.

```javascript
global struct ModInfo
{
    string name = ""
    string description = ""
    string version = ""
    string downloadLink = ""
    int loadPriority = 0
    bool enabled = false
    bool requiredOnClient = false
    bool isRemote
    array<string> conVars = []
}
```

This is meant to make reviewing https://github.com/R2Northstar/NorthstarLauncher/pull/758 and https://github.com/R2Northstar/NorthstarMods/pull/824 easier.

**(I highly discourage you to look at the github diff, which is fucked up, and suggest rather looking at the changes commit per commit!)**

**Don't merge without mods counterpart: https://github.com/R2Northstar/NorthstarMods/pull/899**

#### Testing

1. Install both launcher and mods PRs;
2. Start the game;
3. Try to break the mod menu;
4. Connect to Northstar;
5. Try to break the server browser.