### PR TITLE
MAD: Allow for versioning MWS mods

### DIFF
--- a/primedev/mods/autodownload/moddownloader.cpp
+++ b/primedev/mods/autodownload/moddownloader.cpp
@@ -563,7 +563,6 @@ void ModDownloader::ExtractMod(fs::path modPath, fs::path destinationPath, Verif
 			// Cleanup
 			if (fout)
 				fclose(fout);
-
 		}
 
 		return true;


### PR DESCRIPTION
Extracts MWS mods to the right directory hopefully.

A MWS mod that has been downloaded should have the `mod.json` found in `remote/mods/author.modname-version/mod.json`

CC @EM4Volts 