### PR TITLE
Offline persistent data, sent upon connection

### DIFF
--- a/primedev/Northstar.cmake
+++ b/primedev/Northstar.cmake
@@ -121,6 +121,8 @@ add_library(
     "scripts/scriptjson.cpp"
     "scripts/scriptjson.h"
     "scripts/scriptutility.cpp"
+    "shared/offline_persistence.cpp"
+    "shared/offline_persistence.h"
     "server/auth/bansystem.cpp"
     "server/auth/bansystem.h"
     "server/auth/serverauthentication.cpp"

--- a/primedev/engine/r2engine.cpp
+++ b/primedev/engine/r2engine.cpp
@@ -13,6 +13,8 @@ CBaseClient* g_pClientArray;
 
 server_state_t* g_pServerState;
 
+CClientState* g_pLocalClientState;
+
 char* g_pModName =
 	nullptr; // we cant set this up here atm since we dont have an offset to it in engine, instead we store it in IsRespawnMod
 
@@ -34,4 +36,6 @@ ON_DLL_LOAD("engine.dll", R2Engine, (CModule module))
 	g_pServerState = module.Offset(0x12A53D48).RCast<server_state_t*>();
 
 	g_pGlobals = module.Offset(0x7C6F70).RCast<CGlobalVars*>();
+
+	g_pLocalClientState = module.Offset(0x7A42C0).RCast<CClientState*>();
 }

--- a/primedev/engine/r2engine.h
+++ b/primedev/engine/r2engine.h
@@ -217,6 +217,153 @@ static_assert(offsetof(CBaseClient, m_UID) == 0xF500);
 
 extern CBaseClient* g_pClientArray;
 
+#pragma pack(push, 1)
+struct CClientState
+{
+	uint64_t iNetChannelHandlerVftable;
+	uint64_t iConnectionLessPacketHandlerVfTable;
+	uint64_t qword10;
+	uint64_t qword18;
+	uint64_t qword20;
+	char snapshots;
+	uint8_t gap29[47];
+	uint32_t dword58;
+	uint8_t gap5C[4];
+	uint64_t qword60;
+	uint64_t qword68;
+	uint32_t dword70;
+	uint32_t dword74;
+	uint8_t byte78;
+	uint8_t gap79[3];
+	uint32_t dword7C;
+	uint8_t gap80[20];
+	uint8_t byte94;
+	uint8_t gap95[3];
+	uint32_t dword98;
+	uint8_t gap9C[4];
+	uint64_t qwordA0;
+	uint64_t qwordA8;
+	uint32_t dwordB0;
+	char charB4;
+	uint8_t gapB5[148];
+	uint8_t byte149;
+	uint8_t gap14A[2];
+	char char14C;
+	uint8_t gap14D[19];
+	uint8_t byte160;
+	uint8_t byte161;
+	uint8_t gap162[2];
+	uint32_t dword164;
+	uint32_t dword168;
+	uint8_t gap16C[4];
+	uint32_t dword170;
+	char m_szLevelFileName[64];
+	char m_szLevelBaseName[64];
+	char m_szLastLevelBaseName[64];
+	char m_szSkyBoxBaseName[64];
+	uint32_t dword274;
+	uint32_t dword278;
+	uint32_t dword27C;
+	uint8_t gap280[4];
+	uint32_t dword284;
+	uint32_t dword288;
+	uint32_t dword28C;
+	uint8_t byte290;
+	uint8_t gap291[3];
+	uint32_t dword294;
+	uint32_t dword298;
+	uint8_t gap29C[20];
+	uint8_t byte2B0;
+	uint8_t gap2B1[7];
+	uint64_t qword2B8;
+	uint64_t qword2C0;
+	char unk_0x800_buff;
+	uint8_t gap2C9[2047];
+	uint32_t dwordAC8;
+	uint8_t gapACC[4];
+	uint64_t unk; // NOT persistentDataSize!
+	uint8_t persistentData[61440]; // Probably smaller than that!
+	uint8_t byteFAD8;
+	uint8_t gapFAD9[3];
+	uint64_t qwordFADC;
+	uint16_t wordFAE4;
+	uint8_t byteFAE6;
+	uint8_t gapFAE7[1025];
+	char clientDataBLockReceiverVfTable;
+	uint8_t gapFEE9[7];
+	uint64_t qwordFEF0;
+	uint8_t gapFEF8[564];
+	uint32_t dword1012C;
+	uint64_t qword10130;
+	uint64_t qword10138;
+	uint64_t qword10140;
+	uint8_t gap10148[8];
+	uint16_t word10150;
+	uint8_t gap10152[6];
+	uint32_t dword10158;
+	uint64_t qword1015C;
+	uint64_t qword10164;
+	uint64_t qword1016C;
+	uint64_t qword10174;
+	uint8_t gap1017C[4];
+	uint32_t dword10180;
+	uint8_t gap10184[4];
+	uint8_t byte10188;
+	uint8_t gap10189[3];
+	uint32_t dword1018C;
+	uint8_t gap10190[13];
+	uint8_t byte1019D;
+	uint8_t gap1019E[2];
+	uint32_t dword101A0;
+	uint64_t qword101A4;
+	uint32_t dword101AC;
+	uint32_t dword101B0;
+	uint32_t dword101B4;
+	uint32_t dword101B8;
+	uint32_t dword101BC;
+	uint32_t dword101C0;
+	uint32_t dword101C4;
+	uint8_t gap101C8[8];
+	uint64_t qword101D0;
+	uint64_t qword101D8;
+	uint64_t qword101E0;
+	uint32_t dword101E8;
+	uint8_t gap101EC[4];
+	uint64_t qword101F0;
+	uint8_t gap101F8[12176];
+	uint64_t qword13188;
+	uint64_t qword13190;
+	char char13198;
+	uint8_t gap13199[7];
+	uint64_t qword131A0;
+	uint64_t qword131A8;
+	uint64_t qword131B0;
+	uint64_t qword131B8;
+	uint64_t qword131C0;
+	uint64_t qword131C8;
+	uint64_t qword131D0;
+	uint64_t qword131D8;
+	uint64_t qword131E0;
+	uint64_t qword131E8;
+	uint32_t dword131F0;
+	uint8_t gap131F4[1028];
+	uint64_t qword135F8;
+	uint64_t qword13600;
+	uint64_t qword13608;
+	uint64_t qword13610;
+	uint64_t qword13618;
+	uint64_t qword13620;
+	char unk_2047_thingies;
+	uint8_t gap13629[32767];
+	uint8_t byte1B628;
+};
+#pragma pack(pop)
+
+// static_assert(sizeof(CClientState) == 0x1B629); // Not sure about this one
+static_assert(offsetof(CClientState, persistentData) == 0xAD8); // Very sure about this one
+
+extern CClientState* g_pLocalClientState;
+
 enum server_state_t
 {
 	ss_dead = 0, // Dead

--- a/primedev/server/auth/serverauthentication.cpp
+++ b/primedev/server/auth/serverauthentication.cpp
@@ -13,6 +13,7 @@
 #include "engine/r2engine.h"
 #include "client/r2client.h"
 #include "server/r2server.h"
+#include "shared/offline_persistence.h"
 
 #include <fstream>
 #include <filesystem>
@@ -166,6 +167,11 @@ void ServerAuthenticationManager::AuthenticatePlayer(CBaseClient* pPlayer, uint6
 	// we probably allow insecure at this point, but make sure not to write anyway if not insecure
 	else if (Cvar_ns_auth_allow_insecure->GetBool())
 	{
+		if (IsLocalPlayer(pPlayer))
+		{
+			g_pOfflinePersistence->ReadOfflinePersistentData(pPlayer);
+		}
+
 		// set persistent data as ready
 		// note: actual placeholder persistent data is populated in script with InitPersistentData()
 		pPlayer->m_iPersistenceReady = ePersistenceReady::READY_INSECURE;
@@ -180,6 +186,11 @@ bool ServerAuthenticationManager::RemovePlayerAuthData(CBaseClient* pPlayer)
 	// hack for special case where we're on a local server, so we erase our own newly created auth data on disconnect
 	if (m_bNeedLocalAuthForNewgame && !strcmp(pPlayer->m_UID, g_pLocalPlayerUserID))
 		return false;
+
+	if (Cvar_ns_auth_allow_insecure_write->GetBool())
+	{
+		return false; // Keep it in memory
+	}
 
 	// we don't have our auth token at this point, so lookup authdata by uid
 	for (auto& auth : m_RemoteAuthenticationData)
@@ -206,10 +217,15 @@ void ServerAuthenticationManager::WritePersistentData(CBaseClient* pPlayer)
 		g_pMasterServerManager->WritePlayerPersistentData(
 			pPlayer->m_UID, (const char*)pPlayer->m_PersistenceBuffer, m_PlayerAuthenticationData[pPlayer].pdataSize);
 	}
-	else if (Cvar_ns_auth_allow_insecure_write->GetBool())
+	else if (Cvar_ns_auth_allow_insecure_write->GetBool() && IsLocalPlayer(pPlayer))
 	{
-		// todo: write pdata to disk here
+		g_pOfflinePersistence->WriteOfflinePersistentData(pPlayer);
 	}
+}
+
+bool ServerAuthenticationManager::IsLocalPlayer(CBaseClient* pPlayer)
+{
+	return g_pLocalPlayerUserID && !strcmp(pPlayer->m_UID, g_pLocalPlayerUserID);
 }
 
 // auth hooks

--- a/primedev/server/auth/serverauthentication.h
+++ b/primedev/server/auth/serverauthentication.h
@@ -53,6 +53,8 @@ public:
 	void AuthenticatePlayer(CBaseClient* pPlayer, uint64_t iUid, char* pAuthToken);
 	bool RemovePlayerAuthData(CBaseClient* pPlayer);
 	void WritePersistentData(CBaseClient* pPlayer);
+
+	bool IsLocalPlayer(CBaseClient* pPlayer);
 };
 
 extern ServerAuthenticationManager* g_pServerAuthentication;

--- a/primedev/shared/offline_persistence.cpp
+++ b/primedev/shared/offline_persistence.cpp
@@ -1,0 +1,254 @@
+#include "offline_persistence.h"
+
+#include "server/auth/serverauthentication.h"
+#include "engine/r2engine.h"
+
+#include <shlobj_core.h>
+#include <fstream>
+#include <filesystem>
+#include <cassert>
+#include <client/r2client.h>
+
+OfflinePersistence* g_pOfflinePersistence;
+
+constexpr auto BASE_CONNECT_PAYLOAD_LENGTH = 21;
+
+void OfflinePersistence::ReadAndEnqueuePDataFromConnectPacket(const unsigned char* packetData, size_t packetSize)
+{
+
+	// Protocol addition:
+	// 8 bytes: UID (uint64_t)
+	// 2 bytes: Length of pData (ushort)
+	// <length> bytes: pData
+	uint64_t uid {};
+	uint16_t pDataSize {};
+	char* pDataBuffer {};
+
+	size_t i = BASE_CONNECT_PAYLOAD_LENGTH;
+
+// Safe read
+#define READ(x)                                                                                                                            \
+	if (i + sizeof(x) <= packetSize)                                                                                                       \
+	{                                                                                                                                      \
+		memcpy(&x, &packetData[i], sizeof(x));                                                                                             \
+		i += sizeof(x);                                                                                                                    \
+	}
+
+	READ(uid);
+	READ(pDataSize);
+
+	if (i + pDataSize >= packetSize)
+	{
+		pDataBuffer = new char[pDataSize];
+		memcpy(pDataBuffer, &packetData[i], pDataSize);
+		i += pDataSize;
+	}
+	else
+	{
+		pDataSize = 0;
+	}
+
+#undef READ
+
+	// Erase previous auth data if any
+	const auto uidStr = std::to_string(uid);
+	g_pServerAuthentication->m_RemoteAuthenticationData.erase(uidStr);
+
+	// Create the new one to put it on server auth, it will get dequeued on next connection (which is this one)
+	RemoteAuthData newAuthData {};
+	strncpy_s(newAuthData.uid, sizeof(newAuthData.uid), uidStr.c_str(), sizeof(newAuthData.uid) - 1);
+	newAuthData.pdataSize = pDataSize;
+	newAuthData.pdata = pDataBuffer;
+
+	g_pServerAuthentication->m_RemoteAuthenticationData.insert(std::make_pair(uidStr, newAuthData));
+}
+
+void OfflinePersistence::AppendPDataToConnectPacket(OUT const char*& data, OUT int& length, OUT std::allocator<char>& allocator)
+{
+	// Protocol addition:
+	// 8 bytes: UID (uint64_t)
+	// 2 bytes: Length of pData (ushort)
+	// <length> bytes: pData
+
+	const uint64_t uid = g_pLocalPlayerUserID ? std::stoull(g_pLocalPlayerUserID) : 0;
+	const auto maxPersistenceBuffer = allocator.allocate(PERSISTENCE_MAX_SIZE);
+	ZeroMemory(maxPersistenceBuffer, PERSISTENCE_MAX_SIZE);
+
+	size_t persistenceLength {};
+	ExportOfflinePersistentData(maxPersistenceBuffer, persistenceLength);
+
+	const auto additionalLength = 8 // uid (uint64_t)
+								  + 2 // length prefix for pdata (ushort)
+								  + persistenceLength;
+
+	const auto newMessageLength = length + additionalLength;
+
+	const auto newMessageBuffer = allocator.allocate(newMessageLength);
+	ZeroMemory(newMessageBuffer, newMessageLength);
+
+	size_t i = 0;
+
+	// Copy original message
+	memcpy(&newMessageBuffer[i], data, length);
+	i += length;
+
+	// Copy UID
+	memcpy(&newMessageBuffer[i], &uid, sizeof(uid));
+	i += sizeof(uid);
+
+	// Write length
+	assert(persistenceLength <= std::numeric_limits<uint16_t>().max()); // The things i'd do not to write USHRT_MAX
+	const auto persistenceLengthU16 = static_cast<uint16_t>(persistenceLength);
+	memcpy(&newMessageBuffer[i], &persistenceLengthU16, sizeof(persistenceLengthU16));
+	i += sizeof(persistenceLengthU16);
+
+	// Copy persistence
+	memcpy(&newMessageBuffer[i], maxPersistenceBuffer, persistenceLength);
+	i += persistenceLength;
+
+	data = newMessageBuffer;
+	length = i;
+}
+
+void OfflinePersistence::ExportOfflinePersistentData(OUT char* buffer, OUT size_t& len)
+{
+	const auto path = GetOfflinePersistentDataPath();
+	std::ifstream localData(path, std::ios::binary | std::ios::in);
+	if (localData.is_open())
+	{
+		ZeroMemory(buffer, PERSISTENCE_MAX_SIZE);
+		localData.read(buffer, PERSISTENCE_MAX_SIZE);
+		const auto streamPosition = localData.gcount();
+		if (streamPosition != -1)
+		{
+			len = streamPosition;
+		}
+		else
+		{
+			len = PERSISTENCE_MAX_SIZE;
+		}
+	}
+}
+
+void OfflinePersistence::ReadOfflinePersistentData(CBaseClient* pPlayer)
+{
+	assert(g_pServerAuthentication->IsLocalPlayer(pPlayer));
+
+	const auto path = GetOfflinePersistentDataPath();
+	std::ifstream localData(path, std::ios::binary | std::ios::in);
+	if (localData.is_open())
+	{
+		ZeroMemory(pPlayer->m_PersistenceBuffer, ARRAYSIZE(pPlayer->m_PersistenceBuffer));
+		localData.read(pPlayer->m_PersistenceBuffer, ARRAYSIZE(pPlayer->m_PersistenceBuffer));
+	}
+}
+
+void OfflinePersistence::WriteOfflinePersistentData(CBaseClient* pPlayer)
+{
+	assert(g_pServerAuthentication->IsLocalPlayer(pPlayer));
+
+	WriteOfflinePersistentData(pPlayer->m_PersistenceBuffer, g_pServerAuthentication->m_PlayerAuthenticationData[pPlayer].pdataSize);
+}
+
+void OfflinePersistence::WriteOfflinePersistentData(const char* buffer, size_t size)
+{
+	if (size > 0) // Prevent a zero-size write from clearing the persistent data entirely
+	{
+		const auto path = GetOfflinePersistentDataPath();
+		const auto dir = path.parent_path();
+		std::filesystem::create_directory(dir);
+
+		std::ofstream localData(path, std::ios::binary | std::ios::out);
+		if (localData.is_open())
+		{
+			localData.write(buffer, size);
+		}
+	}
+}
+
+std::filesystem::path OfflinePersistence::GetOfflinePersistentDataPath()
+{
+	const auto filename = std::format("persistent.pdata");
+
+	// TODO: Where is the best place to put persistent NS files? I vote for AppData but is another place already defined for this?
+	PWSTR appData = NULL;
+	if (SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_CREATE, NULL, &appData) == S_OK)
+	{
+		char dest[MAX_PATH];
+		wcstombs(dest, appData, MAX_PATH);
+
+		// Create a folder for northstar
+		std::filesystem::path appDataPath(dest);
+
+		return appDataPath / "Northstar" / filename;
+	}
+
+	return std::filesystem::path(filename);
+}
+
+const uint64_t __fastcall OfflinePersistence::h_NET_SendPacket(
+	void* chan, int _socketIndex, const netadr_s* address, const char* data, int length, __int64 arg_28, char bCompressed, int a8, char a9)
+{
+	if (g_pServerAuthentication->Cvar_ns_auth_allow_insecure_write->GetBool())
+	{
+		bool isConnectPacket = _socketIndex == 0 && length == BASE_CONNECT_PAYLOAD_LENGTH && data[4] == 'H';
+		if (isConnectPacket)
+		{
+			std::allocator<char> allocator;
+
+			g_pOfflinePersistence->AppendPDataToConnectPacket(data, length, allocator);
+
+			bCompressed = length > 1024; // This will very likely occur. Since single burst transmissions are <1228, we compress above ~1000
+
+			const auto result = NET_SendPacket(chan, _socketIndex, address, data, length, arg_28, bCompressed, a8, a9);
+
+			return result;
+		}
+	}
+
+	return NET_SendPacket(chan, _socketIndex, address, data, length, arg_28, bCompressed, a8, a9);
+}
+
+void (*OfflinePersistence::o_pPacketHandler_HandleConnect)(void* packetHandler, int source, netpacket_s* packet, __int64 a4, bool a5) =
+	nullptr;
+void OfflinePersistence::h_PacketHandler_HandleConnect(void* packetHandler, int source, netpacket_s* packet, __int64 a4, bool a5)
+{
+	if (g_pServerAuthentication->Cvar_ns_auth_allow_insecure_write->GetBool())
+	{
+		if (packet->size > BASE_CONNECT_PAYLOAD_LENGTH) // Extra connect data is used to supply persistent data upon connection
+		{
+			g_pOfflinePersistence->ReadAndEnqueuePDataFromConnectPacket(packet->data, packet->size);
+		}
+	}
+
+	o_pPacketHandler_HandleConnect(packetHandler, source, packet, a4, a5);
+}
+
+// Upon local client disconnection, write all persistent data down to disk
+// TODO: Write it when it's changed instead? (after a call to SetPersistentVar ?)
+static void (*o_pCClientState__Disconnect)(CClientState* self, char unk) = nullptr;
+void h_CClientState__Disconnect(CClientState* self, char unk)
+{
+	if (g_pServerAuthentication->Cvar_ns_auth_allow_insecure_write->GetBool() && *self->persistentData)
+	{
+		g_pOfflinePersistence->WriteOfflinePersistentData(reinterpret_cast<const char*>(self->persistentData), PERSISTENCE_MAX_SIZE);
+	}
+
+	o_pCClientState__Disconnect(self, unk);
+}
+
+ON_DLL_LOAD("engine.dll", OfflinePersistenceCtor, (CModule module))
+{
+	g_pOfflinePersistence = new OfflinePersistence(module);
+}
+
+OfflinePersistence::OfflinePersistence(CModule module)
+{
+	HookAttach(&(PVOID&)NET_SendPacket, (PVOID)h_NET_SendPacket);
+
+	o_pPacketHandler_HandleConnect = module.Offset(0x1183A0).RCast<decltype(o_pPacketHandler_HandleConnect)>();
+	HookAttach(&(PVOID&)o_pPacketHandler_HandleConnect, (PVOID)h_PacketHandler_HandleConnect);
+
+	o_pCClientState__Disconnect = module.Offset(0x8DC50).RCast<decltype(o_pCClientState__Disconnect)>();
+	HookAttach(&(PVOID&)o_pCClientState__Disconnect, (PVOID)h_CClientState__Disconnect);
+}

--- a/primedev/shared/offline_persistence.h
+++ b/primedev/shared/offline_persistence.h
@@ -1,0 +1,48 @@
+#pragma once
+
+class OfflinePersistence
+{
+public:
+	void ExportOfflinePersistentData(OUT char* buffer, OUT size_t& len);
+	void WriteOfflinePersistentData(const char* buffer, size_t length);
+	void WriteOfflinePersistentData(class CBaseClient* pPlayer);
+	void ReadOfflinePersistentData(class CBaseClient* pPlayer);
+
+	OfflinePersistence(CModule engineModule);
+
+private:
+	std::filesystem::path GetOfflinePersistentDataPath();
+
+	void ReadAndEnqueuePDataFromConnectPacket(const unsigned char* packetData, size_t packetSize);
+	void AppendPDataToConnectPacket(OUT const char*& data, OUT int& length, OUT std::allocator<char>& allocator);
+
+	// Hooks
+	static const uint64_t __fastcall h_NET_SendPacket(
+		void* chan,
+		int _socketIndex,
+		const struct netadr_s* address,
+		const char* data,
+		int length,
+		__int64 arg_28,
+		char bCompressed,
+		int a8,
+		char a9);
+
+	static void h_PacketHandler_HandleConnect(void* packetHandler, int source, struct netpacket_s* packet, __int64 a4, bool a5);
+
+	static const uint64_t(__fastcall* OfflinePersistence::o_pNET_SendPacket)(
+		void* chan,
+		int _socketIndex,
+		const struct netadr_s* address,
+		const char* data,
+		int length,
+		__int64 arg_28,
+		char bCompressed,
+		int a8,
+		char a9);
+
+	static void (*OfflinePersistence::o_pPacketHandler_HandleConnect)(
+		void* packetHandler, int source, struct netpacket_s* packet, __int64 a4, bool a5);
+};
+
+extern OfflinePersistence* g_pOfflinePersistence;


### PR DESCRIPTION
This is a port of the hastily-closed #930 regarding the Persistent data specifically.

Since this is now separate there are a few questions that I need yall to answer before I can proceed, they are not technical questions but rather related to the organization of the project.

Currently, offline persistent data is sent by the client upon connection by adding the payload to the `connect` command and handling it on arrival. That means that for offline persistent data to be a thing, the server needs to be aware of it (and parse for it), and the client needs to be aware of it (and send the payload).

Questions:
- **Should I aim to replace online Persistent data with Offline persistent data completely, or should it be a switch?**
(Currently, it's a switch with ns_auth_allow_insecure_etc. With it, you get offline pdata. Without it, you get online pdata.)

- **If this is a switch, should it be:**
    - **A clientside switch**, meaning the server has to accept mixed-mode pdata (both online and offline) and will use the offline pdata _when provided by the joinee_, falling back on online other wise
    - **A serverside switch**, meaning the client will *always* write and send offline pdata, and the server will sometimes accept it and sometimes refuse it depending on whether it's configured to accept or refuse it.
(Currently: worst of both worlds, it neesd the dvar to be set on _both_ client and server for it to work)

My personal opinion is to cut the online part entirely and to make it always offline, always included in the connect payload. But I need yall to put your decision in concrete before I can continue work on this PR.

⚠️ This PR won't build until https://github.com/R2Northstar/NorthstarLauncher/pull/934 and https://github.com/R2Northstar/NorthstarLauncher/pull/933 are up (in some fashion)