### PR TITLE
Feature/lan discovery

### DIFF
--- a/primedev/Northstar.cmake
+++ b/primedev/Northstar.cmake
@@ -70,6 +70,8 @@ add_library(
     "engine/r2engine.h"
     "engine/runframe.cpp"
     "game/client/clientmode_shared.cpp"
+    "lan/lan.cpp"
+    "lan/lan.h"
     "logging/crashhandler.cpp"
     "logging/crashhandler.h"
     "logging/logging.cpp"

--- a/primedev/dedicated/dedicated.cpp
+++ b/primedev/dedicated/dedicated.cpp
@@ -71,8 +71,10 @@ void RunServer(CDedicatedExports* dedicated)
 // use server presence to update window title
 class DedicatedConsoleServerPresence : public ServerPresenceReporter
 {
-	void ReportPresence(const ServerPresence* pServerPresence) override
+	void ReportPresence(double flCurrentTime, const ServerPresence* pServerPresence) override
 	{
+		ServerPresenceReporter::ReportPresence(flCurrentTime, pServerPresence);
+
 		SetConsoleTitleA(fmt::format(
 							 "{} - {} {}/{} players ({})",
 							 pServerPresence->m_sServerName,

--- a/primedev/lan/lan.cpp
+++ b/primedev/lan/lan.cpp
@@ -16,7 +16,7 @@ constexpr char LAN_BROADCAST_SCAN_MSG[] = "\xFF\xFF\xFF\xFF"
 
 Lan* g_pLan;
 
-Lan::Lan(bool isLanMode)
+Lan::Lan()
 	: m_bIsBroadcastSocketOK(false)
 	, m_broadcastEndpointSize(0)
 	, m_broadcastSocket(0)
@@ -26,19 +26,16 @@ Lan::Lan(bool isLanMode)
 	if (bInitialised)
 		return;
 
-	if (isLanMode)
-	{
-		const auto wVersionRequested = MAKEWORD(2, 2);
-		WSADATA wsaData;
-		int lastError = WSAStartup(wVersionRequested, &wsaData);
-		assert(!lastError);
+	const auto wVersionRequested = MAKEWORD(2, 2);
+	WSADATA wsaData;
+	int lastError = WSAStartup(wVersionRequested, &wsaData);
+	assert(!lastError);
 
-		isLanMode &= lastError == ERROR_SUCCESS;
-		SetupBroadcastSocket();
-	}
+	const bool isLanAvailable = lastError == ERROR_SUCCESS;
+	SetupBroadcastSocket();
 
 	bInitialised = true;
-	m_bIsLanMode = isLanMode;
+	m_bIsLanAvailable = isLanAvailable;
 }
 
 std::vector<ServerPresence> Lan::ScanForServers()
@@ -275,11 +272,21 @@ void Lan::SetupBroadcastSocket()
 	this->m_bIsBroadcastSocketOK = lastError == ERROR_SUCCESS;
 }
 
-void Lan::LanServerReporter::ReportPresence(const ServerPresence* pServerPresence)
+void Lan::LanServerReporter::ReportPresence(double flCurrentTime, const ServerPresence* pServerPresence)
 {
 	// Send unicast to broadcasting clients - default Windows firewall allows a single unicast response to a broadcast within 3
 	// seconds of the emitted broadcast, so broadcasting has to be a client's job, not a server's job
 	std::lock_guard _(g_pLan->m_clientListMutex);
+
+	if (g_pLan->m_clientsToReplyTo.size() > 0)
+	{
+		// We don't trigger the presence cooldown if we did nothing - this allows the LAN server to answer broadcasts with minimal latency
+		ServerPresenceReporter::ReportPresence(flCurrentTime, pServerPresence);
+	}
+	else
+	{
+		return; // Nothing to do here
+	}
 
 	for (const auto& client : g_pLan->m_clientsToReplyTo)
 	{

--- a/primedev/lan/lan.cpp
+++ b/primedev/lan/lan.cpp
@@ -1,0 +1,396 @@
+#include "lan.h"
+
+#include "server/serverpresence.h"
+#include "engine/r2engine.h"
+#include "engine/custom_packet_handler.h"
+
+#include <chrono>
+#include <iphlpapi.h>
+#include <util/utils.h>
+
+using namespace std::literals::chrono_literals;
+
+constexpr char LAN_BROADCAST_SCAN_MSG[] = "\xFF\xFF\xFF\xFF"
+										  "\x4C" // This one is not taken afaik
+										  "scan";
+
+Lan* g_pLan;
+
+Lan::Lan(bool isLanMode)
+	: m_bIsBroadcastSocketOK(false)
+	, m_broadcastEndpointSize(0)
+	, m_broadcastSocket(0)
+	, m_broadcastEndpoint({})
+{
+	static bool bInitialised = false;
+	if (bInitialised)
+		return;
+
+	if (isLanMode)
+	{
+		const auto wVersionRequested = MAKEWORD(2, 2);
+		WSADATA wsaData;
+		int lastError = WSAStartup(wVersionRequested, &wsaData);
+		assert(!lastError);
+
+		isLanMode &= lastError == ERROR_SUCCESS;
+		SetupBroadcastSocket();
+	}
+
+	bInitialised = true;
+	m_bIsLanMode = isLanMode;
+}
+
+std::vector<ServerPresence> Lan::ScanForServers()
+{
+	std::vector<ServerPresence> presences {};
+
+	// Independent thread is necessary for WSA error to function properly and not pollute the basegame
+	std::thread t(
+		[&]()
+		{
+			SendScanPing();
+			presences = ReceivePresences();
+		});
+
+	t.join();
+
+	return presences;
+}
+
+void Lan::DiscoverClient(const netadr_t& adr)
+{
+
+	std::lock_guard _(m_clientListMutex);
+	LanServerReporter::ScanningClient client {};
+	client.address = adr;
+
+	m_clientsToReplyTo.emplace_back(client);
+}
+
+uint16_t Lan::GetBroadcastPort() const
+{
+	if (g_pCVar)
+	{
+		if (auto cvar = g_pCVar->FindVar("serverport"))
+		{
+			return static_cast<uint16_t>(cvar->GetInt());
+		}
+	}
+
+	return 37015;
+}
+
+void Lan::SendScanPing()
+{
+	if (this->m_bIsBroadcastSocketOK)
+	{
+		int lastError = {};
+
+		// Value used in NET_SendTo
+		netPayload_s payload {};
+
+		// We need to encrypt it first
+		{
+			// For encryption you need to know your local IP Address and Port
+			// Therefore we must do one broadcast for each network card with a bound address
+			sockaddr_in sin {};
+			int addressLength = sizeof(sin);
+			netadr_t r2address {};
+			if (getsockname(m_broadcastSocket, reinterpret_cast<sockaddr*>(&sin), &addressLength) == 0 && sin.sin_family == AF_INET &&
+				addressLength == sizeof(sin))
+			{
+				// We're gonna use this crypto provider only once so it does not really matter
+				//   what IP we supply NET_Encrypt, let's give it the correct broadcast IP+Port still
+				r2address.type = NA_IP;
+				r2address.port = sin.sin_port;
+				r2address.ip[10] = 0xFF; // IPV4 marker
+				r2address.ip[11] = 0xFF;
+				memcpy_s(&r2address.ip[12], 4, &this->m_broadcastEndpoint.Ipv4.sin_addr, sizeof(this->m_broadcastEndpoint.Ipv4.sin_addr));
+			}
+			else
+			{
+				assert(!(lastError = WSAGetLastError()));
+
+				// No point in sending it because it won't be decryptable :(
+				NS::log::NORTHSTAR->error("Failed to get local netadr_t for encryption!");
+				return;
+			}
+
+			ZeroMemory(&payload, sizeof(payload));
+
+			static_assert(sizeof(payload.encryptHeader.nonce) == 12);
+			static_assert(sizeof(payload.encryptHeader.tag) == 16);
+
+			int encryptedLength = NET_Encrypt(
+				&r2address,
+				LAN_BROADCAST_SCAN_MSG,
+				sizeof(LAN_BROADCAST_SCAN_MSG),
+				payload.messageData,
+				sizeof(payload.messageData),
+				&payload.encryptHeader.tag,
+				sizeof(payload.encryptHeader.tag),
+				&payload.encryptHeader.nonce,
+				sizeof(payload.encryptHeader.nonce));
+
+			assert(encryptedLength > 0);
+			if (encryptedLength <= 0)
+			{
+				NS::log::NORTHSTAR->error("Failed to encrypt client scan message!");
+				return;
+			}
+
+			encryptedLength += sizeof(netPayload_s::encryptHeader);
+
+			const auto result = sendto(
+				this->m_broadcastSocket,
+				reinterpret_cast<const char*>(&payload),
+				encryptedLength,
+				0,
+				reinterpret_cast<const sockaddr*>(&this->m_broadcastEndpoint),
+				this->m_broadcastEndpointSize);
+
+			switch (lastError = WSAGetLastError())
+			{
+			case WSAECONNREFUSED:
+			case WSAEALREADY:
+			case WSAECONNABORTED:
+			case WSAETIMEDOUT:
+				lastError = ERROR_SUCCESS;
+				break;
+			}
+
+			assert(!lastError);
+			this->m_bIsBroadcastSocketOK &= lastError == ERROR_SUCCESS;
+		}
+	}
+}
+
+std::vector<ServerPresence> Lan::ReceivePresences(uint32_t timeout)
+{
+	std::unordered_map<std::string, ServerPresence> discoveries {};
+
+	if (this->m_bIsBroadcastSocketOK)
+	{
+		int lastError = {};
+
+		setsockopt(this->m_broadcastSocket, SOL_SOCKET, SO_RCVTIMEO, reinterpret_cast<const char*>(&timeout), sizeof(timeout));
+		assert(!(lastError = WSAGetLastError()));
+
+		// expected response
+		Lan::LanServerReporter::Payload presenceMessage {};
+
+		_SOCKADDR_INET from {};
+		int32_t fromLength = sizeof(from);
+
+		while (true)
+		{
+			const auto received = recvfrom(
+				this->m_broadcastSocket,
+				reinterpret_cast<char*>(&presenceMessage),
+				sizeof(presenceMessage),
+				0,
+				reinterpret_cast<sockaddr*>(&from),
+				&fromLength);
+
+			lastError = WSAGetLastError();
+			if (lastError == WSAETIMEDOUT)
+			{
+				lastError = 0;
+				break;
+			}
+			else if (lastError)
+			{
+				assert(!lastError);
+				break;
+			}
+			else if (received == 0)
+			{
+				break; // Empty read is not supposed to happen in UDP but...
+			}
+
+			// We only allow exact size and we ignore fragmentation, since we're under the MTU and not in a Stream protocol
+			// it should be fine
+			if (received == sizeof(presenceMessage))
+			{
+				// A server can be reported twice if we share more than one network together
+				const auto presence = presenceMessage.ToPresence(&from, fromLength);
+				if (!discoveries.contains(presence.m_sServerId))
+				{
+					discoveries.insert(std::make_pair(presence.m_sServerId, presence));
+				}
+			}
+		}
+
+		this->m_bIsBroadcastSocketOK = lastError == ERROR_SUCCESS;
+	}
+
+	std::vector<ServerPresence> servers {};
+	for (auto const& kv : discoveries)
+	{
+		servers.emplace_back(kv.second);
+	}
+
+	return servers;
+}
+
+void Lan::SetupBroadcastSocket()
+{
+	int lastError = {};
+
+	this->m_bIsBroadcastSocketOK = false;
+
+	this->m_broadcastSocket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	assert(!(lastError = WSAGetLastError()));
+
+	sockaddr_in bEndpoint {};
+	{
+		const auto ip = INADDR_BROADCAST;
+		bEndpoint.sin_family = AF_INET;
+		memcpy_s(&bEndpoint.sin_addr, sizeof(bEndpoint.sin_addr), &ip, sizeof(ip));
+		bEndpoint.sin_port = htons(GetBroadcastPort());
+	}
+
+	// No matter how big it is, this struct is big enough for it (whether ipv6 or ipv4)
+	ZeroMemory(&this->m_broadcastEndpoint, sizeof(this->m_broadcastEndpoint));
+	this->m_broadcastEndpoint = static_cast<SOCKADDR_INET>(bEndpoint);
+	this->m_broadcastEndpointSize = sizeof(bEndpoint);
+
+	constexpr bool dontLinger = true;
+	constexpr bool broadcast = true;
+
+	setsockopt(this->m_broadcastSocket, SOL_SOCKET, SO_DONTLINGER, reinterpret_cast<const char*>(&dontLinger), sizeof(dontLinger));
+	setsockopt(this->m_broadcastSocket, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char*>(&broadcast), sizeof(broadcast));
+
+	assert(!(lastError = WSAGetLastError()));
+
+	sockaddr_in listenEndpoint {};
+	listenEndpoint.sin_family = AF_INET;
+	// Any port is good, we'll have to punch through the firewall anyway
+
+	bind(m_broadcastSocket, reinterpret_cast<sockaddr*>(&listenEndpoint), sizeof(listenEndpoint));
+
+	assert(!(lastError = WSAGetLastError()));
+
+	this->m_bIsBroadcastSocketOK = lastError == ERROR_SUCCESS;
+}
+
+void Lan::LanServerReporter::ReportPresence(const ServerPresence* pServerPresence)
+{
+	// Send unicast to broadcasting clients - default Windows firewall allows a single unicast response to a broadcast within 3
+	// seconds of the emitted broadcast, so broadcasting has to be a client's job, not a server's job
+	std::lock_guard _(g_pLan->m_clientListMutex);
+
+	for (const auto& client : g_pLan->m_clientsToReplyTo)
+	{
+		NS::log::NORTHSTAR->info("Replying with presence to client {}", client.ToString());
+
+		Lan::LanServerReporter::Payload serializedPresence(pServerPresence);
+
+		std::string data(reinterpret_cast<const char*>(&serializedPresence), sizeof(serializedPresence));
+
+		netadr_s destination = client.address;
+
+		constexpr auto SERVER_SOCKET_INDEX = 1;
+		constexpr auto COMPRESSED = false;
+
+		NET_SendPacket(nullptr, SERVER_SOCKET_INDEX, &destination, data.data(), data.size(), 0, COMPRESSED, 0, 0);
+	}
+
+	g_pLan->m_clientsToReplyTo.clear();
+}
+
+Lan::LanServerReporter::Payload::Payload(const ServerPresence* pServerPresence)
+{
+	// Copy simple properties
+#define SET(x) this->x = pServerPresence->x
+	SET(m_iPort);
+	SET(m_bIsSingleplayerServer);
+
+	SET(m_iPlayerCount);
+	SET(m_iMaxPlayers);
+
+#undef SET
+
+	// Copy char buffers
+#define SET(x)                                                                                                                             \
+	assert(sizeof(pServerPresence->x) == sizeof(this->x));                                                                                 \
+	std::memcpy(this->x, pServerPresence->x, sizeof(this->x))
+
+	SET(m_Password);
+	SET(m_MapName);
+	SET(m_PlaylistName);
+
+#undef SET
+
+	// These two are strings!
+#define SET_STRING(x)                                                                                                                      \
+	ZeroMemory(this->x, sizeof(this->x));                                                                                                  \
+	std::strncpy(this->x, pServerPresence->x.c_str(), sizeof(this->x));
+
+	SET_STRING(m_sServerName);
+	SET_STRING(m_sServerDesc);
+
+#undef SET_STRING
+}
+
+ServerPresence Lan::LanServerReporter::Payload::ToPresence(const SOCKADDR_INET* from, int32_t fromLength)
+{
+	ServerPresence presence {};
+
+	// Copy simple properties
+#define SET(x) presence.x = this->x
+	SET(m_iPort);
+	SET(m_sServerName);
+	SET(m_sServerDesc);
+	SET(m_bIsSingleplayerServer);
+
+	SET(m_iPlayerCount);
+	SET(m_iMaxPlayers);
+
+#undef SET
+
+	// Copy char buffers
+#define SET(x)                                                                                                                             \
+	assert(sizeof(presence.x) == sizeof(this->x));                                                                                         \
+	std::memcpy(presence.x, this->x, sizeof(this->x))
+
+	SET(m_Password);
+	SET(m_MapName);
+	SET(m_PlaylistName);
+
+#undef SET
+
+	// Generate server ID from IP + port
+	{
+		char name[NI_MAXHOST] {};
+		int lastError = getnameinfo(reinterpret_cast<const sockaddr*>(from), fromLength, name, sizeof(name), NULL, 0, NI_NUMERICHOST);
+
+		assert(!lastError);
+		if (lastError == ERROR_SUCCESS)
+		{
+			presence.m_sServerId = std::format("{}:{}", name, m_iPort);
+		}
+		else
+		{
+			// As a fallback
+			presence.m_sServerId = std::format("{}:{}", m_sServerName, m_iPort);
+		}
+	}
+
+	return presence;
+}
+
+ON_DLL_LOAD_RELIESON("engine.dll", LanDiscoveryPacketHandler, CustomPacketHandler, (CModule module))
+{
+	assert(g_pCustomPacketHandler);
+	static_assert(ARRAYSIZE(LAN_BROADCAST_SCAN_MSG) > 4);
+
+	g_pCustomPacketHandler->RegisterPacketHandler(
+		LAN_BROADCAST_SCAN_MSG[4],
+		[](void* handler, netpacket_s* packet, OUT bool& executeOriginalHandler)
+		{
+			// Received a reply to my broadcast, so we need to reply to this client
+			g_pLan->DiscoverClient(packet->adr);
+		});
+}

--- a/primedev/lan/lan.h
+++ b/primedev/lan/lan.h
@@ -3,13 +3,10 @@
 #include "server/serverpresence.h"
 #include "engine/r2engine.h"
 
-// Required for the very normal Microsoft API for interface enumeration
-#pragma comment(lib, "iphlpapi.lib")
-
 class Lan
 {
 public:
-	Lan(bool isLanMode);
+	Lan();
 
 	class LanServerReporter : public ServerPresenceReporter
 	{
@@ -64,15 +61,22 @@ public:
 		friend Lan;
 
 	public:
-		void ReportPresence(const struct ServerPresence* pServerPresence) override;
+		void ReportPresence(double flCurrentTime, const struct ServerPresence* pServerPresence) override;
+
+	protected:
+		float GetPresenceUpdateCooldown() override
+		{
+			return 100.0f; // 100 ms is good because it wastes no resources when there is no scan to reply to, and responds timely when
+						   // there is any
+		};
 	};
 
-	bool Enabled() { return m_bIsLanMode; }
+	bool Enabled() { return m_bIsLanAvailable; }
 	std::vector<ServerPresence> ScanForServers();
 	void DiscoverClient(const netadr_t& adr);
 
 private:
-	bool m_bIsLanMode = false;
+	bool m_bIsLanAvailable = false;
 
 	_SOCKADDR_INET m_broadcastEndpoint;
 	int32_t m_broadcastEndpointSize; // WSA is a strange fellow
@@ -82,7 +86,7 @@ private:
 
 	uint16_t GetBroadcastPort() const;
 	void SendScanPing();
-	std::vector<ServerPresence> ReceivePresences(uint32_t timeout = 3000);
+	std::vector<ServerPresence> ReceivePresences(uint32_t timeout = 1000);
 	void SetupBroadcastSocket();
 
 	std::mutex m_clientListMutex {};

--- a/primedev/lan/lan.h
+++ b/primedev/lan/lan.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "server/serverpresence.h"
+#include "engine/r2engine.h"
+
+// Required for the very normal Microsoft API for interface enumeration
+#pragma comment(lib, "iphlpapi.lib")
+
+class Lan
+{
+public:
+	Lan(bool isLanMode);
+
+	class LanServerReporter : public ServerPresenceReporter
+	{
+		struct ScanningClient
+		{
+			// This can actually be a variety of sockets so we store the length with it
+			netadr_t address;
+
+			std::string ToString() const
+			{
+				std::ostringstream ipStringStream {};
+				for (auto i = 0; i < sizeof(address.ip); i++)
+				{
+					const uint8_t byte = address.ip[i];
+					const std::string characters = std::to_string(byte);
+					ipStringStream << characters;
+
+					if (i < sizeof(address.ip) - 1)
+					{
+						ipStringStream << ".";
+					}
+				}
+
+				const std::string port = std::to_string(address.port);
+				ipStringStream << ":" << port;
+
+				return ipStringStream.str();
+			}
+		};
+
+		struct Payload
+		{
+			uint16_t m_iPort;
+			char m_sServerName[64];
+			char m_sServerDesc[256];
+			char m_Password[256];
+
+			char m_MapName[32];
+			char m_PlaylistName[64];
+			bool m_bIsSingleplayerServer;
+
+			uint8_t m_iPlayerCount;
+			uint8_t m_iMaxPlayers;
+
+			Payload(const struct ServerPresence* pServerPresence);
+			Payload() = default;
+			ServerPresence ToPresence(const SOCKADDR_INET* from, int32_t fromLength);
+		};
+
+		static_assert(sizeof(Payload) < 1200);
+
+		friend Lan;
+
+	public:
+		void ReportPresence(const struct ServerPresence* pServerPresence) override;
+	};
+
+	bool Enabled() { return m_bIsLanMode; }
+	std::vector<ServerPresence> ScanForServers();
+	void DiscoverClient(const netadr_t& adr);
+
+private:
+	bool m_bIsLanMode = false;
+
+	_SOCKADDR_INET m_broadcastEndpoint;
+	int32_t m_broadcastEndpointSize; // WSA is a strange fellow
+	SOCKET m_broadcastSocket;
+
+	bool m_bIsBroadcastSocketOK;
+
+	uint16_t GetBroadcastPort() const;
+	void SendScanPing();
+	std::vector<ServerPresence> ReceivePresences(uint32_t timeout = 3000);
+	void SetupBroadcastSocket();
+
+	std::mutex m_clientListMutex {};
+	std::vector<LanServerReporter::ScanningClient> m_clientsToReplyTo {};
+};
+
+extern Lan* g_pLan;

--- a/primedev/masterserver/masterserver.cpp
+++ b/primedev/masterserver/masterserver.cpp
@@ -11,6 +11,7 @@
 #include "util/version.h"
 #include "server/auth/bansystem.h"
 #include "dedicated/dedicated.h"
+#include "lan/lan.h"
 
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
@@ -19,6 +20,10 @@
 
 #include <cstring>
 #include <regex>
+#include <WinSock2.h>
+#include <ws2ipdef.h>
+#include <WinDNS.h>
+#include <iphlpapi.h>
 
 using namespace std::chrono_literals;
 
@@ -54,6 +59,33 @@ RemoteServerInfo::RemoteServerInfo(
 
 	playerCount = newPlayerCount;
 	maxPlayers = newMaxPlayers;
+
+	onLAN = false;
+}
+
+RemoteServerInfo::RemoteServerInfo(const ServerPresence& presence)
+{
+	ZeroMemory(id, sizeof(id));
+	strncpy_s(id, sizeof(id), presence.m_sServerId.c_str(), presence.m_sServerId.size());
+
+	ZeroMemory(name, sizeof(name));
+	strncpy_s(name, sizeof(name), presence.m_sServerName.c_str(), presence.m_sServerName.size());
+
+	description = presence.m_sServerDesc;
+
+	ZeroMemory(map, sizeof(map));
+	strncpy_s(map, sizeof(map), presence.m_MapName, sizeof(presence.m_MapName));
+
+	ZeroMemory(playlist, sizeof(playlist));
+	strncpy_s(playlist, sizeof(playlist), presence.m_PlaylistName, sizeof(presence.m_PlaylistName));
+
+	ZeroMemory(region, sizeof(region)); // Not relevant to a LAN party I suppose
+
+	playerCount = presence.m_iPlayerCount;
+	maxPlayers = presence.m_iMaxPlayers;
+	requiresPassword = presence.m_Password[0] != '\x00';
+
+	onLAN = true;
 }
 
 void SetCommonHttpClientOptions(CURL* curl)
@@ -204,6 +236,37 @@ void MasterServerManager::RequestServerList()
 			m_bScriptRequestingServerList = true;
 
 			spdlog::info("Requesting server list from {}", Cvar_ns_masterserver_hostname->GetString());
+
+			if (g_pLan->Enabled())
+			{
+				spdlog::info("Polling local area network for servers...");
+
+				// This is done synchronously with a timeout of ~1sec
+				// The issue is that the way Master server communication is set in NS is very unlike the way Quake/DPMaster do it
+				// traditionally, and so NS has a caveat: it has to receive the server list in one burst. The architecture of NS does not
+				// seem set up in a way that remote servers can be dynamically added to the list "as they are found", like on DP or source
+				// games, so we have to block for LAN discovery _then_ block for Online discovery _then_ display. That leaves a very short
+				// time window for LAN discovery.
+				//
+				// Ultimately the big TODO here is to allow server discovery to happen in an event based
+				// fashion ("I have found you, I add you now") rather than in a synchronous, "all at once" fashion
+				const auto servers = g_pLan->ScanForServers();
+
+				for (const auto& server : servers)
+				{
+					RemoteServerInfo remoteServerInfo(server);
+
+					// if server already exists, remove it and add it with the updated info
+					m_vRemoteServers.erase(
+						std::remove_if(
+							m_vRemoteServers.begin(),
+							m_vRemoteServers.end(),
+							[&](const RemoteServerInfo& s) { return s.onLAN && s.id == remoteServerInfo.id; }),
+						m_vRemoteServers.end());
+
+					m_vRemoteServers.emplace_back(remoteServerInfo);
+				}
+			}
 
 			CURL* curl = curl_easy_init();
 			SetCommonHttpClientOptions(curl);
@@ -603,6 +666,38 @@ void MasterServerManager::AuthenticateWithServer(const char* uid, const char* pl
 	// dont wait, just stop if we're trying to do 2 auth requests at once
 	if (m_bAuthenticatingWithGameServer || g_pVanillaCompatibility->GetVanillaCompatibility())
 		return;
+
+	if (server.onLAN) // Lan clients are self authentified
+	{
+		// Very normal Windows APIs require very normal formats
+		constexpr size_t serverAddressLength = sizeof(server.id);
+		wchar_t* wideAddressPort = new wchar_t[serverAddressLength];
+		mbstowcs(wideAddressPort, server.id, serverAddressLength);
+		NET_ADDRESS_INFO addressInfo {};
+		USHORT port {};
+		const auto parse = ParseNetworkString(wideAddressPort, NET_STRING_IPV4_SERVICE, &addressInfo, &port, NULL);
+		delete[] wideAddressPort;
+
+		if (parse == ERROR_SUCCESS)
+		{
+			m_pendingConnectionInfo.ip = addressInfo.Ipv4Address.sin_addr;
+			m_pendingConnectionInfo.port = port;
+
+			strncpy_s(m_pendingConnectionInfo.authToken, sizeof(m_pendingConnectionInfo.authToken), uid, strlen(uid));
+
+			m_bHasPendingConnectionInfo = true;
+			m_bSuccessfullyAuthenticatedWithGameServer = true;
+
+			m_currentServer = server;
+			m_sCurrentServerPassword = std::string();
+			return;
+		}
+		else
+		{
+			spdlog::error("Could not parse ip address of LAN server {}", server.id);
+			assert(parse);
+		}
+	}
 
 	m_bAuthenticatingWithGameServer = true;
 	m_bScriptAuthenticatingWithGameServer = true;
@@ -1007,6 +1102,12 @@ ON_DLL_LOAD_RELIESON("engine.dll", MasterServer, (ConCommand, ServerPresence), (
 
 	MasterServerPresenceReporter* presenceReporter = new MasterServerPresenceReporter;
 	g_pServerPresence->AddPresenceReporter(presenceReporter);
+
+	if (g_pLan->Enabled())
+	{
+		Lan::LanServerReporter* presenceReporter = new Lan::LanServerReporter;
+		g_pServerPresence->AddPresenceReporter(presenceReporter);
+	}
 }
 
 void MasterServerPresenceReporter::CreatePresence(const ServerPresence* pServerPresence)
@@ -1015,8 +1116,10 @@ void MasterServerPresenceReporter::CreatePresence(const ServerPresence* pServerP
 	m_nNumRegistrationAttempts = 0;
 }
 
-void MasterServerPresenceReporter::ReportPresence(const ServerPresence* pServerPresence)
+void MasterServerPresenceReporter::ReportPresence(double flCurrentTime, const ServerPresence* pServerPresence)
 {
+	ServerPresenceReporter::ReportPresence(flCurrentTime, pServerPresence);
+
 	// make a copy of presence for multithreading purposes
 	ServerPresence threadedPresence(pServerPresence);
 

--- a/primedev/masterserver/masterserver.h
+++ b/primedev/masterserver/masterserver.h
@@ -36,8 +36,10 @@ public:
 
 	// connection stuff
 	bool requiresPassword;
+	bool onLAN; // Means server ID is means of joining
 
 public:
+	// Non-LAN Ctor
 	RemoteServerInfo(
 		const char* newId,
 		const char* newName,
@@ -48,6 +50,12 @@ public:
 		int newPlayerCount,
 		int newMaxPlayers,
 		bool newRequiresPassword);
+
+	// LAN Ctor
+	RemoteServerInfo(const ServerPresence& presence);
+
+private:
+	RemoteServerInfo();
 };
 
 struct RemoteServerConnectionInfo
@@ -172,7 +180,7 @@ public:
 	void CreatePresence(const ServerPresence* pServerPresence) override;
 
 	// Run on an internal to either add the server to the MS or update it.
-	void ReportPresence(const ServerPresence* pServerPresence) override;
+	void ReportPresence(double flCurrentTime, const ServerPresence* pServerPresence) override;
 
 	// Called when we need to remove the server from the master server.
 	void DestroyPresence(const ServerPresence* pServerPresence) override;

--- a/primedev/primelauncher/CMakeLists.txt
+++ b/primedev/primelauncher/CMakeLists.txt
@@ -24,5 +24,5 @@ target_link_libraries(
 
 set_target_properties(
     NorthstarLauncher PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${NS_BINARY_DIR} LINK_FLAGS
-                                                                           "/MANIFEST:NO /DEBUG /STACK:8000000"
+                                                                           "/MANIFEST:NO /DEBUG /STACK:8000000 /DYNAMICBASE:NO"
     )

--- a/primedev/primelauncher/CMakeLists.txt
+++ b/primedev/primelauncher/CMakeLists.txt
@@ -24,5 +24,5 @@ target_link_libraries(
 
 set_target_properties(
     NorthstarLauncher PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${NS_BINARY_DIR} LINK_FLAGS
-                                                                           "/MANIFEST:NO /DEBUG /STACK:8000000 /DYNAMICBASE:NO"
+                                                                           "/MANIFEST:NO /DEBUG /STACK:8000000"
     )

--- a/primedev/server/serverpresence.cpp
+++ b/primedev/server/serverpresence.cpp
@@ -152,10 +152,6 @@ void ServerPresenceManager::RunFrame(double flCurrentTime)
 	for (ServerPresenceReporter* reporter : m_vPresenceReporters)
 		reporter->RunFrame(flCurrentTime, &m_ServerPresence);
 
-	// run on a specified delay
-	if ((flCurrentTime - m_flLastPresenceUpdate) * 1000 < Cvar_ns_server_presence_update_rate->GetFloat())
-		return;
-
 	// is this the first frame we're updating this presence?
 	if (m_bFirstPresenceUpdate)
 	{
@@ -169,7 +165,13 @@ void ServerPresenceManager::RunFrame(double flCurrentTime)
 	m_flLastPresenceUpdate = flCurrentTime;
 
 	for (ServerPresenceReporter* reporter : m_vPresenceReporters)
-		reporter->ReportPresence(&m_ServerPresence);
+	{
+		// run on a specified delay
+		if (reporter->IsDueForUpdate(flCurrentTime))
+		{
+			reporter->ReportPresence(flCurrentTime, &m_ServerPresence);
+		}
+	}
 }
 
 void ServerPresenceManager::SetPort(const int iPort)
@@ -228,6 +230,17 @@ void ServerPresenceManager::SetPlaylist(const char* pPlaylistName)
 void ServerPresenceManager::SetPlayerCount(const int iPlayerCount)
 {
 	m_ServerPresence.m_iPlayerCount = iPlayerCount;
+}
+
+inline void ServerPresenceReporter::ReportPresence(double flCurrentTime, const ServerPresence*)
+{
+	// Default implementation just notifies the presence as updated
+	m_flLastPresenceUpdate = flCurrentTime;
+}
+
+inline bool ServerPresenceReporter::IsDueForUpdate(double flCurrentTime)
+{
+	return (flCurrentTime - m_flLastPresenceUpdate) * 1000 < GetPresenceUpdateCooldown();
 }
 
 ON_DLL_LOAD_RELIESON("engine.dll", ServerPresence, ConVar, (CModule module))

--- a/primedev/server/serverpresence.h
+++ b/primedev/server/serverpresence.h
@@ -42,10 +42,20 @@ public:
 class ServerPresenceReporter
 {
 public:
+	// TODO Abstract?
 	virtual void CreatePresence(const ServerPresence* /*pServerPresence*/) {}
-	virtual void ReportPresence(const ServerPresence* /*pServerPresence*/) {}
 	virtual void DestroyPresence(const ServerPresence* /*pServerPresence*/) {}
 	virtual void RunFrame(double /*flCurrentTime*/, const ServerPresence* /*pServerPresence*/) {}
+
+	virtual void ReportPresence(double flCurrentTime, const ServerPresence* /*pServerPresence*/);
+
+	bool IsDueForUpdate(double flCurrentTime);
+
+protected:
+	virtual float GetPresenceUpdateCooldown() { return g_pServerPresence->Cvar_ns_server_presence_update_rate->GetFloat(); };
+
+private:
+	float m_flLastPresenceUpdate;
 };
 
 class ServerPresenceManager
@@ -59,7 +69,6 @@ private:
 	std::vector<ServerPresenceReporter*> m_vPresenceReporters;
 
 	double m_flLastPresenceUpdate = 0;
-	ConVar* Cvar_ns_server_presence_update_rate;
 
 	ConVar* Cvar_ns_server_name;
 	ConVar* Cvar_ns_server_desc;
@@ -69,6 +78,8 @@ private:
 	ConVar* Cvar_ns_report_sp_server_to_masterserver;
 
 public:
+	ConVar* Cvar_ns_server_presence_update_rate;
+
 	void AddPresenceReporter(ServerPresenceReporter* reporter);
 
 	void CreateConVars();


### PR DESCRIPTION
(from #930 )
This feature allows discovering and broadcasting Northstar  games on the Local network, in addition to the Master server.
It uses the pre existing ServerPresenceReporter architecture that existed prior.

For that feat it requires one modification/restructuring: the cooldown of Server presence report is now handled *per reporter* instead of globally. This is because the LAN presence report is a "reply", so it needs short cycle time, while the Master server presence is an "announcement", so it needs a long cycle time. Implemented as it is, it should cause no regression, the master server reporting will still have 5000ms of cycle time while the LAN only has 100ms.

LAN uses the connectionless handler so no additional port need be opened, however it means the Scan packet must be encrypted, therefore this will rely on my previous PRs  (#934  and #933 ) to work. This also gives an example of how to use the NET_Send with encryption on the project, which hopefully can be reused elsewhere.

As far as I my understanding goes, I think there is a fatal flaw in the way NS does "server list populating" which will make this code slower than it should be, but fixing it would require a lot of restructuration and is maybe better left for another PR.

⚠️ This PR won't build until #934  and #933  are up (in some fashion)