### PR TITLE
Add an option to not allocate the console

### DIFF
--- a/primedev/logging/logging.cpp
+++ b/primedev/logging/logging.cpp
@@ -122,8 +122,10 @@ void CustomSink::custom_log(const custom_log_msg& msg)
 
 void InitialiseConsole()
 {
-	if (AllocConsole() != FALSE)
-	{
+	if (strstr(GetCommandLineA(), "-noallocconsole")) {
+		FreeConsole();
+		return;
+	} else if (AllocConsole() != FALSE)	{
 		freopen("CONOUT$", "w", stdout);
 		freopen("CONOUT$", "w", stderr);
 	}

--- a/primedev/logging/logging.cpp
+++ b/primedev/logging/logging.cpp
@@ -122,10 +122,13 @@ void CustomSink::custom_log(const custom_log_msg& msg)
 
 void InitialiseConsole()
 {
-	if (strstr(GetCommandLineA(), "-noallocconsole")) {
+	if (strstr(GetCommandLineA(), "-noallocconsole"))
+	{
 		FreeConsole();
 		return;
-	} else if (AllocConsole() != FALSE)	{
+	}
+	else if (AllocConsole() != FALSE)
+	{
 		freopen("CONOUT$", "w", stdout);
 		freopen("CONOUT$", "w", stderr);
 	}


### PR DESCRIPTION
on linux the default wine console is just ugly and frankly unreadable so this pr adds an option to disable it. log files are good enough most of the time.

it's `-noallocconsole` btw