### PR TITLE
Prevent invalid packet flooding

### DIFF
--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -449,14 +449,15 @@ bool, __fastcall, (void* a1))
 
 // Clients can cause NET_ReceiveDatagram to stop listening each frame by sending an invalid LZSS packet. (see engine.dll+0x21B735)
 // This doesn't outright solve the problem but you'd basically need to be DDoSing the server to achieve the same effect.
-// Pasted from R1Delta: (https://github.com/r1delta/r1delta/blob/f04cc67e6247c5e15633b95f84fc69eca7252dc6/engine/security_fixes.cpp#L811) (thanks wanderer)
+// Pasted from R1Delta: (https://github.com/r1delta/r1delta/blob/f04cc67e6247c5e15633b95f84fc69eca7252dc6/engine/security_fixes.cpp#L811)
+// (thanks wanderer)
 // clang-format off
 AUTOHOOK(NET_ReceiveDatagram, engine.dll + 0x21B520, bool, __fastcall, (int sock, netpacket_t* packet, bool encrypted))
 // clang-format on
 {
-	for(int i = Cvar_ns_recvfrom_per_frame_limit->GetInt(); i > 0; i--)
+	for (int i = Cvar_ns_recvfrom_per_frame_limit->GetInt(); i > 0; i--)
 	{
-		if(net_error)
+		if (net_error)
 			*net_error = 0;
 
 		if (NET_ReceiveDatagram(sock, packet, encrypted))


### PR DESCRIPTION
This adds a workaround to the fact that flooding `NET_ReceiveDatagram` with invalid packets, (namely invalid LZSS compression (-3) packets see `engine.dll+0x21B735`) causes the server to stop receiving that frame. This adds a configurable number of times to iterate listening per call from `NET_GetPacket`.

Basically just pasted from [R1Delta security_fixes.cpp](https://github.com/r1delta/r1delta/blob/f04cc67e6247c5e15633b95f84fc69eca7252dc6/engine/security_fixes.cpp#L811)
### Code review:
🙂 

### Testing:
idk probably works 👍 