### PR TITLE
Cache nix builds on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
-          nix run nixpkgs#attic-client -- push northstar result/
+          nix run nixpkgs#attic-client -- push northstar $(nix build .#yourPackage --print-out-paths)
 
   format-check-cmake-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,12 @@ jobs:
       - name: Build
         run: nix build
 
-      - name: Login into Cache Server
+      - name: Cache this Build
         continue-on-error: true
-        run: nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
-
-      - name: Upload Artifacts to Cache
-        continue-on-error: true
-        run: nix run nixpkgs#attic-client -- push northstar result/
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: |
+          nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
+          nix run nixpkgs#attic-client -- push northstar result/
 
   format-check-cmake-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,17 +96,13 @@ jobs:
       - name: Build
         run: nix build
 
-      - name: Extract Short Commit Hash
-        id: extract
-        shell: bash
-        run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+      - name: Login into Cache Server
+        continue-on-error: true
+        run: nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
 
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: NorthstarLauncher-NIX-${{ steps.extract.outputs.commit }}
-          path: |
-            result/
+      - name: Upload Artifacts to Cache
+        continue-on-error: true
+        run: nix run nixpkgs#attic-client -- push northstar result/
 
   format-check-cmake-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
-          nix run nixpkgs#attic-client -- push northstar $(nix build .#yourPackage --print-out-paths)
+          nix run nixpkgs#attic-client -- push northstar $(nix build --print-out-paths)
 
   format-check-cmake-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,13 +96,17 @@ jobs:
       - name: Build
         run: nix build
 
-      - name: Login into Cache Server
-        continue-on-error: true
-        run: nix run nixpkgs#attic-client -- login northstar https://attic.catornot.net ${{ secrets.ATTIC_CACHE_TOKEN }}
+      - name: Extract Short Commit Hash
+        id: extract
+        shell: bash
+        run: echo commit=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
 
-      - name: Upload Artifacts to Cache
-        continue-on-error: true
-        run: nix run nixpkgs#attic-client -- push northstar result/
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: NorthstarLauncher-NIX-${{ steps.extract.outputs.commit }}
+          path: |
+            result/
 
   format-check-cmake-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pr replaces the artifact uploads for the nix build with a step to push the build to caching server. 

ik this pr is only relevant to a small subset of people but this would be used in a future release pipeline rewrite so this is very important!

the secrets should be already setup in repos.

will also implement this in discord rpc repo and nothstar plugins repo :)

this is the server's public key : `northstar:H8QBUAeduEw6jGl3HtGeW/79pMPv7wSCAv8BSUon3kw=`
the server is found at `https://attic.catornot.net/northstar`

a draft for now until I test this in https://github.com/catornot/northstar-nightly