### PR TITLE
Fix reloading plugins

### DIFF
--- a/primedev/plugins/pluginmanager.cpp
+++ b/primedev/plugins/pluginmanager.cpp
@@ -1,6 +1,7 @@
 #include "pluginmanager.h"
 
 #include <regex>
+#include <ranges>
 #include "plugins.h"
 #include "config/profile.h"
 #include "core/convar/concommand.h"
@@ -111,13 +112,14 @@ bool PluginManager::LoadPlugins(bool reloaded)
 
 void PluginManager::ReloadPlugins()
 {
-	for (const Plugin& plugin : this->GetLoadedPlugins())
-	{
-		plugin.Unload();
-	}
+	NS::log::PLUGINSYS->info("Reloading plugins");
 
-	this->plugins.clear();
-	this->LoadPlugins(true);
+	for (const Plugin& plugin : this->plugins | std::views::reverse)
+	{
+		std::string name = plugin.GetName();
+		if (plugin.Reload())
+			NS::log::PLUGINSYS->warn("Reloaded {}", name);
+	}
 }
 
 void PluginManager::RemovePlugin(HMODULE handle)

--- a/primedev/plugins/pluginmanager.cpp
+++ b/primedev/plugins/pluginmanager.cpp
@@ -118,7 +118,7 @@ void PluginManager::ReloadPlugins()
 	{
 		std::string name = plugin.GetName();
 		if (plugin.Reload())
-			NS::log::PLUGINSYS->warn("Reloaded {}", name);
+			NS::log::PLUGINSYS->info("Reloaded {}", name);
 	}
 }
 

--- a/primedev/plugins/plugins.cpp
+++ b/primedev/plugins/plugins.cpp
@@ -138,9 +138,9 @@ bool Plugin::Unload() const
 
 	if (IsValid())
 	{
-		bool unloaded = m_callbacks->Unload();
+		bool shouldUnload = m_callbacks->Unload();
 
-		if (!unloaded)
+		if (!shouldUnload)
 			return false;
 	}
 
@@ -154,14 +154,18 @@ bool Plugin::Unload() const
 	return true;
 }
 
-void Plugin::Reload() const
+bool Plugin::Reload() const
 {
+	std::string location = m_location;
+
 	bool unloaded = Unload();
 
 	if (!unloaded)
-		return;
+		return false;
 
-	g_pPluginManager->LoadPlugin(fs::path(m_location), true);
+	g_pPluginManager->LoadPlugin(fs::path(location), true);
+
+	return true;
 }
 
 void Plugin::Log(spdlog::level::level_enum level, char* msg) const

--- a/primedev/plugins/plugins.h
+++ b/primedev/plugins/plugins.h
@@ -28,7 +28,7 @@ public:
 
 	Plugin(std::string path);
 	bool Unload() const;
-	void Reload() const;
+	bool Reload() const;
 
 	// sys
 	void Log(spdlog::level::level_enum level, char* msg) const;


### PR DESCRIPTION
Originally it probably worked if all plugins could be reloaded but it also just dropped all the plugins regardless of whether it can be reloaded or not.

So this pr attempts to amend that by individually reloading all the plugins instead of dropping then loading them all.

(this still doesn't really fix it since I can't get any plugin to be reloaded 💢 so that's why it's a draft)

was (wow crash)
![image](https://github.com/user-attachments/assets/b69b8c85-e76c-44c1-9e06-1a7480aa767d)

now (wow still doesn't work!)
![image](https://github.com/user-attachments/assets/8ebdef11-2490-42f2-9fb1-221b70243f51)

so basically I need some help but I think this pr is good first stepping stone. :)

ignore the screenshots before this

## how to test

with this pr if upon reloading plugins nothing crashes then that means it worked as intended. 
