### PR TITLE
Revert "Fix crash in `ReadFileAsync`"

### DIFF
--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -479,20 +479,11 @@ void*, __fastcall, (PakHandle nPakHandle, void* pCallback))
 
 // we hook this exclusively for resolving stbsp paths, but seemingly it's also used for other stuff like vpk, rpak, mprj and starpak loads
 // tbh this actually might be for memory mapped files or something, would make sense i think
-// rtech_game.dll + 0x1e20
 // clang-format off
 HOOK(OpenFileHook, o_pOpenFile, 
 void*, __fastcall, (const char* pPath, void* pCallback))
 // clang-format on
 {
-	// NOTE [Fifty]: For some reason some users are getting pPath as null when
-	//               loading a server, ReadFileAsync uses CreateFileA and checks
-	//               its return value so this is completely safe
-	if (pPath == NULL)
-	{
-		return ReadFileAsync(pPath, pCallback);
-	}
-
 	fs::path path(pPath);
 	std::string newPath = "";
 	fs::path filename = path.filename();


### PR DESCRIPTION
Reverts R2Northstar/NorthstarLauncher#521

Building [fails](https://github.com/R2Northstar/NorthstarLauncher/actions/runs/14391709815/job/40359932310) on `main`, I guess the PR waited for too long to be reviewed.