### PR TITLE
scripts/client: Remove uses of Autohook from `scriptbrowserhooks.cpp`

### DIFF
--- a/primedev/scripts/client/scriptbrowserhooks.cpp
+++ b/primedev/scripts/client/scriptbrowserhooks.cpp
@@ -1,6 +1,4 @@
 
-AUTOHOOK_INIT()
-
 bool* bIsOriginOverlayEnabled;
 
 static void(__fastcall* o_pOpenExternalWebBrowser)(char* pUrl, char flags) = nullptr;
@@ -17,8 +15,6 @@ static void __fastcall h_OpenExternalWebBrowser(char* pUrl, char flags)
 
 ON_DLL_LOAD_CLIENT("engine.dll", ScriptExternalBrowserHooks, (CModule module))
 {
-	AUTOHOOK_DISPATCH()
-
 	o_pOpenExternalWebBrowser = module.Offset(0x184E40).RCast<decltype(o_pOpenExternalWebBrowser)>();
 	HookAttach(&(PVOID&)o_pOpenExternalWebBrowser, (PVOID)h_OpenExternalWebBrowser);
 

--- a/primedev/scripts/client/scriptbrowserhooks.cpp
+++ b/primedev/scripts/client/scriptbrowserhooks.cpp
@@ -3,23 +3,24 @@ AUTOHOOK_INIT()
 
 bool* bIsOriginOverlayEnabled;
 
-// clang-format off
-AUTOHOOK(OpenExternalWebBrowser, engine.dll + 0x184E40, 
-void, __fastcall, (char* pUrl, char flags))
-// clang-format on
+static void(__fastcall* o_pOpenExternalWebBrowser)(char* pUrl, char flags) = nullptr;
+static void __fastcall h_OpenExternalWebBrowser(char* pUrl, char flags)
 {
 	bool bIsOriginOverlayEnabledOriginal = *bIsOriginOverlayEnabled;
 	bool isHttp = !strncmp(pUrl, "http://", 7) || !strncmp(pUrl, "https://", 8);
 	if (flags & 2 && isHttp) // custom force external browser flag
 		*bIsOriginOverlayEnabled = false; // if this bool is false, game will use an external browser rather than the origin overlay one
 
-	OpenExternalWebBrowser(pUrl, flags);
+	o_pOpenExternalWebBrowser(pUrl, flags);
 	*bIsOriginOverlayEnabled = bIsOriginOverlayEnabledOriginal;
 }
 
 ON_DLL_LOAD_CLIENT("engine.dll", ScriptExternalBrowserHooks, (CModule module))
 {
 	AUTOHOOK_DISPATCH()
+
+	o_pOpenExternalWebBrowser = module.Offset(0x184E40).RCast<decltype(o_pOpenExternalWebBrowser)>();
+	HookAttach(&(PVOID&)o_pOpenExternalWebBrowser, (PVOID)h_OpenExternalWebBrowser);
 
 	bIsOriginOverlayEnabled = module.Offset(0x13978255).RCast<bool*>();
 }


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Check that the "force external web browser" script flag for `OpenExternalWebBrowser` still works (i.e it opens in a separate web browser instead of the origin/steam/whatever overaly)
