### PR TITLE
add initdata size for backwards / forward compat

### DIFF
--- a/primedev/plugins/interfaces/IPluginCallbacks.h
+++ b/primedev/plugins/interfaces/IPluginCallbacks.h
@@ -18,6 +18,7 @@ namespace PluginContext
 struct PluginNorthstarData
 {
 	HMODULE pluginHandle;
+	uint64_t size = sizeof(PluginNorthstarData);
 };
 
 class IPluginCallbacks


### PR DESCRIPTION
adding the size allows safely adding members to the InitData struct with backwards compatibility https://github.com/torvalds/linux/blob/master/include/uapi/linux/fs.h#L562-L563