### PR TITLE
Add InitScript callback

### DIFF
--- a/primedev/mods/mod.cpp
+++ b/primedev/mods/mod.cpp
@@ -501,22 +501,18 @@ void Mod::ParseInitScript(rapidjson_document& json)
 
 	if (json["InitScript"].IsObject())
 	{
-		auto initScriptMember = json["InitScript"].FindMember("InitScript");
-		auto callbackMember = json["InitScript"].FindMember("Callback");
-		if (initScriptMember == json["InitScript"].MemberEnd() && initScriptMember->value.IsString())
+		if (!json["InitScript"].HasMember("InitScript") || !json["InitScript"]["InitScript"].IsString())
 		{
 			spdlog::warn("'InitScript' member is doesn't exist or isn't a string, skipping...");
 			return;
 		}
+		initScript = json["InitScript"]["InitScript"].GetString();
 
-		initScript = initScriptMember->value.GetString();
-
-		if (callbackMember == json["InitScript"].MemberEnd() && callbackMember->value.IsString())
+		if (!json["InitScript"].HasMember("InitScriptCallback") || !json["InitScript"]["InitScriptCallback"].IsString())
 		{
 			return;
 		}
-
-		initScriptCallBack = std::optional(callbackMember->value.GetString());
+		initScriptCallBack = std::optional(json["InitScript"]["InitScriptCallback"].GetString());
 
 		return;
 	}

--- a/primedev/mods/mod.cpp
+++ b/primedev/mods/mod.cpp
@@ -503,14 +503,16 @@ void Mod::ParseInitScript(rapidjson_document& json)
 	{
 		auto initScriptMember = json["InitScript"].FindMember("InitScript");
 		auto callbackMember = json["InitScript"].FindMember("Callback");
-		if (initScriptMember == json["InitScript"].MemberEnd() && initScriptMember->value.IsString()) {
+		if (initScriptMember == json["InitScript"].MemberEnd() && initScriptMember->value.IsString())
+		{
 			spdlog::warn("'InitScript' member is doesn't exist or isn't a string, skipping...");
 			return;
 		}
 
 		initScript = initScriptMember->value.GetString();
 
-		if (callbackMember == json["InitScript"].MemberEnd() && callbackMember->value.IsString()) {
+		if (callbackMember == json["InitScript"].MemberEnd() && callbackMember->value.IsString())
+		{
 			return;
 		}
 
@@ -518,8 +520,6 @@ void Mod::ParseInitScript(rapidjson_document& json)
 
 		return;
 	}
-
-
 
 	initScript = json["InitScript"].GetString();
 }

--- a/primedev/mods/mod.cpp
+++ b/primedev/mods/mod.cpp
@@ -1,4 +1,5 @@
 #include "rapidjson/error/en.h"
+#include <optional>
 
 Mod::Mod(fs::path modDir, const char* jsonBuf)
 {
@@ -491,11 +492,34 @@ void Mod::ParseInitScript(rapidjson_document& json)
 	if (!json.HasMember("InitScript"))
 		return;
 
-	if (!json["InitScript"].IsString())
+	// to be backwards compatible :)
+	if (!json["InitScript"].IsObject() && !json["InitScript"].IsString())
 	{
-		spdlog::warn("'InitScript' field is not a string, skipping...");
+		spdlog::warn("'InitScript' field is not a string nor an object, skipping...");
 		return;
 	}
+
+	if (json["InitScript"].IsObject())
+	{
+		auto initScriptMember = json["InitScript"].FindMember("InitScript");
+		auto callbackMember = json["InitScript"].FindMember("Callback");
+		if (initScriptMember == json["InitScript"].MemberEnd() && initScriptMember->value.IsString()) {
+			spdlog::warn("'InitScript' member is doesn't exist or isn't a string, skipping...");
+			return;
+		}
+
+		initScript = initScriptMember->value.GetString();
+
+		if (callbackMember == json["InitScript"].MemberEnd() && callbackMember->value.IsString()) {
+			return;
+		}
+
+		initScriptCallBack = std::optional(callbackMember->value.GetString());
+
+		return;
+	}
+
+
 
 	initScript = json["InitScript"].GetString();
 }

--- a/primedev/mods/mod.h
+++ b/primedev/mods/mod.h
@@ -1,3 +1,4 @@
+#include <optional>
 class Mod;
 
 struct ModConVar
@@ -105,6 +106,7 @@ public:
 	std::vector<std::string> LocalisationFiles;
 	// custom script init.nut
 	std::string initScript;
+	std::optional<std::string> initScriptCallBack;
 
 	// other files:
 

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -11,6 +11,7 @@
 #include "ns_version.h"
 #include "core/vanilla.h"
 
+#include "spdlog/spdlog.h"
 #include "vscript/vscript.h"
 
 #include <any>
@@ -376,8 +377,6 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 {
 	bool ret = CSquirrelVM_init<context>(vm, realContext, time);
 
-	g_pPluginManager->InformSqvmCreated(vm);
-
 	for (Mod mod : g_pModManager->m_LoadedMods)
 	{
 		if (mod.m_bEnabled && mod.initScript.size() != 0)
@@ -388,7 +387,20 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 				g_pSquirrel[context]->compilefile(vm, path.c_str(), name.c_str(), 1);
 
 			if (mod.initScriptCallBack.has_value())
-				g_pSquirrel[context]->Call(mod.initScriptCallBack.value().c_str());
+			{
+				// g_pSquirrel[context]->Call can't be used here ...
+				SQObject functionobj {};
+				int result = g_pSquirrel[context]->sq_getfunction(vm->sqvm, mod.initScriptCallBack.value().c_str(), &functionobj, 0);
+				if (result != 0) // This func returns 0 on success for some reason
+				{
+					spdlog::error("InitScript was unable to find function with name '{}'. Is it global?", mod.initScriptCallBack.value());
+					continue;
+				}
+
+				g_pSquirrel[context]->pushobject(vm->sqvm, &functionobj); // Push the function object
+				g_pSquirrel[context]->pushroottable(vm->sqvm);
+				g_pSquirrel[context]->_call(vm->sqvm, 0);
+			}
 		}
 	}
 	return ret;

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -388,7 +388,7 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 				g_pSquirrel[context]->compilefile(vm, path.c_str(), name.c_str(), 1);
 
 			if (mod.initScriptCallBack.has_value())
-					g_pSquirrel[context]->Call(mod.initScriptCallBack.value().c_str());
+				g_pSquirrel[context]->Call(mod.initScriptCallBack.value().c_str());
 		}
 	}
 	return ret;

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -12,6 +12,7 @@
 #include "core/vanilla.h"
 
 #include "spdlog/spdlog.h"
+#include "vscript/languages/squirrel_re/include/squirrel.h"
 #include "vscript/vscript.h"
 
 #include <any>
@@ -391,7 +392,7 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 				// g_pSquirrel[context]->Call can't be used here ...
 				SQObject functionobj {};
 				int result = g_pSquirrel[context]->sq_getfunction(vm->sqvm, mod.initScriptCallBack.value().c_str(), &functionobj, 0);
-				if (result != 0) // This func returns 0 on success for some reason
+				if (result != SQRESULT_NULL)
 				{
 					spdlog::error("InitScript was unable to find function with name '{}'. Is it global?", mod.initScriptCallBack.value());
 					continue;

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -375,6 +375,9 @@ template <ScriptContext context> bool (*CSquirrelVM_init)(CSquirrelVM* vm, Scrip
 template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelVM* vm, ScriptContext realContext, float time)
 {
 	bool ret = CSquirrelVM_init<context>(vm, realContext, time);
+
+	g_pPluginManager->InformSqvmCreated(vm);
+
 	for (Mod mod : g_pModManager->m_LoadedMods)
 	{
 		if (mod.m_bEnabled && mod.initScript.size() != 0)
@@ -383,6 +386,9 @@ template <ScriptContext context> bool __fastcall CSquirrelVM_initHook(CSquirrelV
 			std::string path = std::string("scripts/vscripts/") + mod.initScript;
 			if (g_pSquirrel[context]->compilefile(vm, path.c_str(), name.c_str(), 0))
 				g_pSquirrel[context]->compilefile(vm, path.c_str(), name.c_str(), 1);
+
+			if (mod.initScriptCallBack.has_value())
+					g_pSquirrel[context]->Call(mod.initScriptCallBack.value().c_str());
 		}
 	}
 	return ret;


### PR DESCRIPTION
Allows squirrel to execute code before native functions are registered.
very useful for squirrel meta programming.

new feature in bp_ort that uses this :)
```c
global function BP_ORT_InitCallback

struct SerializableStruct {
    int a,
    string b, 
    array<string> c,
}

void function BP_ORT_InitCallback() {
    SerializableStruct s = { ... };
    s.a = 1;
    s.b = "b";
    s.c = [ "c" ];
     
    BPRegisterTypePun( "SerializableStruct", s )
}
```
**squirrel reflection**