### PR TITLE
Fix Null Deref crash

### DIFF
--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -484,6 +484,14 @@ HOOK(OpenFileHook, o_pOpenFile,
 void*, __fastcall, (const char* pPath, void* pCallback))
 // clang-format on
 {
+	// NOTE [Fifty]: For some reason some users are getting pPath as null when
+	//               loading a server, ReadFileAsync uses CreateFileA and checks
+	//               its return value so this is completely safe
+	if (pPath == NULL)
+	{
+		return ReadFileAsync(pPath, pCallback);
+	}
+	
 	fs::path path(pPath);
 	std::string newPath = "";
 	fs::path filename = path.filename();

--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -489,7 +489,7 @@ void*, __fastcall, (const char* pPath, void* pCallback))
 	//               its return value so this is completely safe
 	if (pPath == NULL)
 	{
-		return ReadFileAsync(pPath, pCallback);
+		return o_pOpenFile(pPath, pCallback);
 	}
 	
 	fs::path path(pPath);

--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -491,7 +491,6 @@ void*, __fastcall, (const char* pPath, void* pCallback))
 	{
 		return o_pOpenFile(pPath, pCallback);
 	}
-	
 	fs::path path(pPath);
 	std::string newPath = "";
 	fs::path filename = path.filename();

--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -491,6 +491,7 @@ void*, __fastcall, (const char* pPath, void* pCallback))
 	{
 		return o_pOpenFile(pPath, pCallback);
 	}
+
 	fs::path path(pPath);
 	std::string newPath = "";
 	fs::path filename = path.filename();

--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -485,7 +485,7 @@ void*, __fastcall, (const char* pPath, void* pCallback))
 // clang-format on
 {
 	// NOTE [Fifty]: For some reason some users are getting pPath as null when
-	//               loading a server, ReadFileAsync uses CreateFileA and checks
+	//               loading a server, o_pOpenFile uses CreateFileA and checks
 	//               its return value so this is completely safe
 	if (pPath == NULL)
 	{


### PR DESCRIPTION
Recreation of https://github.com/R2Northstar/NorthstarLauncher/pull/521 since it got reverted.
Original description:

> Fixes a NULL dereference crash in `ReadFileAsync`
> 
> This seems to be very rare, there's currently an open [ticket](https://discord.com/channels/920776187884732556/1134199951971332096) where this occurs. This version hasnt been tested yet.
> 
> I also promised to ping `@shmordan_08` when this gets released
> 
> Closes #520 