### PR TITLE
Pin clang version to 16 for formatting in the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-24-11": {
+      "locked": {
+        "lastModified": 1731603435,
+        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1770107345,
@@ -54,6 +70,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-24-11": "nixpkgs-24-11",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    nixpkgs-24-11.url = "github:NixOS/nixpkgs/24.11"; # needed for clang-format-16
+
     flake-utils.url = "github:numtide/flake-utils";
 
     treefmt-nix.url = "github:numtide/treefmt-nix";
@@ -15,6 +17,7 @@
     {
       self,
       nixpkgs,
+      nixpkgs-24-11,
       flake-utils,
       treefmt-nix,
     }:
@@ -135,6 +138,7 @@
 
               # settings
               settings.formatter.clang-format = {
+              	package = nixpkgs-24-11.legacyPackages.${system}.llvmPackages_16.clang-tools;
                 args = [
                   "-i"
                   "--style=file"

--- a/flake.nix
+++ b/flake.nix
@@ -139,14 +139,19 @@
               # settings
               settings.formatter.clang-format = {
                 package = nixpkgs-24-11.legacyPackages.${system}.llvmPackages_16.clang-tools;
-                args = [
+                command = "${nixpkgs-24-11.legacyPackages.${system}.llvmPackages_16.clang-tools}/bin/clang-format";
+                options = [
                   "-i"
                   "--style=file"
                 ];
                 excludes = [
                   "primedev/include/**"
-                  "primedev/*.cpp"
-                  "primedev/*.h"
+                  "primedev/thirdparty/**"
+                  "primedev/wsockproxy/**"
+                  "primedev/dllmain.cpp"
+                  "primedev/ns_version.h"
+                  "primedev/pch.h"
+                  "primedev/resource1.h"
                 ];
               };
             }

--- a/flake.nix
+++ b/flake.nix
@@ -138,7 +138,7 @@
 
               # settings
               settings.formatter.clang-format = {
-              	package = nixpkgs-24-11.legacyPackages.${system}.llvmPackages_16.clang-tools;
+                package = nixpkgs-24-11.legacyPackages.${system}.llvmPackages_16.clang-tools;
                 args = [
                   "-i"
                   "--style=file"


### PR DESCRIPTION
Apparently clang versions matter massively for formatting and since the ci uses clang 16 setting the clang-format version in the flake fixes any formatting differences. this does require adding an older nixpkgs version since newer version no longer package clang 16 lol