### PR TITLE
Set execution markers properly

### DIFF
--- a/primedev/client/r2client.cpp
+++ b/primedev/client/r2client.cpp
@@ -4,11 +4,10 @@ char* g_pLocalPlayerUserID;
 char* g_pLocalPlayerOriginToken;
 GetBaseLocalClientType GetBaseLocalClient;
 
-
 ON_DLL_LOAD("engine.dll", R2EngineClient, (CModule module))
 {
 	g_pLocalPlayerUserID = module.Offset(0x13F8E688).RCast<char*>();
 	g_pLocalPlayerOriginToken = module.Offset(0x13979C80).RCast<char*>();
-	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
 
+	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
 }

--- a/primedev/client/r2client.cpp
+++ b/primedev/client/r2client.cpp
@@ -9,12 +9,21 @@ GetBaseLocalClientType GetBaseLocalClient;
 typedef int(__fastcall* o_CBaseClientState_ProcessStringCmd_t)(int64_t a1, int64_t a2);
 static o_CBaseClientState_ProcessStringCmd_t o_CBaseClientState_ProcessStringCmd;
 static int h_CBaseClientState_ProcessStringCmd(int64_t a1, int64_t a2) {
+
+	const char* cmd = *(const char**)(a2 + 32);
+
+	if (!strcmp(cmd + 1, "remote_view"))
+	{
+		return o_CBaseClientState_ProcessStringCmd(a1, a2);
+	}
+
 	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 	{
 		return o_CBaseClientState_ProcessStringCmd(a1, a2);
 	}
 	else
 	{
+		spdlog::info("Blocked CBaseClientState_ProcessStringCmd {}",cmd);
 		return 1;
 	}
 }

--- a/primedev/client/r2client.cpp
+++ b/primedev/client/r2client.cpp
@@ -1,13 +1,33 @@
 #include "r2client.h"
+#include <core/vanilla.h>
 
 char* g_pLocalPlayerUserID;
 char* g_pLocalPlayerOriginToken;
 GetBaseLocalClientType GetBaseLocalClient;
 
+// fix rce expolit
+typedef int(__fastcall* o_CBaseClientState_ProcessStringCmd_t)(int64_t a1, int64_t a2);
+static o_CBaseClientState_ProcessStringCmd_t o_CBaseClientState_ProcessStringCmd;
+static int h_CBaseClientState_ProcessStringCmd(int64_t a1, int64_t a2) {
+	if (g_pVanillaCompatibility->GetVanillaCompatibility())
+	{
+		return o_CBaseClientState_ProcessStringCmd(a1, a2);
+	}
+	else
+	{
+		return 1;
+	}
+}
+
+
 ON_DLL_LOAD("engine.dll", R2EngineClient, (CModule module))
 {
 	g_pLocalPlayerUserID = module.Offset(0x13F8E688).RCast<char*>();
 	g_pLocalPlayerOriginToken = module.Offset(0x13979C80).RCast<char*>();
+	o_CBaseClientState_ProcessStringCmd = module.Offset(0x1A1C20).RCast<o_CBaseClientState_ProcessStringCmd_t>();
+
+	HookAttach(&(PVOID&)o_CBaseClientState_ProcessStringCmd, (PVOID)h_CBaseClientState_ProcessStringCmd);
+
 
 	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
 }

--- a/primedev/client/r2client.cpp
+++ b/primedev/client/r2client.cpp
@@ -12,11 +12,6 @@ static int h_CBaseClientState_ProcessStringCmd(int64_t a1, int64_t a2) {
 
 	const char* cmd = *(const char**)(a2 + 32);
 
-	if (!strcmp(cmd + 1, "remote_view"))
-	{
-		return o_CBaseClientState_ProcessStringCmd(a1, a2);
-	}
-
 	if (g_pVanillaCompatibility->GetVanillaCompatibility())
 	{
 		return o_CBaseClientState_ProcessStringCmd(a1, a2);

--- a/primedev/client/r2client.cpp
+++ b/primedev/client/r2client.cpp
@@ -1,37 +1,14 @@
 #include "r2client.h"
-#include <core/vanilla.h>
 
 char* g_pLocalPlayerUserID;
 char* g_pLocalPlayerOriginToken;
 GetBaseLocalClientType GetBaseLocalClient;
-
-// fix rce expolit
-typedef int(__fastcall* o_CBaseClientState_ProcessStringCmd_t)(int64_t a1, int64_t a2);
-static o_CBaseClientState_ProcessStringCmd_t o_CBaseClientState_ProcessStringCmd;
-static int h_CBaseClientState_ProcessStringCmd(int64_t a1, int64_t a2) {
-
-	const char* cmd = *(const char**)(a2 + 32);
-
-	if (g_pVanillaCompatibility->GetVanillaCompatibility())
-	{
-		return o_CBaseClientState_ProcessStringCmd(a1, a2);
-	}
-	else
-	{
-		spdlog::info("Blocked CBaseClientState_ProcessStringCmd {}",cmd);
-		return 1;
-	}
-}
 
 
 ON_DLL_LOAD("engine.dll", R2EngineClient, (CModule module))
 {
 	g_pLocalPlayerUserID = module.Offset(0x13F8E688).RCast<char*>();
 	g_pLocalPlayerOriginToken = module.Offset(0x13979C80).RCast<char*>();
-	o_CBaseClientState_ProcessStringCmd = module.Offset(0x1A1C20).RCast<o_CBaseClientState_ProcessStringCmd_t>();
-
-	HookAttach(&(PVOID&)o_CBaseClientState_ProcessStringCmd, (PVOID)h_CBaseClientState_ProcessStringCmd);
-
-
 	GetBaseLocalClient = module.Offset(0x78200).RCast<GetBaseLocalClientType>();
+
 }

--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -296,21 +296,21 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !CommandLine()->CheckParm("-norestrictservercommands");
 }
 
-
 bool Cbuf_HasRoomForExecutionMarkers(const int marker)
 {
 	return (*g_ExecutionMarkerCount + marker) < 2048;
 }
 
 // fix rce expolit
+// clang-format off
 AUTOHOOK(CBaseClientState_ProcessStringCmd, engine.dll + 0x1A1C20,
 bool, __fastcall, (CBaseClient* self, int64_t a2))
+// clang-format on
 {
 	if (!Cbuf_HasRoomForExecutionMarkers(2))
 		return true;
 	return CBaseClientState_ProcessStringCmd(self, a2);
 }
-
 
 // ratelimit stringcmds, and prevent remote clients from calling commands that they shouldn't
 // clang-format off

--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -14,6 +14,8 @@ ConVar* Cvar_ns_should_log_all_clientcommands;
 
 ConVar* Cvar_sv_cheats;
 
+int* g_ExecutionMarkerCount;
+
 #define BLOCKED_INFO(s)                                                                                                                    \
 	(                                                                                                                                      \
 		[=]() -> bool                                                                                                                      \
@@ -294,6 +296,22 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !CommandLine()->CheckParm("-norestrictservercommands");
 }
 
+
+bool Cbuf_HasRoomForExecutionMarkers(const int marker)
+{
+	return (*g_ExecutionMarkerCount + marker) < 2048;
+}
+
+// fix rce expolit
+AUTOHOOK(CBaseClientState_ProcessStringCmd, engine.dll + 0x1A1C20,
+bool, __fastcall, (CBaseClient* self, int64_t a2))
+{
+	if (!Cbuf_HasRoomForExecutionMarkers(2))
+		return true;
+	return CBaseClientState_ProcessStringCmd(self, a2);
+}
+
+
 // ratelimit stringcmds, and prevent remote clients from calling commands that they shouldn't
 // clang-format off
 AUTOHOOK(CGameClient__ExecuteStringCommand, engine.dll + 0x1022E0,
@@ -428,7 +446,7 @@ bool, __fastcall, (void* a1))
 ON_DLL_LOAD("engine.dll", EngineExploitFixes, (CModule module))
 {
 	AUTOHOOK_DISPATCH_MODULE(engine.dll)
-
+	g_ExecutionMarkerCount = module.Offset(0x130DE8F0).RCast<int*>();
 	// allow client/ui to run clientcommands despite restricting servercommands
 	module.Offset(0x4FB65).Patch("EB 11");
 	module.Offset(0x4FBAC).Patch("EB 16");

--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -296,12 +296,14 @@ bool, __fastcall, (const char* pModName)) // 48 83 EC 28 48 8B 0D ? ? ? ? 48 8D 
 	return (!strcmp("r2", pModName) || !strcmp("r1", pModName)) && !CommandLine()->CheckParm("-norestrictservercommands");
 }
 
+// Checks if there's room left for execution markers
 bool Cbuf_HasRoomForExecutionMarkers(const int marker)
 {
 	return (*g_ExecutionMarkerCount + marker) < 2048;
 }
 
-// fix rce expolit
+// Set execution markers properly if there's space
+// If not enough space, ignore command
 // clang-format off
 AUTOHOOK(CBaseClientState_ProcessStringCmd, engine.dll + 0x1A1C20,
 bool, __fastcall, (CBaseClient* self, int64_t a2))


### PR DESCRIPTION
Set execution markers properly if there's enough room or ignore command otherwise.
Stops servers from executing commands on the client if not in vanilla. 