### PR TITLE
fix: Do not enable remote mods on first load

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -529,10 +529,17 @@ void ModManager::SearchFilesystemForMods()
 			m_PluginDependencyConstants.insert(dependency);
 		}
 
-		if (m_EnabledModsCfg.HasMember(mod.Name.c_str()) && m_EnabledModsCfg[mod.Name.c_str()].HasMember(mod.Version))
+		// Do not load remote mods on first load
+		if (mod.m_bIsRemote && !m_bHasLoadedMods)
+		{
+			mod.m_bEnabled = false;
+		}
+		// Else, use enabledmods.json if possible
+		else if (m_EnabledModsCfg.HasMember(mod.Name.c_str()) && m_EnabledModsCfg[mod.Name.c_str()].HasMember(mod.Version))
 		{
 			mod.m_bEnabled = m_EnabledModsCfg[mod.Name.c_str()][mod.Version.c_str()].IsTrue();
 		}
+		// Else, enable new mods by default
 		else
 			mod.m_bEnabled = true;
 


### PR DESCRIPTION
Quoting @ASpoonPlaysGames:
If we dont write remote mods to enabledmods.json, then they won't be there if you `reload_mods`, which we do when joining a server in an attempt to load them; but if we do, then they will persist for too long.
Perhaps a solution is to disable all remote mods on boot but treat them like normal mods otherwise?

### Testing:

I tested this using the `mp_brick` map remote mod.

1. With main branch dll, join a server requiring the mod to download it, and check your `enabledmods.json` file, there should be a `true` entry for `"nyami.mp_brick"`;
2. Restart your client, join multiplayer lobby, and run the following command, that should show `mp_brick` is enabled:
```javascript
script foreach (mod in NSGetModsInformation())
{
	print(mod.name + " v" + mod.version + ": " + (mod.enabled ? "ENABLED" : "DISABLED"))
}
```
3. Do the same with the dll from this branch, the command should show `mp_brick` is disabled.