### PR TITLE
Add .dat and .csv to save file extension whitelist

### DIFF
--- a/primedev/mods/modsavefiles.cpp
+++ b/primedev/mods/modsavefiles.cpp
@@ -83,7 +83,7 @@ template <ScriptContext context> void SaveFileManager::SaveFileAsync(fs::path fi
 			}
 
 			// If there's a file extension missing here that you need, feel free to make a PR adding it
-			static const std::set<std::string> whitelist = {".txt", ".json"};
+			static const std::set<std::string> whitelist = {".txt", ".json",".dat",".csv"};
 
 			// Check if file extension is whitelisted
 			std::string extension = file.extension().string();

--- a/primedev/mods/modsavefiles.cpp
+++ b/primedev/mods/modsavefiles.cpp
@@ -83,7 +83,7 @@ template <ScriptContext context> void SaveFileManager::SaveFileAsync(fs::path fi
 			}
 
 			// If there's a file extension missing here that you need, feel free to make a PR adding it
-			static const std::set<std::string> whitelist = {".txt", ".json",".dat",".csv"};
+			static const std::set<std::string> whitelist = {".txt", ".json", ".dat", ".csv"};
 
 			// Check if file extension is whitelisted
 			std::string extension = file.extension().string();


### PR DESCRIPTION
## Add .dat and .csv to save file extension whitelist

### Changes

Extends the `whitelist` set in `modsavefiles.cpp` from `{".txt", ".json"}` to `{".txt", ".json", ".dat", ".csv"}`.

### Motivation

The save file system writes plain text regardless of extension. However, `.txt` and `.json` files are easily recognized by users, who may be tempted to open and hand-edit them out of curiosity — potentially breaking the file format and rendering the save data unusable.

Allowing `.dat` and `.csv` gives mod developers the option to use less “inviting” extensions (especially `.dat`) to discourage casual edits by end users, reducing the likelihood of accidental data corruption and related support issues.

### Security Consideration

Since the underlying write mechanism is identical (plain text via `std::ofstream`), `.dat` and `.csv` carry no additional risk. All existing safeguards — path validation, folder size limits, and NUL character checks — remain in effect.