### PR TITLE
Custom packet handler to extend the Connectionless protocol

### DIFF
--- a/primedev/Northstar.cmake
+++ b/primedev/Northstar.cmake
@@ -61,6 +61,8 @@ add_library(
     "dedicated/dedicatedlogtoclient.cpp"
     "dedicated/dedicatedlogtoclient.h"
     "dedicated/dedicatedmaterialsystem.cpp"
+    "engine/custom_packet_handler.cpp"
+    "engine/custom_packet_handler.h"
     "engine/gl_matsysiface.cpp"
     "engine/host.cpp"
     "engine/hoststate.cpp"

--- a/primedev/engine/custom_packet_handler.cpp
+++ b/primedev/engine/custom_packet_handler.cpp
@@ -1,0 +1,75 @@
+#include "engine/custom_packet_handler.h"
+#include "r2engine.h"
+#include <shared/exploit_fixes/ns_limits.h>
+
+CustomPacketHandler* g_pCustomPacketHandler;
+
+static const std::unordered_set<uint8_t> nativeHandlers({0x41, 0x48, 0x49, 0x4E}); // Not sure if there are others... probably!
+
+bool (*CustomPacketHandler::o_pHandlePacket)(void* packetHandler, netpacket_s* packet) = nullptr;
+bool CustomPacketHandler::h_HandlePacket(void* packetHandler, netpacket_s* packet)
+{
+	if (packet->size >= 5)
+	{
+		uint32_t header = *reinterpret_cast<uint32_t*>(packet->data);
+
+		// packet->data consists of 0xFFFFFFFF (int32 -1) to indicate packets aren't split, followed by a header consisting of a single
+		// character, which is used to uniquely identify the packet kind. Most kinds follow this with a null-terminated string payload
+		// then an arbitrary amoount of data.
+		if (header == 0xFFFFFFFF)
+		{
+			uint8_t controller = packet->data[sizeof(header)];
+
+			if (g_pCustomPacketHandler->customHandlers.contains(controller))
+			{
+				bool shouldFallback = true;
+				const auto callback = g_pCustomPacketHandler->customHandlers.at(controller);
+				callback(packetHandler, packet, shouldFallback);
+
+				if (!shouldFallback)
+				{
+					return true;
+				}
+			}
+		}
+	}
+
+	// check rate limits for the original unconnected packets
+	if (!g_pServerLimits->CheckConnectionlessPacketLimits(packet))
+	{
+		return false;
+	}
+
+	return o_pHandlePacket(packetHandler, packet);
+}
+
+ON_DLL_LOAD("engine.dll", CustomPacketHandler, (CModule module))
+{
+	g_pCustomPacketHandler = new CustomPacketHandler;
+}
+
+bool CustomPacketHandler::RegisterPacketHandler(uint8_t controller, CustomPacketHandlerType handler)
+{
+
+	if (customHandlers.contains(controller))
+	{
+		NS::log::NORTHSTAR->error("Tried to register a custom packet handler for {}, which is already taken", controller);
+		return false;
+	}
+
+	if (nativeHandlers.contains(controller))
+	{
+		NS::log::NORTHSTAR->error("Tried to register a custom packet handler for {}, which is already a native handler", controller);
+		return false;
+	}
+
+	customHandlers.insert(std::make_pair(controller, handler));
+	return true;
+}
+
+CustomPacketHandler::CustomPacketHandler()
+{
+	const auto module = CModule("engine.dll");
+	o_pHandlePacket = module.Offset(0x117800).RCast<decltype(o_pHandlePacket)>();
+	HookAttach(&(PVOID&)o_pHandlePacket, (PVOID)h_HandlePacket);
+}

--- a/primedev/engine/custom_packet_handler.h
+++ b/primedev/engine/custom_packet_handler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+struct CustomPacketHandler
+{
+	typedef void (*CustomPacketHandlerType)(void* packetHandler, struct netpacket_s* packet, OUT bool& runOriginalHandler);
+
+public:
+	bool RegisterPacketHandler(uint8_t controller, CustomPacketHandlerType handler);
+
+	CustomPacketHandler();
+
+private:
+	static bool (*o_pHandlePacket)(void* packetHandler, netpacket_s* packet);
+	static bool h_HandlePacket(void* packetHandler, netpacket_s* packet);
+
+	std::unordered_map<uint8_t, CustomPacketHandlerType> customHandlers {};
+};
+
+extern CustomPacketHandler* g_pCustomPacketHandler;

--- a/primedev/server/servernethooks.cpp
+++ b/primedev/server/servernethooks.cpp
@@ -201,7 +201,9 @@ ON_DLL_LOAD_RELIESON("engine.dll", ServerAtlasPacketHandler, CustomPacketHandler
 {
 	assert(g_pCustomPacketHandler);
 	g_pCustomPacketHandler->RegisterPacketHandler(
-		'T', [](void* handler, netpacket_s* packet, OUT bool& executeOriginalHandler) {
+		'T',
+		[](void* handler, netpacket_s* packet, OUT bool& executeOriginalHandler)
+		{
 			ProcessAtlasConnectionlessPacket(packet);
 			executeOriginalHandler = false;
 		});

--- a/primedev/server/servernethooks.cpp
+++ b/primedev/server/servernethooks.cpp
@@ -2,6 +2,7 @@
 #include "engine/r2engine.h"
 #include "shared/exploit_fixes/ns_limits.h"
 #include "masterserver/masterserver.h"
+#include "engine/custom_packet_handler.h"
 
 #include <string>
 #include <thread>
@@ -168,27 +169,6 @@ static void ProcessAtlasConnectionlessPacket(netpacket_t* packet)
 	return;
 }
 
-AUTOHOOK(ProcessConnectionlessPacket, engine.dll + 0x117800, bool, , (void* a1, netpacket_t* packet))
-{
-	// packet->data consists of 0xFFFFFFFF (int32 -1) to indicate packets aren't split, followed by a header consisting of a single
-	// character, which is used to uniquely identify the packet kind. Most kinds follow this with a null-terminated string payload
-	// then an arbitrary amoount of data.
-
-	// T (no rate limits since we authenticate packets before doing anything expensive)
-	if (4 < packet->size && packet->data[4] == 'T')
-	{
-		ProcessAtlasConnectionlessPacket(packet);
-		return false;
-	}
-
-	// check rate limits for the original unconnected packets
-	if (!g_pServerLimits->CheckConnectionlessPacketLimits(packet))
-		return false;
-
-	// A, H, I, N
-	return ProcessConnectionlessPacket(a1, packet);
-}
-
 ON_DLL_LOAD_RELIESON("engine.dll", ServerNetHooks, ConVar, (CModule module))
 {
 	AUTOHOOK_DISPATCH_MODULE(engine.dll)
@@ -215,4 +195,14 @@ ON_DLL_LOAD_RELIESON("engine.dll", ServerNetHooks, ConVar, (CModule module))
 		"0",
 		FCVAR_NONE,
 		"Whether to disable signature verification for Atlas connectionless packets (DANGEROUS: this allows anyone to impersonate Atlas)");
+}
+
+ON_DLL_LOAD_RELIESON("engine.dll", ServerAtlasPacketHandler, CustomPacketHandler, (CModule module))
+{
+	assert(g_pCustomPacketHandler);
+	g_pCustomPacketHandler->RegisterPacketHandler(
+		'T', [](void* handler, netpacket_s* packet, OUT bool& executeOriginalHandler) {
+			ProcessAtlasConnectionlessPacket(packet);
+			executeOriginalHandler = false;
+		});
 }

--- a/primedev/shared/exploit_fixes/exploitfixes.cpp
+++ b/primedev/shared/exploit_fixes/exploitfixes.cpp
@@ -452,7 +452,7 @@ bool, __fastcall, (void* a1))
 // Pasted from R1Delta: (https://github.com/r1delta/r1delta/blob/f04cc67e6247c5e15633b95f84fc69eca7252dc6/engine/security_fixes.cpp#L811)
 // (thanks wanderer)
 // clang-format off
-AUTOHOOK(NET_ReceiveDatagram, engine.dll + 0x21B520, bool, __fastcall, (int sock, netpacket_t* packet, bool encrypted))
+AUTOHOOK(NET_ReceiveDatagram, engine.dll + 0x21B520, bool, __fastcall, (uint32_t sockIndex, netpacket_t* packet, bool encrypted))
 // clang-format on
 {
 	for (int i = Cvar_ns_recvfrom_per_frame_limit->GetInt(); i > 0; i--)
@@ -460,7 +460,7 @@ AUTOHOOK(NET_ReceiveDatagram, engine.dll + 0x21B520, bool, __fastcall, (int sock
 		if (net_error)
 			*net_error = 0;
 
-		if (NET_ReceiveDatagram(sock, packet, encrypted))
+		if (NET_ReceiveDatagram(sockIndex, packet, encrypted))
 			return true;
 
 		if (net_error && *net_error)


### PR DESCRIPTION
Created a custom packet handler so that the connectionless protocol can be extended safely and easily in more than 1 place. This is a prerequisite for LAN discovery (which needs a discovery message to be registered).
I've also taken the liberty of renaming a var in the NET_ReceiveDatagram because it is misnomed - it assumes a socket is being passed when it is the _socket index_ that is passed, the game registers and manages four sockets and this is an index of that.

### Testing:

I've tested it with LAN mode and the custom packet handler works well, but I don't know how to test the original "Atlas" packet because my game never seems to receive it (breakpoint never hits)
