### PR TITLE
Default compile constants to 0 if not defined 

### DIFF
--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -20,7 +20,7 @@
 AUTOHOOK_INIT()
 
 SquirrelManagerManager g_pSquirrel;
-
+thread_local SQCompiler* pIfDirectiveCompiler;
 std::shared_ptr<ColoredLogger> getSquirrelLoggerByContext(ScriptContext context)
 {
 	switch (context)
@@ -326,9 +326,43 @@ bool IsUIVM(ScriptContext context, HSQUIRRELVM pSqvm)
 	return ScriptContext(pSqvm->sharedState->cSquirrelVM->vmContext) == ScriptContext::UI;
 }
 
+template <ScriptContext context> std::int64_t (*SQCompiler_ParseDirective)(SQCompiler* pCompiler);
+template <ScriptContext context> std::int64_t __fastcall SQCompiler_ParseDirectiveHook(SQCompiler* pCompiler)
+{
+	SQCompiler* pPreviousCompiler = pIfDirectiveCompiler;
+	pIfDirectiveCompiler = pCompiler;
+	const std::int64_t result = SQCompiler_ParseDirective<context>(pCompiler);
+	pIfDirectiveCompiler = pPreviousCompiler;
+	return result;
+}
+
+template <ScriptContext context>
+bool (*SQCompiler_ResolveLocalOrConstant)(void* pFunctionState, SQObject* pIdentifier, SQObject* pValue, std::uintptr_t* pType);
+template <ScriptContext context>
+bool __fastcall SQCompiler_ResolveLocalOrConstantHook(
+    void* pFunctionState, SQObject* pIdentifier, SQObject* pValue, std::uintptr_t* pType)
+{
+	if (SQCompiler_ResolveLocalOrConstant<context>(pFunctionState, pIdentifier, pValue, pType))
+		return true;
+
+	if (!pIfDirectiveCompiler || pIfDirectiveCompiler->preprocessorDepth <= 0)
+		return false;
+
+	// evaluate to 0 if we're doing directives because #if with a compile error is stupid
+	pValue->_Type = OT_INTEGER;
+	pValue->structNumber = 0;
+	pValue->_VAL.as64Integer = 0;
+	constexpr std::uint32_t typeHash = 0x9E3779B9u - 0x61C88647u * static_cast<std::uint32_t>(OT_INTEGER);
+	constexpr std::size_t typeIndex = (typeHash / 0xF499u) & 0x3FFFu;
+	SQSharedState* pSharedState = pIfDirectiveCompiler->pSQVM->sharedState;
+	*pType = reinterpret_cast<std::uintptr_t>(&pSharedState->compilerTypeDescriptors[typeIndex]);
+	return true;
+}
+
 template <ScriptContext context> void* (*sq_compiler_create)(HSQUIRRELVM sqvm, void* a2, void* a3, SQBool bShouldThrowError);
 template <ScriptContext context> void* __fastcall sq_compiler_createHook(HSQUIRRELVM sqvm, void* a2, void* a3, SQBool bShouldThrowError)
 {
+	pIfDirectiveCompiler = nullptr;
 	// store whether errors generated from this compile should be fatal
 	if (IsUIVM(context, sqvm))
 		g_pSquirrel[ScriptContext::UI]->m_bFatalCompilationErrors = bShouldThrowError;
@@ -789,6 +823,11 @@ ON_DLL_LOAD_RELIESON("client.dll", ClientSquirrel, ConCommand, (CModule module))
 
 	MAKEHOOK(module.Offset(0x8AD0), &sq_compiler_createHook<ScriptContext::CLIENT>, &sq_compiler_create<ScriptContext::CLIENT>);
 
+	MAKEHOOK(module.Offset(0x58590), &SQCompiler_ParseDirectiveHook<ScriptContext::CLIENT>,
+	         &SQCompiler_ParseDirective<ScriptContext::CLIENT>);
+	MAKEHOOK(module.Offset(0x65CB0), &SQCompiler_ResolveLocalOrConstantHook<ScriptContext::CLIENT>,
+	         &SQCompiler_ResolveLocalOrConstant<ScriptContext::CLIENT>);
+
 	MAKEHOOK(module.Offset(0x12B00), &SQPrintHook<ScriptContext::CLIENT>, &SQPrint<ScriptContext::CLIENT>);
 	MAKEHOOK(module.Offset(0x12BA0), &SQPrintHook<ScriptContext::UI>, &SQPrint<ScriptContext::UI>);
 
@@ -867,6 +906,11 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, (CModule module))
 		&g_pSquirrel[ScriptContext::SERVER]->RegisterSquirrelFunc);
 
 	MAKEHOOK(module.Offset(0x8AA0), &sq_compiler_createHook<ScriptContext::SERVER>, &sq_compiler_create<ScriptContext::SERVER>);
+
+	MAKEHOOK(module.Offset(0x58530), &SQCompiler_ParseDirectiveHook<ScriptContext::SERVER>,
+	         &SQCompiler_ParseDirective<ScriptContext::SERVER>);
+	MAKEHOOK(module.Offset(0x65C50), &SQCompiler_ResolveLocalOrConstantHook<ScriptContext::SERVER>,
+	         &SQCompiler_ResolveLocalOrConstant<ScriptContext::SERVER>);
 
 	MAKEHOOK(module.Offset(0x1FE90), &SQPrintHook<ScriptContext::SERVER>, &SQPrint<ScriptContext::SERVER>);
 	MAKEHOOK(module.Offset(0x260E0), &CreateNewVMHook<ScriptContext::SERVER>, &CreateNewVM<ScriptContext::SERVER>);

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -339,8 +339,7 @@ template <ScriptContext context> std::int64_t __fastcall SQCompiler_ParseDirecti
 template <ScriptContext context>
 bool (*SQCompiler_ResolveLocalOrConstant)(void* pFunctionState, SQObject* pIdentifier, SQObject* pValue, std::uintptr_t* pType);
 template <ScriptContext context>
-bool __fastcall SQCompiler_ResolveLocalOrConstantHook(
-    void* pFunctionState, SQObject* pIdentifier, SQObject* pValue, std::uintptr_t* pType)
+bool __fastcall SQCompiler_ResolveLocalOrConstantHook(void* pFunctionState, SQObject* pIdentifier, SQObject* pValue, std::uintptr_t* pType)
 {
 	if (SQCompiler_ResolveLocalOrConstant<context>(pFunctionState, pIdentifier, pValue, pType))
 		return true;
@@ -823,10 +822,12 @@ ON_DLL_LOAD_RELIESON("client.dll", ClientSquirrel, ConCommand, (CModule module))
 
 	MAKEHOOK(module.Offset(0x8AD0), &sq_compiler_createHook<ScriptContext::CLIENT>, &sq_compiler_create<ScriptContext::CLIENT>);
 
-	MAKEHOOK(module.Offset(0x58590), &SQCompiler_ParseDirectiveHook<ScriptContext::CLIENT>,
-	         &SQCompiler_ParseDirective<ScriptContext::CLIENT>);
-	MAKEHOOK(module.Offset(0x65CB0), &SQCompiler_ResolveLocalOrConstantHook<ScriptContext::CLIENT>,
-	         &SQCompiler_ResolveLocalOrConstant<ScriptContext::CLIENT>);
+	MAKEHOOK(
+		module.Offset(0x58590), &SQCompiler_ParseDirectiveHook<ScriptContext::CLIENT>, &SQCompiler_ParseDirective<ScriptContext::CLIENT>);
+	MAKEHOOK(
+		module.Offset(0x65CB0),
+		&SQCompiler_ResolveLocalOrConstantHook<ScriptContext::CLIENT>,
+		&SQCompiler_ResolveLocalOrConstant<ScriptContext::CLIENT>);
 
 	MAKEHOOK(module.Offset(0x12B00), &SQPrintHook<ScriptContext::CLIENT>, &SQPrint<ScriptContext::CLIENT>);
 	MAKEHOOK(module.Offset(0x12BA0), &SQPrintHook<ScriptContext::UI>, &SQPrint<ScriptContext::UI>);
@@ -907,10 +908,12 @@ ON_DLL_LOAD_RELIESON("server.dll", ServerSquirrel, ConCommand, (CModule module))
 
 	MAKEHOOK(module.Offset(0x8AA0), &sq_compiler_createHook<ScriptContext::SERVER>, &sq_compiler_create<ScriptContext::SERVER>);
 
-	MAKEHOOK(module.Offset(0x58530), &SQCompiler_ParseDirectiveHook<ScriptContext::SERVER>,
-	         &SQCompiler_ParseDirective<ScriptContext::SERVER>);
-	MAKEHOOK(module.Offset(0x65C50), &SQCompiler_ResolveLocalOrConstantHook<ScriptContext::SERVER>,
-	         &SQCompiler_ResolveLocalOrConstant<ScriptContext::SERVER>);
+	MAKEHOOK(
+		module.Offset(0x58530), &SQCompiler_ParseDirectiveHook<ScriptContext::SERVER>, &SQCompiler_ParseDirective<ScriptContext::SERVER>);
+	MAKEHOOK(
+		module.Offset(0x65C50),
+		&SQCompiler_ResolveLocalOrConstantHook<ScriptContext::SERVER>,
+		&SQCompiler_ResolveLocalOrConstant<ScriptContext::SERVER>);
 
 	MAKEHOOK(module.Offset(0x1FE90), &SQPrintHook<ScriptContext::SERVER>, &SQPrint<ScriptContext::SERVER>);
 	MAKEHOOK(module.Offset(0x260E0), &CreateNewVMHook<ScriptContext::SERVER>, &CreateNewVM<ScriptContext::SERVER>);

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -351,7 +351,7 @@ bool __fastcall SQCompiler_ResolveLocalOrConstantHook(void* pFunctionState, SQOb
 	pValue->_Type = OT_INTEGER;
 	pValue->structNumber = 0;
 	pValue->_VAL.as64Integer = 0;
-	constexpr std::uint32_t typeHashMagic  = 0x9E3779B9u - 0x61C88647u;
+	constexpr std::uint32_t typeHashMagic = 0x9E3779B9u - 0x61C88647u;
 	constexpr std::uint32_t typeHash = typeHashMagic * static_cast<std::uint32_t>(OT_INTEGER);
 	constexpr std::size_t typeIndex = (typeHash / 0xF499u) & 0x3FFFu;
 	SQSharedState* pSharedState = pIfDirectiveCompiler->pSQVM->sharedState;

--- a/primedev/squirrel/squirrel.cpp
+++ b/primedev/squirrel/squirrel.cpp
@@ -343,7 +343,7 @@ bool __fastcall SQCompiler_ResolveLocalOrConstantHook(void* pFunctionState, SQOb
 {
 	if (SQCompiler_ResolveLocalOrConstant<context>(pFunctionState, pIdentifier, pValue, pType))
 		return true;
-
+	// if we're not in a preprocessor directive, we don't want to resolve the identifier as a constant
 	if (!pIfDirectiveCompiler || pIfDirectiveCompiler->preprocessorDepth <= 0)
 		return false;
 
@@ -351,7 +351,8 @@ bool __fastcall SQCompiler_ResolveLocalOrConstantHook(void* pFunctionState, SQOb
 	pValue->_Type = OT_INTEGER;
 	pValue->structNumber = 0;
 	pValue->_VAL.as64Integer = 0;
-	constexpr std::uint32_t typeHash = 0x9E3779B9u - 0x61C88647u * static_cast<std::uint32_t>(OT_INTEGER);
+	constexpr std::uint32_t typeHashMagic  = 0x9E3779B9u - 0x61C88647u;
+	constexpr std::uint32_t typeHash = typeHashMagic * static_cast<std::uint32_t>(OT_INTEGER);
 	constexpr std::size_t typeIndex = (typeHash / 0xF499u) & 0x3FFFu;
 	SQSharedState* pSharedState = pIfDirectiveCompiler->pSQVM->sharedState;
 	*pType = reinterpret_cast<std::uintptr_t>(&pSharedState->compilerTypeDescriptors[typeIndex]);

--- a/primedev/squirrel/squirrelautobind.h
+++ b/primedev/squirrel/squirrelautobind.h
@@ -21,16 +21,16 @@ class __squirrelautobind;
 		__squirrelautobind CONCAT2(__squirrelautobind, __LINE__)(                                                                          \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext) & ScriptContext::UI)                                                                          \
+				if constexpr ((runOnContext)&ScriptContext::UI)                                                                            \
 					g_pSquirrel[ScriptContext::UI]->AddFuncRegistration(                                                                   \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::UI >);                \
-				if constexpr ((runOnContext) & ScriptContext::CLIENT)                                                                      \
+				if constexpr ((runOnContext)&ScriptContext::CLIENT)                                                                        \
 					g_pSquirrel[ScriptContext::CLIENT]->AddFuncRegistration(                                                               \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::CLIENT >);            \
 			},                                                                                                                             \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext) & ScriptContext::SERVER)                                                                      \
+				if constexpr ((runOnContext)&ScriptContext::SERVER)                                                                        \
 					g_pSquirrel[ScriptContext::SERVER]->AddFuncRegistration(                                                               \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::SERVER >);            \
 			});                                                                                                                            \
@@ -44,15 +44,15 @@ class __squirrelautobind;
 		__squirrelautobind CONCAT2(__squirrelautobind, __LINE__)(                                                                          \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext) & ScriptContext::UI)                                                                          \
+				if constexpr ((runOnContext)&ScriptContext::UI)                                                                            \
 					g_pSquirrel[ScriptContext::UI]->AddFuncOverride(__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::UI >);    \
-				if constexpr ((runOnContext) & ScriptContext::CLIENT)                                                                      \
+				if constexpr ((runOnContext)&ScriptContext::CLIENT)                                                                        \
 					g_pSquirrel[ScriptContext::CLIENT]->AddFuncOverride(                                                                   \
 						__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::CLIENT >);                                            \
 			},                                                                                                                             \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext) & ScriptContext::SERVER)                                                                      \
+				if constexpr ((runOnContext)&ScriptContext::SERVER)                                                                        \
 					g_pSquirrel[ScriptContext::SERVER]->AddFuncOverride(                                                                   \
 						__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::SERVER >);                                            \
 			});                                                                                                                            \

--- a/primedev/squirrel/squirrelautobind.h
+++ b/primedev/squirrel/squirrelautobind.h
@@ -21,16 +21,16 @@ class __squirrelautobind;
 		__squirrelautobind CONCAT2(__squirrelautobind, __LINE__)(                                                                          \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext)&ScriptContext::UI)                                                                            \
+				if constexpr ((runOnContext) & ScriptContext::UI)                                                                          \
 					g_pSquirrel[ScriptContext::UI]->AddFuncRegistration(                                                                   \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::UI >);                \
-				if constexpr ((runOnContext)&ScriptContext::CLIENT)                                                                        \
+				if constexpr ((runOnContext) & ScriptContext::CLIENT)                                                                      \
 					g_pSquirrel[ScriptContext::CLIENT]->AddFuncRegistration(                                                               \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::CLIENT >);            \
 			},                                                                                                                             \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext)&ScriptContext::SERVER)                                                                        \
+				if constexpr ((runOnContext) & ScriptContext::SERVER)                                                                      \
 					g_pSquirrel[ScriptContext::SERVER]->AddFuncRegistration(                                                               \
 						returnType, __STR(funcName), argTypes, helpText, CONCAT2(Script_, funcName) < ScriptContext::SERVER >);            \
 			});                                                                                                                            \
@@ -44,15 +44,15 @@ class __squirrelautobind;
 		__squirrelautobind CONCAT2(__squirrelautobind, __LINE__)(                                                                          \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext)&ScriptContext::UI)                                                                            \
+				if constexpr ((runOnContext) & ScriptContext::UI)                                                                          \
 					g_pSquirrel[ScriptContext::UI]->AddFuncOverride(__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::UI >);    \
-				if constexpr ((runOnContext)&ScriptContext::CLIENT)                                                                        \
+				if constexpr ((runOnContext) & ScriptContext::CLIENT)                                                                      \
 					g_pSquirrel[ScriptContext::CLIENT]->AddFuncOverride(                                                                   \
 						__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::CLIENT >);                                            \
 			},                                                                                                                             \
 			[]()                                                                                                                           \
 			{                                                                                                                              \
-				if constexpr ((runOnContext)&ScriptContext::SERVER)                                                                        \
+				if constexpr ((runOnContext) & ScriptContext::SERVER)                                                                      \
 					g_pSquirrel[ScriptContext::SERVER]->AddFuncOverride(                                                                   \
 						__STR(funcName), CONCAT2(Script_, funcName) < ScriptContext::SERVER >);                                            \
 			});                                                                                                                            \

--- a/primedev/vscript/languages/squirrel_re/squirrel/sqcompiler.h
+++ b/primedev/vscript/languages/squirrel_re/squirrel/sqcompiler.h
@@ -14,7 +14,9 @@ struct SQCompiler
 	int64_t qword98;
 	BYTE gapA0[280];
 	bool bFatalError;
-	BYTE gap1B9[143];
+	BYTE gap1B9[11];
+	int preprocessorDepth;
+	BYTE gap1C8[128];
 	int64_t qword248;
 	int64_t qword250;
 	int64_t qword258;

--- a/primedev/vscript/languages/squirrel_re/squirrel/sqstate.h
+++ b/primedev/vscript/languages/squirrel_re/squirrel/sqstate.h
@@ -58,7 +58,9 @@ struct SQSharedState
 	SQTable* _entityTypesMaybe;
 	SQObjectType unknownTable2Type;
 	SQTable* unknownTable2;
-	unsigned char gap_41D8[64];
+	unsigned char gap_41D8[16];
+	SQObject* compilerTypeDescriptors;
+	unsigned char gap_41F0[40];
 	SQCompiler* pCompiler;
 	SQObjectType _compilerKeywordsType;
 	SQTable* _compilerKeywords;


### PR DESCRIPTION
Default compile time constants like `#ifdef VANILLIA` to 0 if they do not exist. 