### PR TITLE
Hopefix stack corruption that occured here one time?

### DIFF
--- a/primedev/rtech/rui.cpp
+++ b/primedev/rtech/rui.cpp
@@ -48,11 +48,12 @@ void h_gamestate_info_ffa(RuiFunctions_t* funcs, RuiGlobals* globals, RuiInstanc
 
 	float endTime = data->endTime;
 	float timeLeft = endTime - globals->currentTime;
-	char* buffer = (char*)alloca(2048);
-	strcpy_s(buffer, 2048, data->statusText);
+	char buffer[2048] {};
+	strcpy_s(buffer, ARRAYSIZE(buffer) - 1, data->statusText);
+
 	if (strcmp(buffer, "") == 0)
 	{
-		strcpy_s(buffer, 2048, "#PL_ffa");
+		strcpy_s(buffer, ARRAYSIZE(buffer) - 1, "#PL_ffa");
 	}
 
 	if (timeLeft < 0.0f || endTime == -1.0e30f)


### PR DESCRIPTION
I had a corruption error here once, as if more data had been copied to the array than there should be. It might have been entirely intermittent but the debugger pointed to this line as the culprit.

I'm not sure why exactly and this error disappeared once I put this fix in place, so that might be it? It looks rather safe so I thought i'd share it. If it's not appropriate or relevant, feel free to close PR and move on

Since the buffer is set to zero with {}, null termination is mandatory, so copying 2048-1 bytes ensure that the buffer will always be null terminated no matter the length of 'statusText'. When I checked it with a debugger it didn't seem usually that long but... it's technically possible that it would be, I suppose