### PR TITLE
Fix dangling rpak ref crash

### DIFF
--- a/primedev/core/filesystem/rpakfilesystem.cpp
+++ b/primedev/core/filesystem/rpakfilesystem.cpp
@@ -199,8 +199,6 @@ void PakLoadManager::OnPakUnloading(PakHandle handle)
 	{
 		// you get dangling references if you don't unload all mod paks but have some loaded, these cause crashes if you download mods at runtime for example.
 		g_pPakLoadManager->UnloadAllModPaks();
-		g_pPakLoadManager->CleanUpUnloadedPaks();
-		g_pPakLoadManager->SetForceReloadOnMapLoad(true);
 	}
 
 	// set handle of the mod pak (if any) that has this handle for proper tracking


### PR DESCRIPTION
<!-- 
WHEN OPENING A PULL REQUEST KEEP IN MIND:
-> If the changes you made can be summarised in a screenshot, add one (e.g. you changed the layout of an in-game menu)
-> If the changes you made can be summarised in a screenrecording, add one (e.g. proof that you fixed a certain bug)

-> For fixes, description on how to reproduce the bug are appreciated and help your PR get merged faster
-> For features, description on how to use the feature is appreciated and will help your PR get merged faster

-> Please use a sensible title for your pull request

-> Please describe the changes you made. The easier it is to understand what you changed, the higher the chances of your PR being merged (in a timely manner).

-> If you made multiple independent changes, please make a new PR for each one. This prevents your PR being blocked from merging by one of the changes you made.

Note that commit messages in PRs will generally be squashed to keep commit history clean.
-->

This fixes a crash where if you have a mod that contains an rpak and load/unload another it will crash (see [this comment](https://github.com/Mauler125/r5sdk/blob/c49e0d2123bc3ddb53419005ddd7c6ef73925faf/src/engine/cmodel_bsp.cpp#L1013) in r5sdk). Particularly noticeable with auto-downloaded mods. 

4v will probably be pleased to have this merged.

### Testing:
Have `Northstar.Custom` loaded and try loading/unloading tons of mods that add custom rpaks. Without this patch you should crash fairly consistently, at least on unloading. I didn't test this super vigorously but it did solve it for me.

