### PR TITLE
Remove cheat flag from `cl_gib_lifetime`

### DIFF
--- a/primedev/shared/misccommands.cpp
+++ b/primedev/shared/misccommands.cpp
@@ -365,8 +365,7 @@ void FixupCvarFlags()
 
 	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {
 		{"sv_stressbots", "0"}, // not currently used but this is probably a bad default if we get bots working
-		{"cl_pred_optimize", "0"}, // fixes issues with animation prediction in thirdperson
-		{"cl_gib_lifetime", "10"} // default value (3) is too low
+		{"cl_pred_optimize", "0"} // fixes issues with animation prediction in thirdperson
 	};
 
 	for (auto& fixup : CVAR_FIXUP_ADD_FLAGS)

--- a/primedev/shared/misccommands.cpp
+++ b/primedev/shared/misccommands.cpp
@@ -365,7 +365,7 @@ void FixupCvarFlags()
 
 	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {
 		{"sv_stressbots", "0"}, // not currently used but this is probably a bad default if we get bots working
-		{"cl_pred_optimize", "0"} // fixes issues with animation prediction in thirdperson
+		{"cl_pred_optimize", "0"}, // fixes issues with animation prediction in thirdperson
 		{"cl_gib_lifetime", "10"} // default value (3) is too low
 	};
 

--- a/primedev/shared/misccommands.cpp
+++ b/primedev/shared/misccommands.cpp
@@ -366,6 +366,7 @@ void FixupCvarFlags()
 	const std::vector<std::tuple<const char*, const char*>> CVAR_FIXUP_DEFAULT_VALUES = {
 		{"sv_stressbots", "0"}, // not currently used but this is probably a bad default if we get bots working
 		{"cl_pred_optimize", "0"} // fixes issues with animation prediction in thirdperson
+		{"cl_gib_lifetime", "10"} // default value (3) is too low
 	};
 
 	for (auto& fixup : CVAR_FIXUP_ADD_FLAGS)

--- a/primedev/shared/misccommands.cpp
+++ b/primedev/shared/misccommands.cpp
@@ -301,6 +301,7 @@ void FixupCvarFlags()
 		// these 2 could be FCVAR_CHEAT, i guess?
 		{"cl_draw_player_model", FCVAR_DEVELOPMENTONLY},
 		{"cl_always_draw_3p_player", FCVAR_DEVELOPMENTONLY},
+		{"cl_gib_lifetime", FCVAR_CHEAT},
 		{"idcolor_neutral", FCVAR_DEVELOPMENTONLY},
 		{"idcolor_ally", FCVAR_DEVELOPMENTONLY},
 		{"idcolor_ally_cb1", FCVAR_DEVELOPMENTONLY},


### PR DESCRIPTION
There is literally 0 reason for it to have it, especially because its ragdoll counterparts `cl_ragdoll_force_fade_time_` don't. No idea what Respawn was thinking to be honest


https://github.com/user-attachments/assets/fa32f5da-c3e0-494f-addb-1d3b064e9a94

