### PR TITLE
determine calling plugin by return address

### DIFF
--- a/primedev/plugins/interfaces/sys/ISys.cpp
+++ b/primedev/plugins/interfaces/sys/ISys.cpp
@@ -7,8 +7,20 @@
 class CSys : public ISys
 {
 public:
-	void Log(HMODULE handle, LogLevel level, char* msg)
+	void Log(int64_t unused, LogLevel level, char* msg)
 	{
+		void* callee = _ReturnAddress();
+		void* pluginHandle;
+		RtlPcToFileHeader(callee, &pluginHandle);
+
+		// This should never happen
+		if (!pluginHandle)
+		{
+
+			NS::log::PLUGINSYS->warn("Unmapped plugin attempted to log from callee {}", static_cast<void*>(pluginHandle));
+			return;
+		}
+
 		spdlog::level::level_enum spdLevel;
 
 		switch (level)
@@ -26,40 +38,62 @@ public:
 			break;
 		}
 
-		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin(handle);
+		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin((HMODULE)pluginHandle);
 		if (plugin)
 		{
 			plugin->Log(spdLevel, msg);
 		}
 		else
 		{
-			NS::log::PLUGINSYS->warn("Attempted to log message '{}' with invalid plugin handle {}", msg, static_cast<void*>(handle));
+			NS::log::PLUGINSYS->warn("Attempted to log message '{}' with invalid plugin handle {}", msg, static_cast<void*>(pluginHandle));
 		}
 	}
 
-	void Unload(HMODULE handle)
+	void Unload(int64_t unused)
 	{
-		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin(handle);
+		void* callee = _ReturnAddress();
+		void* pluginHandle;
+		RtlPcToFileHeader(callee, &pluginHandle);
+
+		// This should never happen
+		if (!pluginHandle)
+		{
+			NS::log::PLUGINSYS->warn("Attempted to unload unmapped plugin from callee {}", static_cast<void*>(pluginHandle));
+			return;
+		}
+
+		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin((HMODULE)pluginHandle);
 		if (plugin)
 		{
 			plugin->Unload();
 		}
 		else
 		{
-			NS::log::PLUGINSYS->warn("Attempted to unload plugin with invalid handle {}", static_cast<void*>(handle));
+			NS::log::PLUGINSYS->warn("Attempted to unload plugin with invalid handle {}", static_cast<void*>(pluginHandle));
 		}
 	}
 
-	void Reload(HMODULE handle)
+	void Reload(int64_t unused)
 	{
-		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin(handle);
+		void* callee = _ReturnAddress();
+		void* pluginHandle = 0;
+		RtlPcToFileHeader(callee, &pluginHandle);
+
+		// This should never happen
+		if (!pluginHandle)
+		{
+			NS::log::PLUGINSYS->warn("Attempted to reload unmapped plugin from callee {}", static_cast<void*>(pluginHandle));
+			return;
+		}
+
+		std::optional<Plugin> plugin = g_pPluginManager->GetPlugin((HMODULE)pluginHandle);
 		if (plugin)
 		{
 			plugin->Reload();
 		}
 		else
 		{
-			NS::log::PLUGINSYS->warn("Attempted to reload plugin with invalid handle {}", static_cast<void*>(handle));
+			NS::log::PLUGINSYS->warn("Attempted to reload plugin with invalid handle {}", static_cast<void*>(pluginHandle));
 		}
 	}
 };

--- a/primedev/plugins/interfaces/sys/ISys.h
+++ b/primedev/plugins/interfaces/sys/ISys.h
@@ -1,6 +1,8 @@
 #ifndef ILOGGING_H
 #define ILOGGING_H
 
+#include <stdint.h>
+
 #define SYS_VERSION "NSSys001"
 
 enum class LogLevel : int
@@ -13,9 +15,9 @@ enum class LogLevel : int
 class ISys
 {
 public:
-	virtual void Log(HMODULE handle, LogLevel level, char* msg) = 0;
-	virtual void Unload(HMODULE handle) = 0;
-	virtual void Reload(HMODULE handle) = 0;
+	virtual void Log(int64_t unused, LogLevel level, char* msg) = 0;
+	virtual void Unload(int64_t unused) = 0;
+	virtual void Reload(int64_t unused) = 0;
 };
 
 #endif


### PR DESCRIPTION
With the old system it was possible to act in the name of a different plugin. For example it was possible to log something using DiscordRPC's sink by just passing the DiscordRPC handle to INSSys::Log.

To test just start the game and observe that DiscordRPC logging still works