### PR TITLE
fix: Manifesto migration

### DIFF
--- a/primedev/mods/modmanager.cpp
+++ b/primedev/mods/modmanager.cpp
@@ -624,6 +624,10 @@ void ModManager::ExportModsConfigurationToFile()
 		m_EnabledModsCfg[mod.Name.c_str()][mod.Version.c_str()].SetBool(mod.m_bEnabled);
 	}
 
+	// Exporting manifesto version
+	const char* versionMember = "Version";
+	m_EnabledModsCfg.AddMember(rapidjson_document::StringRefType(versionMember), manifestoVersion, m_EnabledModsCfg.GetAllocator());
+
 	std::ofstream writeStream(cfgPath);
 	rapidjson::OStreamWrapper writeStreamWrapper(writeStream);
 	rapidjson::PrettyWriter<rapidjson::OStreamWrapper> writer(writeStreamWrapper);
@@ -660,7 +664,6 @@ void ModManager::DiscoverMods()
 		// Check file format, and rename file if it is not using new format
 		bool isUsingUnknownFormat =
 			!m_EnabledModsCfg.IsObject() || !m_EnabledModsCfg.HasMember("Version") || !m_EnabledModsCfg["Version"].IsInt();
-
 		isUsingOldFormat =
 			m_EnabledModsCfg.IsObject() &&
 			(!m_EnabledModsCfg.HasMember("Version") || (m_EnabledModsCfg["Version"].IsInt() && m_EnabledModsCfg["Version"].GetInt() == 0));
@@ -710,6 +713,10 @@ void ModManager::DiscoverMods()
 		// Force manifesto write to disk
 		newModsDetected = true;
 	}
+
+	// Load manifesto version into memory
+	manifestoVersion = m_EnabledModsCfg[versionMember].GetInt();
+	spdlog::info("Using manifesto version {} to set mods state.", manifestoVersion);
 
 	for (Mod& mod : m_LoadedMods)
 	{

--- a/primedev/mods/modmanager.h
+++ b/primedev/mods/modmanager.h
@@ -35,6 +35,7 @@ private:
 	bool m_bHasEnabledModsCfg;
 	rapidjson_document m_EnabledModsCfg;
 	std::string cfgPath;
+	int manifestoVersion = 0;
 
 	// precalculated hashes
 	size_t m_hScriptsRsonHash;


### PR DESCRIPTION
Currently, launcher uses the `"Northstar.Client"` entry of the `enabledmods.json` file to check whether the latter uses an old format; that's an issue since Vanilla+ does not add such entry to the manifesto.
Additionally, manifesto migration seem to fail if ran several times in a row (might be due to an already existing `enabledmods.old.json` file, **to be confirmed**).

This adds the correct check, to avoid trying to migrate manifesto if that's not actually needed.

### Testing

#### Northstar

1. In the `enabledmods.json`, `"Version"` field being non-existent or not being an int should trigger migration;
2. Running migration several times in a row should not raise errors.

#### VanillaPlus

Make sure to remove `enabledmods.**` before trying these.

1. With `v1.31.1`, running the game twice is successful (even though a migration is done the second time), but game won't load the third time due to manifesto migration failing;
3. With this PR, running the game should be fine, no matter the repetition count.

