### PR TITLE
Add mod version argument to `NSSetModEnabled` function

### DIFF
--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -92,15 +92,16 @@ ADD_SQFUNC("array<string>", NSGetModNames, "", "", ScriptContext::SERVER | Scrip
 	return SQRESULT_NOTNULL;
 }
 
-ADD_SQFUNC("void", NSSetModEnabled, "string modName, bool enabled", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+ADD_SQFUNC("void", NSSetModEnabled, "string modName, string modVersion, bool enabled", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
-	const SQBool enabled = g_pSquirrel<context>->getbool(sqvm, 2);
+	const SQChar* modVersion = g_pSquirrel<context>->getstring(sqvm, 2);
+	const SQBool enabled = g_pSquirrel<context>->getbool(sqvm, 3);
 
 	// manual lookup, not super performant but eh not a big deal
 	for (Mod& mod : g_pModManager->m_LoadedMods)
 	{
-		if (!mod.Name.compare(modName))
+		if (!mod.Name.compare(modName) && !mod.Version.compare(modVersion))
 		{
 			mod.m_bEnabled = enabled;
 			return SQRESULT_NULL;

--- a/primedev/scripts/client/scriptmodmenu.cpp
+++ b/primedev/scripts/client/scriptmodmenu.cpp
@@ -92,7 +92,12 @@ ADD_SQFUNC("array<string>", NSGetModNames, "", "", ScriptContext::SERVER | Scrip
 	return SQRESULT_NOTNULL;
 }
 
-ADD_SQFUNC("void", NSSetModEnabled, "string modName, string modVersion, bool enabled", "", ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
+ADD_SQFUNC(
+	"void",
+	NSSetModEnabled,
+	"string modName, string modVersion, bool enabled",
+	"",
+	ScriptContext::SERVER | ScriptContext::CLIENT | ScriptContext::UI)
 {
 	const SQChar* modName = g_pSquirrel<context>->getstring(sqvm, 1);
 	const SQChar* modVersion = g_pSquirrel<context>->getstring(sqvm, 2);


### PR DESCRIPTION
With this PR, the `NSSetModEnabled` function enables a given version of the input mod only, and not all of its versions (which would crash due to files conflicts).

Check mods counterpart PR for more details. 