### PR TITLE
fix: Add vanilla compatibility for `setplaylistvaroverride` byte-patch

### DIFF
--- a/primedev/shared/playlist.cpp
+++ b/primedev/shared/playlist.cpp
@@ -1,6 +1,7 @@
 #include "playlist.h"
 #include "core/convar/concommand.h"
 #include "core/convar/convar.h"
+#include "core/vanilla.h"
 #include "squirrel/squirrel.h"
 #include "engine/hoststate.h"
 #include "engine/r2engine.h"
@@ -121,5 +122,7 @@ ON_DLL_LOAD_RELIESON("engine.dll", PlaylistHooks, (ConCommand, ConVar), (CModule
 	module.Offset(0x18ED8D).Patch("C3");
 
 	// patch to allow setplaylistvaroverride to be called before map init on dedicated and private match launched through the game
-	module.Offset(0x18ED17).NOP(6);
+	// only run on non-vanilla as this patch makes users unable to change private match settings on vanilla
+	if (!g_pVanillaCompatibility->GetVanillaCompatibility())
+		module.Offset(0x18ED17).NOP(6);
 }


### PR DESCRIPTION
The exact same thing as https://github.com/R2Northstar/NorthstarLauncher/pull/687. I know that Spoon said this should be handled in a different way, but since toggling vanilla isn't a thing right now, i don't really think it matters. If that ever changes this can just be updated.

Another part of why im making this is because i don't want people to download a random `.dll` from NexusMods to fix it https://www.nexusmods.com/titanfall2/mods/62
