### PR TITLE
server: Remove uses of Autohook from`serverchathooks.cpp`

### DIFF
--- a/primedev/server/serverchathooks.cpp
+++ b/primedev/server/serverchathooks.cpp
@@ -59,7 +59,7 @@ static void __fastcall h_CServerGameDLL__OnReceivedSayTextMessage(CServerGameDLL
 void ChatSendMessage(unsigned int playerIndex, const char* text, bool isTeam)
 {
 	bShouldCallSayTextHook = true;
-	o_pCServerGameDLL__OnReceivedSayTextMessage(
+	h_CServerGameDLL__OnReceivedSayTextMessage(
 		g_pServerGameDLL,
 		// Ensure the first bit isn't set, since this indicates a custom message
 		(playerIndex + 1) & CUSTOM_MESSAGE_INDEX_MASK,

--- a/primedev/server/serverchathooks.cpp
+++ b/primedev/server/serverchathooks.cpp
@@ -19,9 +19,6 @@ class CRecipientFilter
 
 CServerGameDLL* g_pServerGameDLL;
 
-void(__fastcall* CServerGameDLL__OnReceivedSayTextMessage)(
-	CServerGameDLL* self, unsigned int senderPlayerId, const char* text, int channelId);
-
 void(__fastcall* CRecipientFilter__Construct)(CRecipientFilter* self);
 void(__fastcall* CRecipientFilter__Destruct)(CRecipientFilter* self);
 void(__fastcall* CRecipientFilter__AddAllPlayers)(CRecipientFilter* self);
@@ -35,10 +32,9 @@ void(__fastcall* MessageWriteString)(const char* sz);
 void(__fastcall* MessageWriteBool)(bool bValue);
 
 bool bShouldCallSayTextHook = false;
-// clang-format off
-AUTOHOOK(_CServerGameDLL__OnReceivedSayTextMessage, server.dll + 0x1595C0,
-void, __fastcall, (CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam))
-// clang-format on
+
+static void (__fastcall* o_pCServerGameDLL__OnReceivedSayTextMessage)(CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam) = nullptr;
+static void __fastcall h_CServerGameDLL__OnReceivedSayTextMessage(CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam)
 {
 	RemoveAsciiControlSequences(const_cast<char*>(text), true);
 
@@ -47,7 +43,7 @@ void, __fastcall, (CServerGameDLL* self, unsigned int senderPlayerId, const char
 	if (bShouldCallSayTextHook)
 	{
 		bShouldCallSayTextHook = false;
-		_CServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerId, text, isTeam);
+		o_pCServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerId, text, isTeam);
 		return;
 	}
 
@@ -59,13 +55,13 @@ void, __fastcall, (CServerGameDLL* self, unsigned int senderPlayerId, const char
 		"CServerGameDLL_ProcessMessageStartThread", static_cast<int>(senderPlayerId) - 1, text, isTeam);
 
 	if (result == SQRESULT_ERROR)
-		_CServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerId, text, isTeam);
+		o_pCServerGameDLL__OnReceivedSayTextMessage(self, senderPlayerId, text, isTeam);
 }
 
 void ChatSendMessage(unsigned int playerIndex, const char* text, bool isTeam)
 {
 	bShouldCallSayTextHook = true;
-	CServerGameDLL__OnReceivedSayTextMessage(
+	o_pCServerGameDLL__OnReceivedSayTextMessage(
 		g_pServerGameDLL,
 		// Ensure the first bit isn't set, since this indicates a custom message
 		(playerIndex + 1) & CUSTOM_MESSAGE_INDEX_MASK,
@@ -158,8 +154,9 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerChatHooks, ServerSquirrel, (CModule mod
 {
 	AUTOHOOK_DISPATCH_MODULE(server.dll)
 
-	CServerGameDLL__OnReceivedSayTextMessage =
-		module.Offset(0x1595C0).RCast<void(__fastcall*)(CServerGameDLL*, unsigned int, const char*, int)>();
+	o_pCServerGameDLL__OnReceivedSayTextMessage = module.Offset(0x1595C0).RCast<decltype(o_pCServerGameDLL__OnReceivedSayTextMessage)>();
+	HookAttach(&(PVOID&)o_pCServerGameDLL__OnReceivedSayTextMessage, (PVOID)h_CServerGameDLL__OnReceivedSayTextMessage);
+
 	CRecipientFilter__Construct = module.Offset(0x1E9440).RCast<void(__fastcall*)(CRecipientFilter*)>();
 	CRecipientFilter__Destruct = module.Offset(0x1E9700).RCast<void(__fastcall*)(CRecipientFilter*)>();
 	CRecipientFilter__AddAllPlayers = module.Offset(0x1E9940).RCast<void(__fastcall*)(CRecipientFilter*)>();

--- a/primedev/server/serverchathooks.cpp
+++ b/primedev/server/serverchathooks.cpp
@@ -8,8 +8,6 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-AUTOHOOK_INIT()
-
 class CServerGameDLL;
 
 class CRecipientFilter
@@ -152,8 +150,6 @@ ON_DLL_LOAD("engine.dll", EngineServerChatHooks, (CModule module))
 
 ON_DLL_LOAD_RELIESON("server.dll", ServerChatHooks, ServerSquirrel, (CModule module))
 {
-	AUTOHOOK_DISPATCH_MODULE(server.dll)
-
 	o_pCServerGameDLL__OnReceivedSayTextMessage = module.Offset(0x1595C0).RCast<decltype(o_pCServerGameDLL__OnReceivedSayTextMessage)>();
 	HookAttach(&(PVOID&)o_pCServerGameDLL__OnReceivedSayTextMessage, (PVOID)h_CServerGameDLL__OnReceivedSayTextMessage);
 

--- a/primedev/server/serverchathooks.cpp
+++ b/primedev/server/serverchathooks.cpp
@@ -31,8 +31,10 @@ void(__fastcall* MessageWriteBool)(bool bValue);
 
 bool bShouldCallSayTextHook = false;
 
-static void (__fastcall* o_pCServerGameDLL__OnReceivedSayTextMessage)(CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam) = nullptr;
-static void __fastcall h_CServerGameDLL__OnReceivedSayTextMessage(CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam)
+static void(__fastcall* o_pCServerGameDLL__OnReceivedSayTextMessage)(
+	CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam) = nullptr;
+static void __fastcall h_CServerGameDLL__OnReceivedSayTextMessage(
+	CServerGameDLL* self, unsigned int senderPlayerId, const char* text, bool isTeam)
 {
 	RemoveAsciiControlSequences(const_cast<char*>(text), true);
 


### PR DESCRIPTION
### Code review:
- The original function is prefixed with `o_p` so any times where the old AUTOHOOK was calling the original function it should now be calling that instead.
- The hook function is prefixed with `h_` so any times where we would be wanting to call the hooked function from other functions should now be calling that instead

### Testing:
- Check logs to make sure that all of the changed hooks are being created properly
- Check that the chat hooks still function as expected
