### PR TITLE
fix: Remove `m_bEnabled` duplicated assignment

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -673,8 +673,6 @@ void ModManager::SearchFilesystemForMods()
 		{
 			mod.m_bEnabled = m_EnabledModsCfg[mod.Name.c_str()][mod.Version.c_str()].IsTrue();
 		}
-		if (m_bHasEnabledModsCfg && m_EnabledModsCfg.HasMember(mod.Name.c_str()))
-			mod.m_bEnabled = m_EnabledModsCfg[mod.Name.c_str()].IsTrue();
 		else
 			mod.m_bEnabled = true;
 


### PR DESCRIPTION
Currently, the enabled state of mods is assigned twice, first time using new enabledmods.json format, second time using the old format (guess a merge commit caused this): this leads the launcher to enable all mods, due to 

```javascript
m_EnabledModsCfg[mod.Name.c_str()].IsTrue();
```
being true.

This PR simply removes the second variable assignment, and leaves the correct one in place.

### Testing:

Start the game with a few mods, and try to disable some: it won't be possible with current state, and it should be possible with this PR.

#### Without PR

[without-pr.webm](https://github.com/user-attachments/assets/378ec547-5a85-4041-99a7-80002e802b70)

#### With PR

[with-pr.webm](https://github.com/user-attachments/assets/33ff97af-909f-4536-bbc6-f4c8b38562d6)